### PR TITLE
fix(nitrogen): guard pivot_wider() columns so a missing category doesn't crash

### DIFF
--- a/R/n_prov_destiny.R
+++ b/R/n_prov_destiny.R
@@ -798,6 +798,7 @@ create_n_nat_destiny <- function(example = FALSE) {
       values_from = feed_amount,
       values_fill = 0
     ) |>
+    .ensure_feed_type_cols() |>
     dplyr::mutate(
       # TODO: check if aquaculture belongs here
       # aquaculture was already in feed before these changes, but "magically"
@@ -819,6 +820,21 @@ create_n_nat_destiny <- function(example = FALSE) {
     feed_share_rum_mono = feed_share_rum_mono |>
       dplyr::select(Year, Province_name, Item, share_rum, share_mono)
   )
+}
+
+#' Ensure every Livestock_type pivot column exists after pivot_wider().
+#'
+#' pivot_wider() only creates a column for a level actually present in the
+#' input, so a province/year/item with no aquaculture or pets rows (for
+#' example) would otherwise crash the downstream `feed`/`food_pets` mutate
+#' with "object not found".
+#' @keywords internal
+#' @noRd
+.ensure_feed_type_cols <- function(feed_wide) {
+  required <- c("ruminant", "monogastric", "pets", "aquaculture")
+  missing <- setdiff(required, names(feed_wide))
+  feed_wide[missing] <- 0
+  feed_wide
 }
 
 #' @title Population
