### PR TITLE
Remove unnecessary auth

### DIFF
--- a/.Renviron
+++ b/.Renviron
@@ -1,2 +1,1 @@
 _R_CHECK_SYSTEM_CLOCK_=0
-GOOGLESHEETS_AUTH_FILE=inst/google_cloud_key.json

--- a/man/get_bilateral_trade.Rd
+++ b/man/get_bilateral_trade.Rd
@@ -13,7 +13,7 @@ get_bilateral_trade(file_path)
 A tibble with the reported trade between countries.
 It contains the following columns:
 \itemize{
-\item \code{year}: The year when the data was collected.
+\item \code{year}: The year in which the recorded event occurred.
 \item \code{from_code}: FAOSTAT internal code for the country that is exporting the
 item. Equivalences with ISO 3166-1 numeric can be found in the
 \emph{Area Codes} CSV from the zip file that can be downloaded from
@@ -24,8 +24,8 @@ item. See previous \code{from_code}.
 \item \code{item}: Natural language name for the item that is being traded.
 \item \code{unit}: Measure unit for the traded item. It can have two values:
 \itemize{
-\item \code{"tonnes"}: Trade amount in tonnes (for crop items)
-\item \code{"heads"}: Trade amount in number of animals (for livestock items)
+\item \code{"tonnes"}: Trade amount in tonnes (for crop and livestock products)
+\item \code{"heads"}: Trade amount in number of animals (for live animal items)
 }
 \item \code{value}: The amount traded in the corresponding measure unit.
 }

--- a/man/get_processing_coefs.Rd
+++ b/man/get_processing_coefs.Rd
@@ -13,7 +13,7 @@ get_processing_coefs(file_path)
 A tibble with the quantities for each processed product.
 It contains the following columns:
 \itemize{
-\item \code{year}: The year when the data was collected.
+\item \code{year}: The year in which the recorded event occurred.
 \item \code{area}: The name of the country where the data is from.
 \item \code{area_code}: FAOSTAT internal code for each country. Equivalences
 with ISO 3166-1 numeric can be found in the \emph{Area Codes} CSV from the

--- a/man/get_wide_cbs.Rd
+++ b/man/get_wide_cbs.Rd
@@ -13,7 +13,7 @@ get_wide_cbs(file_path)
 A tibble with the commodity balance sheet data in wide format.
 It contains the following columns:
 \itemize{
-\item \code{year}: The year when the data was collected.
+\item \code{year}: The year in which the recorded event occurred.
 \item \code{area}: The name of the country where the data is from.
 \item \code{area_code}: FAOSTAT internal code for each country. Equivalences
 with ISO 3166-1 numeric can be found in the \emph{Area Codes} CSV from the

--- a/vignettes/trade-sources-coverage.Rmd
+++ b/vignettes/trade-sources-coverage.Rmd
@@ -16,8 +16,8 @@ knitr::opts_chunk$set(
 
 ```{r setup}
 library(WHEP)
-key_path <- here::here(Sys.getenv("GOOGLESHEETS_AUTH_FILE"))
-googlesheets4::gs4_auth(path = key_path)
+# Don't ask for credentials (read public files)
+googlesheets4::gs4_deauth()
 ```
 
 First we read the trade sources sheet and build a dataframe where each row accounts for one year.

--- a/vignettes/workflow-intro.Rmd
+++ b/vignettes/workflow-intro.Rmd
@@ -1038,7 +1038,11 @@ In that example, an Excel sheet must be read. When using the `googlesheets4`
 package, it can automatically open a browser interactively and ask for your
 Google account credentials, but when running check tools, we want everything
 to work from beginning to end without human intervention. This is achievable
-by providing a secret token.
+by providing a secret token ^[For educational purposes I won't change
+anything from this explanation in the guide. However, recently I found out
+that the token is not needed when you're reading public files. For this to
+work automatically we only have to call `googlesheets4::gs4_deauth()` before
+reading the public file.].
 
 Since we _must not_ include secret information in `.Renviron`, the workaround
 is to instead add just the secret file path as an environment variable and then


### PR DESCRIPTION
Thanks to a previous PR where I had to read public files from Google Drive, I noticed our auth for reading an Excel sheet was unnecessary. Calling `googlesheets::gs4_deauth()` before reading a public Google Drive file is enough.