### PR TITLE
fix(livestock): warn explicitly when Tier 2 has no energy coefficients for a species

### DIFF
--- a/R/livestock_ghg_extension.R
+++ b/R/livestock_ghg_extension.R
@@ -101,7 +101,7 @@ build_livestock_ghg_extension <- function(
   )
   n2o <- .sum_emission_cols(emissions, "manure_n2o_total")
   co2e <- ch4 * factors[["ch4"]] + n2o * factors[["n2o"]]
-  .warn_dropped_ghg(co2e)
+  .warn_dropped_ghg(co2e, emissions, tier)
 
   emissions |>
     dplyr::mutate(co2e_kg = co2e) |>
@@ -145,15 +145,51 @@ build_livestock_ghg_extension <- function(
   paste0("IPCC_2019_Tier", tier, "_", toupper(gwp))
 }
 
-.warn_dropped_ghg <- function(co2e) {
+.warn_dropped_ghg <- function(co2e, emissions, tier) {
   n_na <- sum(is.na(co2e))
-  if (n_na > 0L) {
+  if (n_na == 0L) {
+    return(invisible())
+  }
+
+  systematic_species <- .species_with_no_tier_coefs(co2e, emissions)
+  n_systematic <- sum(
+    is.na(co2e) & emissions$species_gen %in% systematic_species
+  )
+  n_partial <- n_na - n_systematic
+
+  if (length(systematic_species) > 0L) {
+    demonstrative <- if (length(systematic_species) == 1L) "this" else "these"
     cli::cli_warn(c(
-      "!" = "Dropping {n_na} livestock row{?s} with unresolved emissions.",
+      "!" = "Dropping {n_systematic} livestock row{?s} for
+        {.val {systematic_species}}: no Tier {tier} coefficients exist for
+        {demonstrative} species.",
+      "i" = "This is a systematic gap (the whole species has no matching
+        coefficient row), not a missing-data one -- Tier 1 (the package
+        default) still covers {demonstrative} species."
+    ))
+  }
+
+  if (n_partial > 0L) {
+    cli::cli_warn(c(
+      "!" = "Dropping {n_partial} livestock row{?s} with unresolved emissions.",
       "i" = "These rows lack the cohort or diet inputs the Tier 2 energy
         balance needs."
     ))
   }
+}
+
+# Species where EVERY row lacking co2e is missing (as opposed to some rows of
+# a species resolving fine and others not, which points to a per-row data gap
+# rather than a species entirely absent from the tier's coefficient tables).
+.species_with_no_tier_coefs <- function(co2e, emissions) {
+  if (!rlang::has_name(emissions, "species_gen")) {
+    return(character())
+  }
+  emissions |>
+    dplyr::mutate(.na = is.na(co2e)) |>
+    dplyr::summarise(.all_na = all(.na), .by = species_gen) |>
+    dplyr::filter(.all_na) |>
+    dplyr::pull(species_gen)
 }
 
 .check_ghg_tier <- function(tier) {

--- a/R/utils.R
+++ b/R/utils.R
@@ -269,6 +269,8 @@ utils::globalVariables(
     ".grp_pos",
     ".is_miss_tmp",
     ".lambda",
+    ".all_na",
+    ".na",
     ".load_inputs_typologies_julia",
     ".n_rates",
     ".pred_end",

--- a/tests/testthat/test_livestock_ghg_extension.R
+++ b/tests/testthat/test_livestock_ghg_extension.R
@@ -128,3 +128,63 @@ testthat::test_that("tier must be 1 or 2", {
     "tier"
   )
 })
+
+testthat::test_that(".warn_dropped_ghg distinguishes a systematic species gap from partial data gaps", {
+  # Regression for #191: Swine/Poultry/Horses/Camels/Mules & Asses have no
+  # Tier 2 energy coefficients at all (ipcc_tier2_energy_coefs only covers
+  # Cattle, Buffalo, Sheep, Goats), so every row of those species silently
+  # got gross_energy = NA and was dropped with a misleading message implying
+  # a per-row data gap. The warning must now name the affected species and
+  # say explicitly this is a systematic coefficient gap, separate from the
+  # existing generic message for genuine per-row missing-data cases.
+  emissions <- tibble::tribble(
+    ~year, ~area_code, ~item_cbs_code, ~species_gen, ~enteric_ch4_tier2, ~manure_ch4_tier2, ~manure_n2o_total,
+    2000, 1, 1, "Cattle", 10, 5, 2,
+    2000, 1, 2, "Cattle", NA_real_, NA_real_, NA_real_,
+    2000, 1, 3, "Swine", NA_real_, NA_real_, NA_real_,
+    2000, 1, 4, "Poultry", NA_real_, NA_real_, NA_real_
+  )
+
+  warnings_caught <- character()
+  withCallingHandlers(
+    whep:::.ghg_co2e_extension(emissions, tier = 2, gwp = "ar6"),
+    warning = function(w) {
+      warnings_caught <<- c(warnings_caught, conditionMessage(w))
+      invokeRestart("muffleWarning")
+    }
+  )
+
+  systematic_warning <- warnings_caught[
+    grepl("Swine", warnings_caught, fixed = TRUE)
+  ]
+  partial_warning <- warnings_caught[
+    grepl("unresolved emissions", warnings_caught, fixed = TRUE)
+  ]
+
+  testthat::expect_length(systematic_warning, 1)
+  testthat::expect_match(systematic_warning, "Swine", fixed = TRUE)
+  testthat::expect_match(systematic_warning, "Poultry", fixed = TRUE)
+  testthat::expect_match(systematic_warning, "no Tier 2 coefficients")
+  testthat::expect_match(systematic_warning, "systematic gap")
+  testthat::expect_length(partial_warning, 1)
+  testthat::expect_false(grepl("Swine", partial_warning, fixed = TRUE))
+})
+
+testthat::test_that("Tier 2 warns explicitly when a real species has no energy coefficients", {
+  # End-to-end: item_cbs_code 1049 (pig meat) maps to species_gen "Swine" via
+  # prepare_livestock_emissions(), which has no Tier 2 Cfi row.
+  prod <- tibble::tribble(
+    ~year, ~area_code, ~item_cbs_code, ~unit, ~value,
+    2000L, 10L, 1049L, "heads", 100000
+  )
+
+  testthat::expect_warning(
+    result <- whep::build_livestock_ghg_extension(
+      tier = 2,
+      data = list(primary_prod = prod)
+    ),
+    "no Tier 2 coefficients"
+  )
+
+  testthat::expect_equal(nrow(result), 0L)
+})


### PR DESCRIPTION
## Summary

`ipcc_tier2_energy_coefs` only has 6 rows (Cattle Dairy/Non-Dairy, Buffalo Dairy/Non-Dairy, Sheep, Goats). `.join_energy_coefs()` (`R/livestock_energy.R`) left-joins on species, so every other species — Swine, Poultry, Horses, Camels, Mules & Asses — gets an all-`NA` `cfi_mj_day_kg075`, which cascades to `NA` `gross_energy`, `NA` `enteric_ch4_tier2`, and `NA` Tier-2 manure terms.

These rows were then silently dropped by `.ghg_co2e_extension()`'s existing `.warn_dropped_ghg()`, whose message ("These rows lack the cohort or diet inputs the Tier 2 energy balance needs") frames the drop as a **missing-data** problem — but here entire species have no coefficient row at all, so it's a **systematic** gap, not a data-driven one. It hides in practice because Tier 1 (the package default) still covers those species, so pigs and poultry only silently disappear if a caller explicitly opts into `tier = 2`.

## Why I didn't just add coefficients

I fetched and read IPCC 2019 Refinement Vol 4 Ch 10 directly before deciding on a fix. **Table 10.4 (Updated)** only tabulates Cfi for Cattle, Buffalo, Sheep and Goats — there is no published Tier-2 energy-balance methodology for the other species in this table. The chapter's own manure-VS section (Eq 10.24) notes that swine gross-energy needs a *different*, feed-intake-based estimation this package doesn't implement (the Tier 2 NEm/Cfi decomposition is fundamentally a ruminant-specific method). Fabricating placeholder coefficients for species IPCC doesn't provide them for would be scientifically wrong. The correct fix is the issue's second suggested option: make the drop explicit and diagnosable rather than inventing coefficients.

## Changes

- `R/livestock_ghg_extension.R`: `.warn_dropped_ghg()` now distinguishes two cases and emits a **separate, precise warning for each**:
  1. **Systematic species gap** — every row of a species resolves to `NA`. Names the affected species explicitly (e.g. `"Swine"`, `"Poultry"`) and states this is a coefficient gap, not a data gap, and that Tier 1 still covers them.
  2. **Genuine per-row data gap** — some rows of a species resolve fine, others don't (the existing, still-accurate message about missing cohort/diet inputs).
- `R/utils.R`: declared the two new NSE temp columns (`.na`, `.all_na`) used by the new species-detection helper.
- `tests/testthat/test_livestock_ghg_extension.R`: added a precise unit test on the two-warning split using a mixed fixture (one systematic species + one partial-data row), and an end-to-end test using `build_livestock_ghg_extension(tier = 2)` with a real `item_cbs_code` (1049, pig meat) that maps to `species_gen = "Swine"` via `prepare_livestock_emissions()`, confirming the full pipeline warns clearly instead of silently vanishing the row.

## Test plan

- [x] New unit test passes: warning correctly names `"Swine"`/`"Poultry"` and says "systematic gap", separately from the generic partial-data warning
- [x] New end-to-end test passes: real Swine `item_cbs_code` triggers the "no Tier 2 coefficients" warning
- [x] Full `test_livestock_ghg_extension.R` (9/9), `test_livestock_energy.R` (13/13), `test_livestock_emissions.R` (6/6) suites pass, 0 failures
- [x] `lintr` clean on changed files
- [x] `air format .` applied

Fixes #191.

🤖 Generated with [Claude Code](https://claude.com/claude-code)