@@ -880,8 +896,10 @@ create_n_nat_destiny <- function(example = FALSE) {
     ) |>
     tidyr::pivot_wider(
       names_from = Destiny,
-      values_from = Total_value
-    )
+      values_from = Total_value,
+      values_fill = 0
+    ) |>
+    .ensure_food_other_uses_cols()
 
   prov_food_other_uses <- total_food_other_uses |>
     dplyr::left_join(
@@ -900,6 +918,20 @@ create_n_nat_destiny <- function(example = FALSE) {
     dplyr::select(Year, Province_name, Item, food, other_uses)
 
   prov_food_other_uses
+}
+
+#' Ensure both Food and Other_uses pivot columns exist after pivot_wider().
+#'
+#' If every row is one Destiny (e.g. no Other_uses rows anywhere in the
+#' input), pivot_wider() never creates that column, and the downstream
+#' mutate() crashes with "object not found".
+#' @keywords internal
+#' @noRd
+.ensure_food_other_uses_cols <- function(total_food_other_uses) {
+  required <- c("Food", "Other_uses")
+  missing <- setdiff(required, names(total_food_other_uses))
+  total_food_other_uses[missing] <- 0
+  total_food_other_uses
 }
 
 #' @title Combine all destinies ------------------------------------------------

--- a/R/n_soil_inputs_nue.R
+++ b/R/n_soil_inputs_nue.R
@@ -163,6 +163,7 @@ create_n_production <- function(example = FALSE) {
       values_from = mg_n,
       values_fill = 0
     ) |>
+    .ensure_destiny_cols() |>
     dplyr::mutate(
       feed = livestock_rum + livestock_mono,
       prod = population_food + population_other_uses + feed + export,
@@ -174,6 +175,26 @@ create_n_production <- function(example = FALSE) {
       .by = c(year, province_name, item, box)
     ) |>
     dplyr::arrange(year, province_name, item, box)
+}
+
+#' Ensure every destiny pivot column exists after pivot_wider().
+#'
+#' If a destiny category (e.g. export) has no rows anywhere in the input,
+#' pivot_wider() never creates that column, and the downstream mutate()
+#' crashes with "object not found".
+#' @keywords internal
+#' @noRd
+.ensure_destiny_cols <- function(prod_wide) {
+  required <- c(
+    "livestock_rum",
+    "livestock_mono",
+    "population_food",
+    "population_other_uses",
+    "export"
+  )
+  missing <- setdiff(required, names(prod_wide))
+  prod_wide[missing] <- 0
+  prod_wide
 }
 
 

--- a/tests/testthat/test_n_prov_destiny.R
+++ b/tests/testthat/test_n_prov_destiny.R
@@ -513,6 +513,51 @@ test_that(".combine_destinies adds food_pets to food", {
 })
 
 
+# .add_feed ---------------------------------------------------------------------
+
+test_that(".add_feed does not crash when a Livestock_type category is entirely absent", {
+  # Regression for #175: pivot_wider() only creates a column for a
+  # Livestock_type level actually present in the input. A dataset with no
+  # Aquaculture or Pets rows at all previously crashed with "object
+  # 'aquaculture' not found" instead of treating those flows as zero.
+  feed_intake <- tibble::tribble(
+    ~Year, ~Province_name, ~Item, ~Livestock_cat, ~FM_Mg,
+    2000, "A", "Wheat", "Cattle_meat", 10,
+    2000, "A", "Wheat", "Pigs", 4
+  )
+
+  out <- .add_feed(feed_intake)
+
+  expect_equal(out$feed_intake$feed, 14)
+  expect_equal(out$feed_intake$food_pets, 0)
+  expect_equal(out$feed_share_rum_mono$share_rum, 10 / 14)
+  expect_equal(out$feed_share_rum_mono$share_mono, 4 / 14)
+})
+
+
+# .calculate_food_and_other_uses -------------------------------------------------
+
+test_that(".calculate_food_and_other_uses does not crash when a Destiny is entirely absent", {
+  # Regression for #175: same pivot_wider() class of bug as .add_feed() --
+  # a dataset with no Other_uses rows at all previously crashed with "object
+  # 'Other_uses' not found".
+  population_share <- tibble::tribble(
+    ~Year, ~Province_name, ~Pop_share,
+    2000, "A", 0.5
+  )
+
+  pie_full_destinies_fm <- tibble::tribble(
+    ~Year, ~Item, ~Destiny, ~Element, ~Value_destiny,
+    2000, "Wheat", "Food", "Domestic_supply", 20
+  )
+
+  out <- .calculate_food_and_other_uses(population_share, pie_full_destinies_fm)
+
+  expect_equal(out$food, 10)
+  expect_equal(out$other_uses, 0)
+})
+
+
 # .convert_to_items_n ----------------------------------------------------------
 
 test_that(".convert_to_items_n converts consumption FM to N", {

--- a/tests/testthat/test_n_soil_inputs_nue.R
+++ b/tests/testthat/test_n_soil_inputs_nue.R
@@ -77,6 +77,22 @@ test_that(".calculate_n_production sums production correctly", {
   expect_equal(out$prod, 10)
 })
 
+test_that(".calculate_n_production does not crash when a destiny category is entirely absent", {
+  # Regression for #175: pivot_wider() only creates a column for a destiny
+  # level actually present in the input. A province/year/item with no export
+  # rows at all previously crashed the mutate() with "object 'export' not
+  # found" instead of treating it as zero.
+  grafs <- tibble::tribble(
+    ~year, ~province_name, ~item, ~box, ~destiny, ~mg_n,
+    2000, "A", "Wheat", "Cropland", "population_food", 5,
+    2000, "A", "Wheat", "Cropland", "livestock_rum", 2
+  )
+
+  out <- .calculate_n_production(grafs)
+
+  expect_equal(out$prod, 7)
+})
+
 
 # calculate_nue_crops
 test_that("calculate_nue_crops computes NUE correctly", {


### PR DESCRIPTION
## Summary

`.add_feed()` (`R/n_prov_destiny.R`) referenced pivoted columns (`ruminant`, `monogastric`, `pets`, `aquaculture`) immediately after `tidyr::pivot_wider(names_from = Livestock_type, ...)`. `pivot_wider()` only creates a column for a level actually present in the input, so any dataset with no `Aquaculture` or `Pets` rows at all crashed the `mutate()` with `object 'aquaculture' not found` instead of treating that flow as zero.

The issue flags the **same bug class** at two sibling functions, both fixed here:
- `.calculate_food_and_other_uses()` (`R/n_prov_destiny.R`): pivots on `Destiny` (`Food`/`Other_uses`) with no `values_fill` and no guard.
- `.calculate_n_production()` (`R/n_soil_inputs_nue.R`): pivots on `destiny` with `values_fill = 0`, but no guard for a category missing entirely (which `values_fill` doesn't cover — it only fills gaps for columns that already exist).

Unlike `build_cbs.R`, which guards every pivoted column with `if (!"x" %in% names(...))` before referencing it, none of these three paths had a guard. Any run over a filtered subset — a narrow year range, a province/year with no pets or aquaculture, a trimmed fixture — crashed with a cryptic "object not found" error instead of producing output.

## Changes

- `R/n_prov_destiny.R`: added `.ensure_feed_type_cols()` (used in `.add_feed()`) and `.ensure_food_other_uses_cols()` (used in `.calculate_food_and_other_uses()`).
- `R/n_soil_inputs_nue.R`: added `.ensure_destiny_cols()` (used in `.calculate_n_production()`).

  Each is a small private helper mirroring the `.ensure_production_cols`/`.bnf_ensure_env_cols` convention already used elsewhere in the package: `setdiff()` the required columns against what's present, and fill any that are absent with `0`.

- `tests/testthat/test_n_prov_destiny.R` / `test_n_soil_inputs_nue.R`: one regression test per function, each using a fixture that omits a whole category. I verified all three fail with the exact original `object '<x>' not found` error when the corresponding guard is removed, then pass once restored (not just "the test I wrote happens to pass").

## Test plan

- [x] 3 new regression tests pass
- [x] Verified each fails with the exact original error when its guard is reverted
- [x] Full `test_n_prov_destiny.R` (43/43) and `test_n_soil_inputs_nue.R` (7/7) suites pass, 0 failures/warnings
- [x] `lintr` clean on changed files
- [x] `air format .` applied

Fixes #175.

🤖 Generated with [Claude Code](https://claude.com/claude-code)