### PR TITLE
fix(livestock): Tier 2 enteric/manure ~20x over-count — scale by cohort_heads (#106)

### DIFF
--- a/R/livestock_cohorts.R
+++ b/R/livestock_cohorts.R
@@ -96,6 +96,24 @@ calculate_cohorts_systems <- function(data, system_shares = NULL) {
   )
 }
 
+#' Number of animals a single emissions row represents.
+#'
+#' Per-head IPCC emissions are scaled to totals by the animal count of the row.
+#' After [calculate_cohorts_systems()] expands a national herd, each row is one
+#' GLEAM cohort, so that count is `cohort_heads` (national `heads` times the
+#' cohort fraction), not the national `heads` the row still carries. Scaling
+#' expanded rows by `heads` and then summing over cohorts inflated Tier 2
+#' totals by the cohort count (issue #106). Without expansion only `heads` is
+#' present and is itself the animal count.
+#' @noRd
+.animal_count <- function(data) {
+  if (rlang::has_name(data, "cohort_heads")) {
+    data$cohort_heads
+  } else {
+    data$heads
+  }
+}
+
 #' Get cohort fractions within each production system.
 #' @noRd
 .get_cohort_fractions <- function(categories) {

--- a/R/livestock_enteric.R
+++ b/R/livestock_enteric.R
@@ -19,9 +19,10 @@
 
   data <- .join_enteric_ef_tier1(data, cattle_ef, other_ef)
 
+  n_animals <- .animal_count(data)
   data |>
     dplyr::mutate(
-      enteric_ch4_tier1 = heads * enteric_ef_kgch4
+      enteric_ch4_tier1 = n_animals * enteric_ef_kgch4
     ) |>
     dplyr::select(-dplyr::any_of(c("ef_cattle", "ef_other")))
 }
@@ -48,13 +49,14 @@
 
   energy_conversion <- livestock_constants$energy_content_ch4_mj_kg
 
+  n_animals <- .animal_count(data)
   data |>
     dplyr::mutate(
       enteric_ch4_per_head = gross_energy *
         (ym_factor / 100) *
         365 /
         energy_conversion,
-      enteric_ch4_tier2 = heads * enteric_ch4_per_head,
+      enteric_ch4_tier2 = n_animals * enteric_ch4_per_head,
       method_enteric = "IPCC_2019_Tier2"
     )
 }

--- a/R/livestock_ghg_extension.R
+++ b/R/livestock_ghg_extension.R
@@ -24,10 +24,11 @@
 #'   manure N2O from a per-animal energy and nitrogen balance, for finer
 #'   resolution, but requires cohort weight and diet inputs. Animals whose
 #'   emissions cannot be resolved (missing diet or energy data) are dropped with
-#'   a warning rather than entering the footprint as `NA`. **Tier 2 is not yet
-#'   calibrated** -- its enteric CH4 currently runs well above Tier 1 -- so
-#'   Tier 1 is the recommended default until the Tier 2 energy model is
-#'   validated.
+#'   a warning rather than entering the footprint as `NA`. Its per-head enteric
+#'   and manure emissions now sit in the same range as the Tier 1 regional
+#'   factors. Tier 1 remains the default because it is complete for every
+#'   country in [get_primary_production()], whereas Tier 2 needs cohort and
+#'   diet inputs.
 #'
 #' The CO2e conversion uses 100-year global warming potentials selected with
 #' `gwp`:

--- a/R/livestock_manure.R
+++ b/R/livestock_manure.R
@@ -9,9 +9,10 @@
 
   data <- .join_manure_ch4_ef_tier1(data)
 
+  n_animals <- .animal_count(data)
   data |>
     dplyr::mutate(
-      manure_ch4_tier1 = heads * manure_ef_kgch4
+      manure_ch4_tier1 = n_animals * manure_ef_kgch4
     )
 }
 
@@ -117,6 +118,7 @@
 
   ch4_density <- 0.67 # kg/m3 CH4 at STP
 
+  n_animals <- .animal_count(data)
   data |>
     dplyr::mutate(
       manure_ch4_per_head = volatile_solids *
@@ -124,7 +126,7 @@
         methane_potential *
         ch4_density *
         weighted_mcf,
-      manure_ch4_tier2 = heads * manure_ch4_per_head
+      manure_ch4_tier2 = n_animals * manure_ch4_per_head
     )
 }
 
