### PR TITLE
PoC: read inputs from GitHub Releases (issue #136)

### DIFF
--- a/R/github_inputs.R
+++ b/R/github_inputs.R
@@ -1,0 +1,81 @@
+# Proof of concept: read whep inputs from a GitHub Releases file store
+# instead of the Nextcloud pins board. See issue #136.
+#
+# Assets live in a data-only repo (default `eduaguilera/whep_inputs`) as flat
+# files named `<alias>.parquet`, attached to a release tag. This module
+# resolves an alias to its release-asset URL, downloads it into a local cache,
+# and returns the path -- matching the shape `.download_pin_paths()` expects.
+#
+# Enable with `options(whep.input_source = "github")` or the environment
+# variable `WHEP_INPUT_SOURCE=github`.
+
+.use_github_inputs <- function() {
+  source <- getOption(
+    "whep.input_source",
+    Sys.getenv("WHEP_INPUT_SOURCE", "pins")
+  )
+  identical(source, "github")
+}
+
+.github_inputs_repo <- function() {
+  getOption(
+    "whep.github_inputs_repo",
+    Sys.getenv("WHEP_GITHUB_INPUTS_REPO", "eduaguilera/whep_inputs")
+  )
+}
+
+.github_inputs_tag <- function() {
+  getOption(
+    "whep.github_inputs_tag",
+    Sys.getenv("WHEP_GITHUB_INPUTS_TAG", "poc")
+  )
+}
+
+.github_asset_url <- function(file_alias, repo, tag) {
+  paste0(
+    "https://github.com/",
+    repo,
+    "/releases/download/",
+    tag,
+    "/",
+    file_alias,
+    ".parquet"
+  )
+}
+
+.github_cache_dir <- function(tag) {
+  dir <- fs::path(tools::R_user_dir("whep", "cache"), "github", tag)
+  fs::dir_create(dir)
+  dir
+}
+
+# Download `<alias>.parquet` from the release (cached) and return its path.
+.get_github_release_paths <- function(file_alias) {
+  repo <- .github_inputs_repo()
+  tag <- .github_inputs_tag()
+  dest <- fs::path(.github_cache_dir(tag), paste0(file_alias, ".parquet"))
+
+  if (fs::file_exists(dest)) {
+    return(as.character(dest))
+  }
+
+  url <- .github_asset_url(file_alias, repo, tag)
+  cli::cli_alert_info(
+    "Fetching {.val {file_alias}} from GitHub release {.val {tag}}..."
+  )
+  status <- utils::download.file(
+    url,
+    destfile = dest,
+    mode = "wb",
+    quiet = TRUE
+  )
+
+  if (!identical(status, 0L) || !fs::file_exists(dest)) {
+    cli::cli_abort(c(
+      "Could not download {.val {file_alias}} from GitHub release.",
+      "i" = "Tried {.url {url}}."
+    ))
+  }
+
+  as.character(dest)
+}

--- a/R/read_raw_inputs.R
+++ b/R/read_raw_inputs.R
@@ -119,6 +119,10 @@
 
 # Get local file paths for a pin alias (download if needed, don't read).
 .download_pin_paths <- function(file_alias) {
+  if (.use_github_inputs()) {
+    return(.get_github_release_paths(file_alias))
+  }
+
   file_info <- .fetch_file_info(file_alias, whep::whep_inputs)
   version <- .choose_version(file_info$version, NULL)
 


### PR DESCRIPTION
**Draft / proof of concept — not for merge.** Demonstrates the GitHub-Releases file-store idea from #136 end to end.

## What it does
Adds an opt-in input source that fetches `<alias>.parquet` from a GitHub release into a local cache, wired into the single `.download_pin_paths()` choke point (`R/github_inputs.R` + a 4-line hook in `R/read_raw_inputs.R`). Default behaviour is unchanged — still the Nextcloud pins board. Enable with:

```r
options(whep.input_source = "github")   # repo/tag also configurable via options or env vars
```

## Data
The 10 inputs `build_primary_production()` needs were mirrored from the current Nextcloud board to a release in `eduaguilera/whep_inputs`:
- Release: https://github.com/eduaguilera/whep_inputs/releases/tag/poc
- 10 assets, 215 MB total, largest 44 MB — **all well under the 2 GiB per-file limit**, so no splitting needed for these tabular inputs (answers one of #136's open questions for this subset).

## Proof it runs
`build_primary_production(start_year = 2015, end_year = 2016)` with `whep.input_source = "github"`, cold cache:
- All 10 inputs fetched from the release assets (216 MB pulled into the whep cache).
- Output: **91,363 rows**, 12 columns, years 2015–2016, sources `FAOSTAT_prod` (90,680) + `LUH2_grassland` (683). Ran in ~82 s over the network.

## Deliberately out of scope (PoC)
- Only the parquet download path is routed to GitHub (enough for `build_primary_production`; `whep_read_file`'s other branches untouched).
- Fixed release tag instead of the per-alias versioning `whep_inputs` currently tracks — the versioning-scheme decision from #136 still needs settling.
- No tests; reads via base `download.file` rather than `piggyback` (kept dependency-free for the demo).

Relates to #136.

🤖 Generated with [Claude Code](https://claude.com/claude-code)