### PR TITLE
feat(gapfilling): log-space interpolation for fill_linear

### DIFF
--- a/R/gapfilling.R
+++ b/R/gapfilling.R
@@ -14,6 +14,14 @@
 #' @param time_col The column containing time values. Default: `year`.
 #' @param interpolate Logical. If `TRUE` (default),
 #'   performs linear interpolation.
+#' @param log_space Logical. If `TRUE`, interior interpolation is performed in
+#'   log space (constant compound growth rate) for each gap segment whose two
+#'   bracketing anchors are both finite and strictly positive; any segment with
+#'   a non-positive or non-finite anchor falls back to linear interpolation.
+#'   Default: `FALSE`, i.e. linear interpolation everywhere. Log-space fills are
+#'   labelled `"Log-linear interpolation"` in the source column, distinct from
+#'   `"Linear interpolation"`, so the choice survives downstream. Carrying
+#'   forward or backward is unaffected.
 #' @param fill_forward Logical. If `TRUE` (default),
 #'   carries last value forward.
 #' @param fill_backward Logical. If `TRUE` (default),
@@ -47,11 +55,13 @@
 #'   interpolate = FALSE,
 #'   .by = c("category"),
 #' )
+#' fill_linear(sample_tibble, value, log_space = TRUE, .by = c("category"))
 fill_linear <- function(
   data,
   value_col,
   time_col = year,
   interpolate = TRUE,
+  log_space = FALSE,
   fill_forward = TRUE,
   fill_backward = TRUE,
   value_smooth_window = NULL,
@@ -61,6 +71,10 @@ fill_linear <- function(
   time_col_name <- rlang::as_name(rlang::enquo(time_col))
   source_col_name <- paste0("source_", value_col_name)
   by_cols <- .by %||% character(0)
+
+  if (!rlang::is_bool(log_space)) {
+    cli::cli_abort("`log_space` must be a single `TRUE` or `FALSE`.")
+  }
 
   n <- nrow(data)
   if (n == 0L) {
@@ -107,6 +121,7 @@ fill_linear <- function(
       smooth_vals,
       times,
       interpolate,
+      log_space,
       fill_forward,
       fill_backward
     )
@@ -129,6 +144,7 @@ fill_linear <- function(
       source_col_name,
       by_cols,
       interpolate,
+      log_space,
       fill_forward,
       fill_backward,
       value_smooth_window,
@@ -190,9 +206,22 @@ fill_linear <- function(
       NA_real_
     )
     interp <- locf + (nocb - locf) * frac
+    if (log_space) {
+      interp_log <- .loglinear_interp(tm, tl, tn, locf, nocb)
+      use_log <- !is.na(interp_log)
+      interp <- data.table::fifelse(use_log, interp_log, interp)
+    }
     mask <- is_na & !is.na(interp) & locf_ok & nocb_ok
     filled[mask] <- interp[mask]
-    source[mask] <- "Linear interpolation"
+    if (log_space) {
+      source[mask] <- data.table::fifelse(
+        use_log[mask],
+        "Log-linear interpolation",
+        "Linear interpolation"
+      )
+    } else {
+      source[mask] <- "Linear interpolation"
+    }
   }
 
   # Carry backward (NAs before first valid in group)
@@ -226,6 +255,7 @@ fill_linear <- function(
   source_col_name,
   by_cols,
   interpolate,
+  log_space,
   fill_forward,
   fill_backward,
   value_smooth_window,
@@ -258,14 +288,14 @@ fill_linear <- function(
         last_v <- valid[length(valid)]
 
         if (interpolate && length(valid) >= 2L && first_v < last_v) {
-          interp <- .safe_na_approx(sv, x = tm, na.rm = FALSE)
-          if (length(interp) == m) {
+          interp <- .interp_series(sv, tm, log_space)
+          if (length(interp$value) == m) {
             mask <- nna &
-              !is.na(interp) &
+              !is.na(interp$value) &
               seq_len(m) > first_v &
               seq_len(m) < last_v
-            filled[mask] <- interp[mask]
-            src[mask] <- "Linear interpolation"
+            filled[mask] <- interp$value[mask]
+            src[mask] <- .interp_source_label(interp$kind[mask])
           }
         }
         if (fill_backward && first_v > 1L) {
@@ -320,6 +350,7 @@ fill_linear <- function(
   smooth_vals,
   times,
   interpolate,
+  log_space,
   fill_forward,
   fill_backward
 ) {
@@ -366,11 +397,11 @@ fill_linear <- function(
     if (length(mid_idx) > 0L) {
       na_mid <- mid_idx[is.na(filled[mid_idx])]
       if (length(na_mid) > 0L) {
-        interp <- .safe_na_approx(smooth_vals, x = times, na.rm = FALSE)
-        if (length(interp) == n) {
-          fill_mask <- na_mid[!is.na(interp[na_mid])]
-          filled[fill_mask] <- interp[fill_mask]
-          source[fill_mask] <- "Linear interpolation"
+        interp <- .interp_series(smooth_vals, times, log_space)
+        if (length(interp$value) == n) {
+          fill_mask <- na_mid[!is.na(interp$value[na_mid])]
+          filled[fill_mask] <- interp$value[fill_mask]
+          source[fill_mask] <- .interp_source_label(interp$kind[fill_mask])
         }
       }
     }
@@ -382,6 +413,72 @@ fill_linear <- function(
   source[has_orig] <- "Original"
 
   list(value = filled, source = source)
+}
+
+# Interpolate a series, optionally refilling each interior segment in log space.
+# `smooth_vals` carries NA at gap positions; the non-NA entries are the anchors.
+# The linear baseline is `.safe_na_approx()` (identical to the prior behaviour,
+# so `log_space = FALSE` is a no-op). When `log_space` is TRUE, every gap whose
+# bracketing anchors are both finite and strictly positive is refilled in log
+# space (constant compound growth rate). Returns a list with `value` (the
+# interpolated vector) and `kind` (per-position label: "loglinear", "linear",
+# or NA where no interpolated value was produced).
+.interp_series <- function(smooth_vals, times, log_space) {
+  n <- length(smooth_vals)
+  linear <- .safe_na_approx(smooth_vals, x = times, na.rm = FALSE)
+  if (length(linear) != n) {
+    return(list(value = linear, kind = NA_character_))
+  }
+
+  kind <- data.table::fifelse(is.na(linear), NA_character_, "linear")
+  value <- linear
+
+  if (log_space) {
+    tt <- as.numeric(times)
+    anchor_time <- data.table::fifelse(!is.na(smooth_vals), tt, NA_real_)
+    anchor_val <- as.numeric(smooth_vals)
+    log_val <- .loglinear_interp(
+      tt,
+      data.table::nafill(anchor_time, "locf"),
+      data.table::nafill(anchor_time, "nocb"),
+      data.table::nafill(anchor_val, "locf"),
+      data.table::nafill(anchor_val, "nocb")
+    )
+    use_log <- is.na(smooth_vals) & !is.na(log_val) & !is.na(linear)
+    value[use_log] <- log_val[use_log]
+    kind[use_log] <- "loglinear"
+  }
+
+  list(value = value, kind = kind)
+}
+
+# Log-space (constant-growth) interpolation between bracketing anchors.
+# Returns the interpolated value where both anchors are finite and strictly
+# positive and the anchor times differ; NA elsewhere (the caller keeps its
+# linear value there). Non-positive anchors are floored to 1 before `log()`
+# purely to avoid NaN warnings; those positions are discarded by `usable`.
+.loglinear_interp <- function(t, t0, t1, v0, v1) {
+  span <- t1 - t0
+  usable <- is.finite(v0) &
+    is.finite(v1) &
+    v0 > 0 &
+    v1 > 0 &
+    is.finite(span) &
+    span != 0
+  safe_v0 <- data.table::fifelse(usable, v0, 1)
+  safe_v1 <- data.table::fifelse(usable, v1, 1)
+  frac <- (t - t0) / span
+  out <- exp(log(safe_v0) + frac * (log(safe_v1) - log(safe_v0)))
+  data.table::fifelse(usable, out, NA_real_)
+}
+
+# Map per-position interpolation `kind` labels to source-column strings.
+.interp_source_label <- function(kind) {
+  data.table::fifelse(
+    !is.na(kind) & kind == "loglinear",
+    "Log-linear interpolation",
+    "Linear interpolation"
+  )
 }
 
 #' Fill gaps summing the previous value of a variable to the value of

--- a/man/fill_linear.Rd
+++ b/man/fill_linear.Rd
@@ -9,6 +9,7 @@ fill_linear(
   value_col,
   time_col = year,
   interpolate = TRUE,
+  log_space = FALSE,
   fill_forward = TRUE,
   fill_backward = TRUE,
   value_smooth_window = NULL,
@@ -24,6 +25,15 @@ fill_linear(
 
 \item{interpolate}{Logical. If \code{TRUE} (default),
 performs linear interpolation.}
+
+\item{log_space}{Logical. If \code{TRUE}, interior interpolation is performed in
+log space (constant compound growth rate) for each gap segment whose two
+bracketing anchors are both finite and strictly positive; any segment with
+a non-positive or non-finite anchor falls back to linear interpolation.
+Default: \code{FALSE}, i.e. linear interpolation everywhere. Log-space fills are
+labelled \code{"Log-linear interpolation"} in the source column, distinct from
+\code{"Linear interpolation"}, so the choice survives downstream. Carrying
+forward or backward is unaffected.}
 
 \item{fill_forward}{Logical. If \code{TRUE} (default),
 carries last value forward.}
@@ -66,4 +76,5 @@ fill_linear(
   interpolate = FALSE,
   .by = c("category"),
 )
+fill_linear(sample_tibble, value, log_space = TRUE, .by = c("category"))
 }

--- a/tests/testthat/test_gapfilling.R
+++ b/tests/testthat/test_gapfilling.R
@@ -386,6 +386,183 @@ testthat::test_that("fill_linear handles no NAs without error", {
     pointblank::expect_col_vals_equal(source_value, "Original")
 })
 
+# fill_linear log_space --------------------------------------------------------
+
+testthat::test_that("fill_linear log_space uses the geometric midpoint", {
+  gap <- tibble::tribble(
+    ~year, ~value,
+    0, 1,
+    5, NA,
+    10, 1024
+  )
+
+  log_result <- gap |>
+    fill_linear(value, log_space = TRUE)
+  linear_result <- gap |>
+    fill_linear(value)
+
+  # Geometric (constant-growth) midpoint of 1 and 1024 is 32, not the
+  # arithmetic midpoint 512.5 that linear interpolation returns.
+  testthat::expect_equal(log_result$value[2], 32)
+  testthat::expect_false(isTRUE(all.equal(log_result$value[2], 512.5)))
+  testthat::expect_equal(log_result$source_value[2], "Log-linear interpolation")
+
+  testthat::expect_equal(linear_result$value[2], 512.5)
+  testthat::expect_equal(linear_result$source_value[2], "Linear interpolation")
+})
+
+testthat::test_that("fill_linear log_space falls back to linear on non-positive anchors", {
+  # A zero anchor makes log space undefined -> linear fallback.
+  tibble::tribble(
+    ~year, ~value,
+    0, 0,
+    5, NA,
+    10, 10
+  ) |>
+    fill_linear(value, log_space = TRUE) |>
+    testthat::expect_equal(
+      tibble::tribble(
+        ~year, ~value, ~source_value,
+        0, 0, "Original",
+        5, 5, "Linear interpolation",
+        10, 10, "Original"
+      )
+    )
+
+  # A negative anchor is likewise undefined -> linear fallback.
+  tibble::tribble(
+    ~year, ~value,
+    0, -4,
+    5, NA,
+    10, 8
+  ) |>
+    fill_linear(value, log_space = TRUE) |>
+    testthat::expect_equal(
+      tibble::tribble(
+        ~year, ~value, ~source_value,
+        0, -4, "Original",
+        5, 2, "Linear interpolation",
+        10, 8, "Original"
+      )
+    )
+})
+
+testthat::test_that("fill_linear log_space mixes log and linear segments in one series", {
+  # First gap has positive anchors (log); second gap is bracketed by a zero
+  # anchor (linear). Both segments coexist with distinct source labels.
+  tibble::tribble(
+    ~year, ~value,
+    0, 1,
+    5, NA,
+    10, 1024,
+    15, NA,
+    20, 0
+  ) |>
+    fill_linear(value, log_space = TRUE) |>
+    testthat::expect_equal(
+      tibble::tribble(
+        ~year, ~value, ~source_value,
+        0, 1, "Original",
+        5, 32, "Log-linear interpolation",
+        10, 1024, "Original",
+        15, 512, "Linear interpolation",
+        20, 0, "Original"
+      )
+    )
+})
+
+testthat::test_that("fill_linear log_space interpolates per group", {
+  tibble::tribble(
+    ~category, ~year, ~value,
+    "a", 0, 1,
+    "a", 5, NA,
+    "a", 10, 1024,
+    "b", 0, 2,
+    "b", 5, NA,
+    "b", 10, 200
+  ) |>
+    fill_linear(value, log_space = TRUE, .by = "category") |>
+    testthat::expect_equal(
+      tibble::tribble(
+        ~category, ~year, ~value, ~source_value,
+        "a", 0, 1, "Original",
+        "a", 5, 32, "Log-linear interpolation",
+        "a", 10, 1024, "Original",
+        "b", 0, 2, "Original",
+        "b", 5, 20, "Log-linear interpolation",
+        "b", 10, 200, "Original"
+      )
+    )
+})
+
+testthat::test_that("fill_linear log_space works on the smoothing (grouped) path", {
+  noisy <- tibble::tribble(
+    ~category, ~year, ~value,
+    "a", 2010, 10,
+    "a", 2011, 12,
+    "a", 2012, 8,
+    "a", 2013, NA,
+    "a", 2014, NA,
+    "a", 2015, 40,
+    "a", 2016, 44,
+    "a", 2017, 36
+  )
+
+  res_lin <- noisy |>
+    fill_linear(value, value_smooth_window = 3, .by = "category")
+  res_log <- noisy |>
+    fill_linear(
+      value,
+      log_space = TRUE,
+      value_smooth_window = 3,
+      .by = "category"
+    )
+
+  # Both fill the interior gap; the log-space fill differs from the linear one
+  # on a rising series and is labelled distinctly.
+  testthat::expect_false(any(is.na(res_lin$value[4:5])))
+  testthat::expect_false(any(is.na(res_log$value[4:5])))
+  testthat::expect_false(isTRUE(all.equal(
+    res_lin$value[4:5],
+    res_log$value[4:5]
+  )))
+  testthat::expect_true(
+    any(res_log$source_value == "Log-linear interpolation")
+  )
+})
+
+testthat::test_that("fill_linear default arguments match linear behaviour (regression lock)", {
+  # Omitting log_space must be byte-identical to log_space = FALSE, and must
+  # reproduce the established linear interpolation output.
+  grouped_default <- fill_linear_fixture() |>
+    fill_linear(value, .by = "category")
+  grouped_explicit <- fill_linear_fixture() |>
+    fill_linear(value, log_space = FALSE, .by = "category")
+  testthat::expect_equal(grouped_default, grouped_explicit)
+
+  ungrouped_default <- simple_linear_series() |>
+    fill_linear(value)
+  ungrouped_explicit <- simple_linear_series() |>
+    fill_linear(value, log_space = FALSE)
+  testthat::expect_equal(ungrouped_default, ungrouped_explicit)
+
+  grouped_default |>
+    dplyr::filter(category == "b") |>
+    dplyr::pull(value) |>
+    testthat::expect_equal(c(1, 2, 3, 4, 5, 5))
+  grouped_default |>
+    dplyr::filter(category == "b") |>
+    dplyr::pull(source_value) |>
+    testthat::expect_equal(c(
+      "Original",
+      "Linear interpolation",
+      "Linear interpolation",
+      "Linear interpolation",
+      "Original",
+      "Last value carried forward"
+    ))
+})
+
 # fill_sum --------------------------------------------------------------------
 
 testthat::test_that("fill_sum accumulates changes while keeping originals", {


### PR DESCRIPTION
## What

Adds a back-compatible `log_space = FALSE` argument to `fill_linear()`. When `TRUE`, each interior gap segment whose **two bracketing anchors are both finite and strictly positive** is interpolated in log space (constant compound growth rate); any segment with a non-positive or non-finite anchor **falls back to linear interpolation**. Carry-forward / carry-backward at the series ends are unchanged, and no extrapolation beyond the anchor range is introduced.

Log-space fills are labelled `"Log-linear interpolation"` in the `source_<value>` column, distinct from `"Linear interpolation"`, so the choice survives downstream provenance.

## Why

Roughly exponential series (energy use, and many economic/biophysical growth series) are systematically **under-filled at mid-gap** by linear interpolation: the geometric mean, not the arithmetic mean, is the constant-growth midpoint. Concretely, the geometric midpoint of `1` and `1024` is `32`, whereas linear interpolation returns `512.5`.

This is promoted from the **energy-hist** long-term-energy pipeline, whose `loglinear_approx()` (landed in commit `dada470` of that repo) is the reference implementation. There, linear interpolation over an exponential gas gap around 1950 over-filled the world-energy series by roughly 30%; the log-space rule removed that bias while leaving non-exponential series (e.g. EROI ratios) on the linear path.

## Design

Extends `fill_linear()` **at origin** with a boolean toggle rather than a sibling `fill_loglinear()`:

- `fill_linear()`'s argument surface is entirely boolean toggles (`interpolate`, `fill_forward`, `fill_backward`); a boolean `log_space` reads as "interpolate in log space" and fits that local style. It is placed right after `interpolate` (all in-repo callers pass every argument past `value_col` by name, so no positional break).
- Log-linear is **not universally more rigorous** than linear (it is undefined for non-positive anchors and inappropriate for non-exponential series), so the package's `method = ` convention — whose default is "the most rigorous method" — does not cleanly apply here; the safe, established general-purpose default is linear. Back-compat also requires the default to reproduce current behaviour exactly.
- All three interpolation code paths (ungrouped `.fill_linear_vec`, grouped-vectorized, grouped-smoothing `.fill_linear_by_group`) route through a single private `.loglinear_interp()` primitive, so the semantics are identical everywhere.

## Back-compatibility

Hard guarantee. With `log_space = FALSE` (the default) every code path is byte-identical to before: the log branches are skipped and the source label is unconditionally `"Linear interpolation"`. A regression-lock test asserts that the default call is identical to an explicit `log_space = FALSE` call **and** reproduces the established linear interpolation output.

## Tests

New tests in `tests/testthat/test_gapfilling.R`:

- geometric midpoint of `(0, 1)` and `(10, 1024)` at `t = 5` is `32`, explicitly `!=` the linear `512.5`;
- zero and negative anchors fall back to linear (`"Linear interpolation"`);
- mixed log/linear segments within one series (distinct labels coexist);
- `.by` grouping (per-group geometric midpoints, no cross-group bleed);
- the grouped-smoothing path with `value_smooth_window`;
- default-argument regression lock.

Verification (worktree, global R 4.5.2 library):

```
devtools::document()   -> only man/fill_linear.Rd regenerated; NAMESPACE unchanged
devtools::test(filter = "gapfilling")  -> FAIL 0 | WARN 0 | SKIP 0 | PASS 128
devtools::test()  (full suite)         -> FAIL 2 | WARN 0 | SKIP 0 | PASS 699
lintr (CI config) on both changed files -> 0 lints
air format . -> idempotent (no changes)
pkgdown coverage check -> empty (fill_linear already listed)
```

The 2 full-suite failures are the pre-existing `test_commodity_balance_sheet.R` failures documented in `CLAUDE.md` (unrelated CBS module; not touched here).

🤖 Generated with [Claude Code](https://claude.com/claude-code)