@@ -493,9 +495,10 @@
       mean(na.rm = TRUE)
     pasture_ef <- dplyr::coalesce(pasture_ef, 0.02)
 
+    n_animals <- .animal_count(data)
     data <- data |>
       dplyr::mutate(
-        manure_n2o_direct = heads * n_excretion * pasture_ef * n2o_to_n
+        manure_n2o_direct = n_animals * n_excretion * pasture_ef * n2o_to_n
       )
   }
 
@@ -534,10 +537,11 @@
       .by = row_id_n2o
     )
 
+  n_animals <- .animal_count(data)
   data |>
     dplyr::left_join(n2o_weighted, by = "row_id_n2o") |>
     dplyr::mutate(
-      manure_n2o_direct = heads *
+      manure_n2o_direct = n_animals *
         n_excretion *
         dplyr::coalesce(weighted_ef3, 0.005) *
         n2o_to_n
@@ -557,10 +561,11 @@
   frac_gas <- .get_indirect_param("frac_gasms")
   frac_leach <- .get_indirect_param("frac_leach")
 
+  n_animals <- .animal_count(data)
   data |>
     dplyr::mutate(
-      n2o_volatilization = heads * n_excretion * frac_gas * ef4 * n2o_to_n,
-      n2o_leaching = heads * n_excretion * frac_leach * ef5 * n2o_to_n,
+      n2o_volatilization = n_animals * n_excretion * frac_gas * ef4 * n2o_to_n,
+      n2o_leaching = n_animals * n_excretion * frac_leach * ef5 * n2o_to_n,
       manure_n2o_indirect = n2o_volatilization +
         n2o_leaching
     ) |>

--- a/man/build_livestock_ghg_extension.Rd
+++ b/man/build_livestock_ghg_extension.Rd
@@ -54,10 +54,11 @@ excretion rates).
 manure N2O from a per-animal energy and nitrogen balance, for finer
 resolution, but requires cohort weight and diet inputs. Animals whose
 emissions cannot be resolved (missing diet or energy data) are dropped with
-a warning rather than entering the footprint as \code{NA}. \strong{Tier 2 is not yet
-calibrated} -- its enteric CH4 currently runs well above Tier 1 -- so
-Tier 1 is the recommended default until the Tier 2 energy model is
-validated.
+a warning rather than entering the footprint as \code{NA}. Its per-head enteric
+and manure emissions now sit in the same range as the Tier 1 regional
+factors. Tier 1 remains the default because it is complete for every
+country in \code{\link[=get_primary_production]{get_primary_production()}}, whereas Tier 2 needs cohort and
+diet inputs.
 }
 
 The CO2e conversion uses 100-year global warming potentials selected with

--- a/tests/testthat/test_livestock_enteric.R
+++ b/tests/testthat/test_livestock_enteric.R
@@ -116,6 +116,36 @@ testthat::test_that("Tier 2 total equals heads * per_head", {
   testthat::expect_equal(total, per_head * heads)
 })
 
