### PR TITLE
fix(bilateral_trade): guard mclapply against fork() on Windows

### DIFF
--- a/R/bilateral_trade.R
+++ b/R/bilateral_trade.R
@@ -128,7 +128,13 @@ get_bilateral_trade <- function(example = FALSE, cbs = NULL) {
   n <- length(codes)
   code_int <- as.integer(levels(codes))
   ngroups <- nrow(btd)
-  n_cores <- max(1L, parallel::detectCores() %/% 2L)
+  # mclapply() forks, which is unavailable on Windows; run serially there.
+  # Same OS guard as spatialize.R. Output is identical on all platforms.
+  n_cores <- if (.Platform$OS.type == "windows") {
+    1L
+  } else {
+    max(1L, parallel::detectCores() %/% 2L)
+  }
 
   btd$bilateral_trade <- parallel::mclapply(
     seq_len(ngroups),


### PR DESCRIPTION
## Problem

`get_bilateral_trade()` crashes on Windows. `R/bilateral_trade.R` (`.process_bilateral_trade()`) calls `parallel::mclapply(..., mc.cores = parallel::detectCores() %/% 2L)`. `mclapply()` relies on `fork()`, which is unavailable on Windows, so any `mc.cores > 1` fails there (works fine on Unix).

Reported by a colleague running whep on Windows (main).

## Fix

Reuse the **same OS guard already present in `R/spatialize.R:245`** (`.Platform$OS.type`). On Windows we set `mc.cores = 1L`; everywhere else the original `detectCores() %/% 2L` is unchanged.

```r
n_cores <- if (.Platform$OS.type == "windows") {
  1L
} else {
  max(1L, parallel::detectCores() %/% 2L)
}
```

## Why this is safe / correct

- From R's own `parallel::mclapply` source, when `cores < 2L` it does `return(lapply(X, FUN, ...))` — it **never reaches the forking path**. So on Windows `mclapply` degrades to plain `lapply`: no fork, no crash.
- Verified empirically: `mc.cores = 1L` runs every task in the master PID (no children spawned); `mc.cores = 2L` forks (the path that breaks on Windows).
- Serial vs. parallel results are `identical()` — **output is unchanged on Unix and identical on Windows**.
- Windows runs serially (slightly slower), which matches the existing trade-off already accepted in `spatialize.R`.

## Scope check

Swept `R/` for other Windows-portability issues: this `mclapply` was the **only** unguarded fork. `spatialize.R` is already guarded; `pins_internal.R` already handles a Windows-specific yaml issue; all path construction uses portable `file.path()`/`tempfile()`/`tempdir()`.

## Testing notes

Behavior-preserving on Unix (no result change). Final confirmation on real Windows hardware is best done by the reporter, who has the environment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)