### PR TITLE
fix(livestock): route cohort split by dairy/non-dairy commodity

### DIFF
--- a/R/livestock_cohorts.R
+++ b/R/livestock_cohorts.R
@@ -7,9 +7,11 @@
 #'
 #' @param data Dataframe with `species`, `heads`, and
 #'   optionally `iso3` or `region`.
-#' @param system_shares Optional dataframe with `species`,
-#'   `system`, `share` columns. If `NULL`, uses
-#'   GLEAM defaults.
+#' @param system_shares Optional dataframe with `species_gen`,
+#'   `system`, `system_share` columns. If `NULL`, uses GLEAM
+#'   defaults and routes dairy/non-dairy commodities to their
+#'   matching production system. Supplying this overrides both,
+#'   so the supplied shares are used verbatim.
 #'
 #' @return Dataframe expanded to cohort level with
 #'   `cohort`, `system`, `cohort_heads`, and
@@ -30,7 +32,8 @@ calculate_cohorts_systems <- function(data, system_shares = NULL) {
       species_gen = .get_general_species(species)
     )
 
-  if (is.null(system_shares)) {
+  use_default <- is.null(system_shares)
+  if (use_default) {
     system_shares <- .default_system_shares()
   }
 
@@ -40,7 +43,17 @@ calculate_cohorts_systems <- function(data, system_shares = NULL) {
       system_shares,
       by = "species_gen",
       relationship = "many-to-many"
-    ) |>
+    )
+
+  # Default shares are keyed by general species, so both cattle commodities
+  # ("Cattle, dairy" / "Cattle, non-dairy") would otherwise receive the same
+  # generic Dairy/Beef blend (issue #109). When the commodity name itself names
+  # a dairy/non-dairy subcategory, send the whole herd to that system instead.
+  if (use_default) {
+    data <- .route_to_commodity_system(data)
+  }
+
+  data <- data |>
     dplyr::mutate(
       system_heads = heads * system_share
     )
@@ -93,6 +106,54 @@ calculate_cohorts_systems <- function(data, system_shares = NULL) {
     "Swine", "Fattening", 0.85,
     "Poultry", "Layers", 0.50,
     "Poultry", "Broilers", 0.50
+  )
+}
+
+#' Route a herd to the production system named by its commodity.
+#'
+#' Default system shares are keyed by general species, so a dairy and a non-dairy
+#' commodity of the same species share one blend. When the commodity name
+#' identifies a dairy/non-dairy subcategory, keep only that subcategory's system
+#' and give it the full share. Commodities that name no subcategory keep the
+#' generic blend untouched.
+#' @noRd
+.route_to_commodity_system <- function(data) {
+  routing <- .subcategory_system_map() |>
+    dplyr::rename(routed_system = system)
+
+  data |>
+    dplyr::mutate(subcategory = .commodity_subcategory(species)) |>
+    dplyr::left_join(routing, by = c("species_gen", "subcategory")) |>
+    dplyr::filter(is.na(routed_system) | system == routed_system) |>
+    dplyr::mutate(
+      system_share = dplyr::if_else(is.na(routed_system), system_share, 1)
+    ) |>
+    dplyr::select(-routed_system, -subcategory)
+}
+
+#' Dairy/non-dairy subcategory named by a commodity, else `NA`.
+#'
+#' Unlike [.get_subcategory()], this returns `NA` (not "Non-Dairy") when the name
+#' does not literally say dairy/non-dairy, so single-commodity species (e.g.
+#' "Buffalo") keep the generic system blend instead of collapsing to one system.
+#' @noRd
+.commodity_subcategory <- function(species) {
+  dplyr::case_when(
+    .is_dairy(species) ~ "Dairy",
+    stringr::str_detect(species, "(?i)non[- ]?dairy") ~ "Non-Dairy",
+    TRUE ~ NA_character_
+  )
+}
+
+#' Production system each commodity subcategory routes to, by species.
+#'
+#' Only cattle has separate dairy and non-dairy commodities in `animals_codes`.
+#' @noRd
+.subcategory_system_map <- function() {
+  tibble::tribble(
+    ~species_gen, ~subcategory, ~system,
+    "Cattle", "Dairy", "Dairy",
+    "Cattle", "Non-Dairy", "Beef"
   )
 }
 