+testthat::test_that("Tier 2 scales cohort rows by cohort_heads, not heads", {
+  # Regression for #106: each expanded cohort row still carries the national
+  # `heads`, so scaling by `heads` and summing over cohorts inflated the herd
+  # total by the cohort count (~20x for cattle).
+  expanded <- tibble::tibble(
+    species = "Cattle, dairy",
+    heads = 1000,
+    iso3 = "DEU",
+    milk_yield_kg_day = 20,
+    diet_quality = "High"
+  ) |>
+    whep::calculate_cohorts_systems()
+
+  result <- expanded |>
+    whep::estimate_energy_demand() |>
+    whep:::.calc_enteric_ch4_tier2()
+
+  # The per-row total uses cohort_heads, not the national heads it carries.
+  testthat::expect_equal(
+    result$enteric_ch4_tier2,
+    result$cohort_heads * result$enteric_ch4_per_head
+  )
+
+  # Aggregated to the herd, the per-head figure stays in the IPCC range
+  # (it was ~1,300 before the fix).
+  per_head <- sum(result$enteric_ch4_tier2) / 1000
+  testthat::expect_gt(per_head, 50)
+  testthat::expect_lt(per_head, 200)
+})
+
 testthat::test_that("Tier 2 adds Method_Enteric column", {
   result <- dairy_tier2_fixture() |>
     estimate_energy_demand() |>

--- a/tests/testthat/test_livestock_manure.R
+++ b/tests/testthat/test_livestock_manure.R
@@ -172,6 +172,33 @@ testthat::test_that("Nex is annualized (kgN/head/yr)", {
   testthat::expect_lt(nex, 200)
 })
 
+testthat::test_that("Manure Tier 2 scales cohort rows by cohort_heads", {
+  # Regression for #106: like enteric CH4, manure CH4 and N2O totals must scale
+  # by the cohort's own head count, not the national `heads` each expanded row
+  # still carries.
+  result <- tibble::tibble(
+    species = "Cattle, dairy",
+    heads = 1000,
+    iso3 = "DEU",
+    milk_yield_kg_day = 20,
+    diet_quality = "High"
+  ) |>
+    whep::calculate_cohorts_systems() |>
+    whep::estimate_energy_demand() |>
+    whep:::.calc_manure_ch4_tier2() |>
+    whep:::.calc_manure_n2o()
+
+  testthat::expect_equal(
+    result$manure_ch4_tier2,
+    result$cohort_heads * result$manure_ch4_per_head
+  )
+  # Aggregated to the herd, manure N2O stays in a realistic per-head range; it
+  # was inflated by the cohort count (~11x) when scaled by national heads.
+  per_head_n2o <- sum(result$manure_n2o_total) / 1000
+  testthat::expect_gt(per_head_n2o, 0.5)
+  testthat::expect_lt(per_head_n2o, 10)
+})
+
 testthat::test_that("Manure Tier 1 Buffalo uses Table 10.15 EF", {
   result <- single_tier1_fixture("Buffalo", 1) |>
     whep:::.calc_manure_ch4_tier1()


### PR DESCRIPTION
Closes #106.

## Problem

IPCC Tier 2 enteric (and manure) emissions came out ~10–20× too high. A dairy cow read ~1,300 kg CH₄/head/yr instead of a realistic ~120.

The formula (`GE × Ym/100 × 365 / 55.65`) and the `55.65` constant were correct. The bug was the **multiplier one layer up**:

- The Tier 2 path expands each national herd into GLEAM cohorts (cattle → 11 rows: 6 Dairy + 5 Beef). Every expanded row still carries the national `heads` **and** its own `cohort_heads`.
- `.calc_enteric_ch4_tier2` computed `enteric_ch4_tier2 = heads × per_head` using the **national** `heads`, then `.ghg_co2e_extension` summed across all cohort rows → inflation by the cohort count.
- The same bug was in `.calc_manure_ch4_tier2`, `.calc_direct_n2o`, and `.calc_indirect_n2o`.
- Tier 1 was unaffected because it never expands cohorts.

It stayed hidden because the existing GHG-extension tests were all structural (linear scaling, summing, no-NA) and never locked a Tier 2 magnitude.

## Fix

Add `.animal_count()` (returns `cohort_heads` when present, else `heads`) and use it for every per-head → total scaling in enteric and manure (CH₄ Tier 1/2, manure N₂O direct + indirect). Tier 1 falls back to `heads`, so its behaviour is unchanged.

## Result

- A synthetic dairy herd: enteric **1266.8 → 117.2 kg CH₄/head/yr**.
- Aggregated Tier 2 enteric/manure now sit within **~0.6–1.25×** of the Tier 1 regional factors (vs ~10–20× for enteric alone before).

## Tests / checks

- New regression tests in `test_livestock_enteric.R` and `test_livestock_manure.R` lock cohort-based scaling and realistic per-head magnitudes (they fail on the old code).
- Refreshed the now-stale "not yet calibrated / runs well above Tier 1" docs on `build_livestock_ghg_extension()`.
- `air format` clean, `lintr` 0 lints, **R CMD check 0/0/0**, full suite **2805 tests, 0 failures**.

## Notes

- A separate, latent issue spotted while doing this — `calculate_cohorts_systems()` applies the generic Cattle 30% Dairy / 70% Beef split to **both** the dairy and non-dairy commodities — is filed as #109 and intentionally out of scope here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)