### PR TITLE
Improve grafs spain performance

### DIFF
--- a/R/n_prov_destiny.R
+++ b/R/n_prov_destiny.R
@@ -73,7 +73,17 @@ create_n_prov_destiny <- function() {
       n_soil_inputs,
       add_feed_output$feed_share_rum_mono
     ) |>
-    .add_n_soil_inputs(n_soil_inputs)
+    .add_n_soil_inputs(n_soil_inputs) |>
+    dplyr::select(
+      Year,
+      Province_name,
+      Item,
+      Irrig_cat,
+      Box,
+      Origin,
+      Destiny,
+      MgN
+    )
 }
 
 #' @title GRAFS Nitrogen (N) flows – National Spain

--- a/R/n_soil_inputs_nue.R
+++ b/R/n_soil_inputs_nue.R
@@ -123,9 +123,8 @@ create_n_soil_inputs <- function() {
 #'
 #' @export
 create_n_production <- function() {
-  grafs_prod_destiny_final <- create_n_prov_destiny()
-
-  .calculate_n_production(grafs_prod_destiny_final)
+  create_n_prov_destiny() |>
+    .calculate_n_production()
 }
 
 #' @title Calculate N Production
@@ -135,7 +134,7 @@ create_n_production <- function() {
 #' @keywords internal
 #' @noRd
 .calculate_n_production <- function(grafs_prod_destiny) {
-  n_prod_data <- grafs_prod_destiny |>
+  grafs_prod_destiny |>
     dplyr::filter(!is.na(Box)) |>
     tidyr::replace_na(list(MgN = 0)) |>
     tidyr::pivot_wider(
@@ -145,10 +144,7 @@ create_n_production <- function() {
     ) |>
     dplyr::mutate(
       feed = livestock_rum + livestock_mono,
-      prod = population_food +
-        population_other_uses +
-        feed +
-        export,
+      prod = population_food + population_other_uses + feed + export,
       # Fish has no domestic production
       prod = dplyr::if_else(Box == "Fish", 0, prod)
     ) |>
@@ -157,8 +153,6 @@ create_n_production <- function() {
       .by = c(Year, Province_name, Item, Box)
     ) |>
     dplyr::arrange(Year, Province_name, Item, Box)
-
-  n_prod_data
 }
 
 


### PR DESCRIPTION
The code was quite slow and I wanted to see if there are some straightforward ways of making it fast without too much effort. In my computer the function `create_n_prov_destiny()` takes now approx. 45s, while it used to be 150s before. In slower computers the difference might be even more noticeable. I'm quite satisfied. I just hope I didn't break anything (I think I even fixed a bug of duplicated rows along the way).
I think most of the improvements were:
- Removing unnecessary `dplyr::group_by()`. When each group ends up having a single row, the code is super slow because it can't vectorize operations, it must do them individually for each group. More groups means slower operation. In some cases grouping+summarization were introduced "just in case" but actually there was already a unique row for each group so I removed the grouping for efficiency. The code still takes a while because in other cases each group ends up having maybe 2 or 3 rows, which is not 1 anymore, so the group is needed but the operations are slow. This might be improvable but may require harder refactors, which we won't do now.
- In some case where a grouping was actually necessary, if there were a lot of rows because of e.g. previous joins, it was possible to perform the group+summarize before the joins, so that the there were less rows to summarize and group, and thus take less time.

As we recently merged the long #18 and expect to write a `TODO` list for future PRs, when reviewing this, please try to focus comments only on whether something was broken with the current changes compared to the previous result.