--- a/R/utils.R
+++ b/R/utils.R
@@ -1082,6 +1082,8 @@ utils::globalVariables(
     "all_categories",
     "cohort_fraction",
     "system_share",
+    "system",
+    "routed_system",
     # livestock bridge
     "Item_Code_product",
     "Liv_prod_cat",

--- a/inst/LIVESTOCK_AUDIT.md
+++ b/inst/LIVESTOCK_AUDIT.md
@@ -275,6 +275,13 @@ cohorts and production systems using:
 - `gleam_livestock_categories`: cohort fractions by species
 - GLEAM S.6 tables (e.g. `gleam_field_operation_ef`, `gleam_mechanization_levels`): system shares by species + region
 
+The default system split is keyed by general species, then routed by the
+commodity's dairy/non-dairy subcategory: a `Cattle, dairy` herd goes
+entirely to the Dairy system and `Cattle, non-dairy` entirely to the Beef
+system, rather than both receiving the generic 30/70 blend (issue #109).
+Single-commodity species (e.g. `Buffalo`) keep the blend. A supplied
+`system_shares` argument overrides this routing.
+
 ---
 
 ### 3.6 Uncertainty (`livestock_uncertainty.R`)

--- a/man/calculate_cohorts_systems.Rd
+++ b/man/calculate_cohorts_systems.Rd
@@ -10,9 +10,11 @@ calculate_cohorts_systems(data, system_shares = NULL)
 \item{data}{Dataframe with \code{species}, \code{heads}, and
 optionally \code{iso3} or \code{region}.}
 
-\item{system_shares}{Optional dataframe with \code{species},
-\code{system}, \code{share} columns. If \code{NULL}, uses
-GLEAM defaults.}
+\item{system_shares}{Optional dataframe with \code{species_gen},
+\code{system}, \code{system_share} columns. If \code{NULL}, uses GLEAM
+defaults and routes dairy/non-dairy commodities to their
+matching production system. Supplying this overrides both,
+so the supplied shares are used verbatim.}
 }
 \value{
 Dataframe expanded to cohort level with

--- a/tests/testthat/test_livestock_cohorts.R
+++ b/tests/testthat/test_livestock_cohorts.R
@@ -34,3 +34,44 @@ testthat::test_that("result has required columns", {
       c("system", "cohort", "cohort_heads")
     )
 })
+
+testthat::test_that("dairy commodity routes only to the Dairy system", {
+  # Regression for #109: the cohort split must follow the commodity, not just
+  # the general species. A "Cattle, dairy" herd is entirely dairy-system cohorts.
+  result <- tibble::tibble(species = "Cattle, dairy", heads = 1000) |>
+    whep::calculate_cohorts_systems()
+
+  testthat::expect_setequal(unique(result$system), "Dairy")
+  testthat::expect_equal(sum(result$cohort_heads), 1000, tolerance = 1)
+})
+
+testthat::test_that("non-dairy commodity routes only to the Beef system", {
+  result <- tibble::tibble(species = "Cattle, non-dairy", heads = 1000) |>
+    whep::calculate_cohorts_systems()
+
+  testthat::expect_setequal(unique(result$system), "Beef")
+  testthat::expect_equal(sum(result$cohort_heads), 1000, tolerance = 1)
+})
+
+testthat::test_that("single-commodity species keep the generic system blend", {
+  # "Buffalo" is one commodity for all buffalo, so it must not collapse to a
+  # single system the way the cattle dairy/non-dairy commodities do.
+  result <- tibble::tibble(species = "Buffalo", heads = 1000) |>
+    whep::calculate_cohorts_systems()
+
+  testthat::expect_setequal(unique(result$system), c("Dairy", "Other"))
+  testthat::expect_equal(sum(result$cohort_heads), 1000, tolerance = 1)
+})
+
+testthat::test_that("supplied system_shares bypass commodity routing", {
+  custom <- tibble::tribble(
+    ~species_gen, ~system, ~system_share,
+    "Cattle", "Dairy", 0.5,
+    "Cattle", "Beef", 0.5
+  )
+  result <- tibble::tibble(species = "Cattle, dairy", heads = 1000) |>
+    whep::calculate_cohorts_systems(system_shares = custom)
+
+  testthat::expect_setequal(unique(result$system), c("Dairy", "Beef"))
+  testthat::expect_equal(sum(result$cohort_heads), 1000, tolerance = 1)
+})


### PR DESCRIPTION
## Summary

`calculate_cohorts_systems()` split a herd across production systems using `.default_system_shares()`, keyed only by **general** species (`Cattle` → 30% Dairy / 70% Beef). Both cattle commodities — `Cattle, dairy` (item_cbs 960) and `Cattle, non-dairy` (961) — therefore received the **same** generic blend, so the cohort composition was independent of the commodity. In `build_livestock_ghg_extension(tier = 2)` this mis-modelled the dairy vs non-dairy split (totals still conserved, since cohort fractions sum to 1).

Fixes #109.

## Change

With the **default** shares, route each herd to the production system named by its commodity's dairy/non-dairy subcategory:

| commodity | before (1000 head) | after |
|---|---|---|
| `Cattle, dairy` | 300 Dairy + 700 Beef | **1000 Dairy** |
| `Cattle, non-dairy` | 300 Dairy + 700 Beef | **1000 Beef** |
| `Buffalo` | 600 Dairy + 400 Other | 600 Dairy + 400 Other (unchanged) |

Three small private helpers in `R/livestock_cohorts.R`:

- `.commodity_subcategory()` — returns `"Dairy"` / `"Non-Dairy"` / `NA`. Returns `NA` (not `"Non-Dairy"`, unlike `.get_subcategory()`) when the name doesn't literally say dairy/non-dairy, so the single `Buffalo` commodity keeps its generic blend instead of collapsing to one system.
- `.subcategory_system_map()` — `Cattle` Dairy→Dairy, Non-Dairy→Beef. Cattle is the only species with separate dairy/non-dairy commodities in `animals_codes`.
- `.route_to_commodity_system()` — filters the joined systems to the routed one and assigns it the full share.

A supplied `system_shares` argument **bypasses** routing and is used verbatim (the issue's per-commodity-shares option). Totals still conserve (`cohort_heads` sum = `heads`).

## Out of scope

Poultry `Chickens, layers` / `Chickens, broilers` are separate commodities with the same class of bug (currently blended 50/50), but that is a layers/broilers distinction, not dairy/non-dairy, so it is left for a follow-up.

## Tests & checks

- New tests in `test_livestock_cohorts.R`: dairy→Dairy-only, non-dairy→Beef-only, single-commodity Buffalo keeps the blend, supplied `system_shares` bypasses routing.
- Existing #106 per-head regression ranges (enteric, manure) still hold with all-dairy cohorts.
- `air format` clean, `devtools::document()`, lint 0, `rcmdcheck` 0 errors / 0 warnings / 0 notes, pkgdown coverage complete.

🤖 Generated with [Claude Code](https://claude.com/claude-code)