### PR TITLE
fix(supply-use): pass feed_mode so build_supply_use() no longer aborts

### DIFF
--- a/R/supply_use.R
+++ b/R/supply_use.R
@@ -91,6 +91,7 @@ build_supply_use <- function(example = FALSE) {
     feed_intake = .build_redistribute_intake(
       grain = "national",
       demand_tier = "ipcc",
+      feed_mode = "historical",
       production = primary_prod,
       cbs = cbs
     )

--- a/tests/testthat/test_supply_use.R
+++ b/tests/testthat/test_supply_use.R
@@ -744,3 +744,58 @@ testthat::test_that(".build_supply_use_from_inputs connects animal draught to cr
   )
   testthat::expect_equal(draught_use$value, draught_supply$value)
 })
+
+# build_supply_use (exported entry point) --------------------------------------
+
+testthat::test_that("build_supply_use() calls .build_redistribute_intake() with a valid feed_mode", {
+  # Regression for #176: the exported build_supply_use() built its feed_intake
+  # input via .build_redistribute_intake() without passing feed_mode, which
+  # has no default and is required -- every real (non-example) call aborted
+  # with "argument 'feed_mode' is missing, with no default" before building
+  # anything. The mock below mirrors .build_redistribute_intake()'s real
+  # signature (feed_mode with no default) so a regression reproduces the
+  # exact original error instead of silently accepting a missing argument.
+  captured <- NULL
+  testthat::local_mocked_bindings(
+    get_wide_cbs = function(...) "cbs_stub",
+    get_primary_production = function(...) "primary_prod_stub",
+    get_processing_coefs = function(...) "coeffs_stub",
+    get_primary_residues = function(...) "residues_stub",
+    .build_redistribute_intake = function(
+      grain,
+      demand_tier,
+      feed_mode,
+      production = NULL,
+      cbs = NULL,
+      years = NULL
+    ) {
+      captured <<- list(
+        grain = grain,
+        demand_tier = demand_tier,
+        feed_mode = feed_mode
+      )
+      "feed_intake_stub"
+    },
+    .build_supply_use_from_inputs = function(
+      items_prod,
+      items_cbs,
+      coeffs,
+      cbs,
+      crop_residues,
+      primary_prod,
+      feed_intake
+    ) {
+      # Force feed_intake's promise: build_supply_use() constructs it via
+      # .build_redistribute_intake() lazily as this call's argument, so it
+      # would otherwise never actually run under R's lazy evaluation.
+      force(feed_intake)
+      "supply_use_stub"
+    },
+    .add_reporting_polity_columns = function(x) x
+  )
+
+  result <- build_supply_use()
+
+  testthat::expect_equal(result, "supply_use_stub")
+  testthat::expect_equal(captured$feed_mode, "historical")
+})


### PR DESCRIPTION
## Summary

`build_supply_use()`'s feed-intake input was built via `.build_redistribute_intake()` (`R/supply_use.R:91-96`) without `feed_mode`, but that argument has no default and is required (`R/feed_intake_redistribute.R:27-53`). Every real (non-`example`) call to the exported `build_supply_use()` aborted **before building anything**:

```
Error in .build_redistribute_intake(...): argument "feed_mode" is missing, with no default
```

`build_io_model()`'s parallel call (`R/io_model.R:135-142`) already passes `feed_mode = "historical"` correctly — which both confirms the intended value and explains why the IO-model path worked while the standalone entry point did not. `"historical"` is also the documented semantic default in the sibling exported function `build_feed_intake_local()`: *"the CBS feed element is treated as realised consumption, so leftover availability is not dumped onto variable-demand livestock."*

## Changes

- `R/supply_use.R`: added `feed_mode = "historical"` to the `.build_redistribute_intake()` call.
- `tests/testthat/test_supply_use.R`: added a smoke test that calls the **real, non-`example`** `build_supply_use()`, mocking only the four remote-data getters and the two downstream builders — so it exercises the actual argument-passing at the exact call site that was broken. Notes on the test itself:
  - The `.build_redistribute_intake` mock mirrors the real function's signature (`feed_mode` with no default), so if this call site ever regresses, the test reproduces the *identical* original error rather than silently accepting a missing argument.
  - The mocked `.build_supply_use_from_inputs` must `force(feed_intake)` — `build_supply_use()` constructs that argument lazily via `.build_redistribute_intake()`, so without forcing it R's lazy evaluation means the call under test would never actually run.
  - I verified this catches the regression directly: reverting the one-line fix and re-running the test reproduces the exact reported error (`argument "feed_mode" is missing, with no default`) before restoring it.

## Test plan

- [x] New smoke test passes: `build_supply_use() calls .build_redistribute_intake() with a valid feed_mode`
- [x] Verified the test fails with the exact original error when the fix is reverted, and passes once restored
- [x] Full `test_supply_use.R` suite passes (23/23, 0 failures/warnings)
- [x] `lintr` clean on changed files
- [x] `air format .` applied

Fixes #176.

🤖 Generated with [Claude Code](https://claude.com/claude-code)