### PR TITLE
fix(bilateral-trade): zero the matrix diagonal so self-trade can't reappear

### DIFF
--- a/R/bilateral_trade.R
+++ b/R/bilateral_trade.R
@@ -166,6 +166,12 @@ get_bilateral_trade <- function(example = FALSE, cbs = NULL) {
   active <- which(exports > 0 | imports > 0)
   sub <- trade_matrix[active, active, drop = FALSE]
   sub[sub == 0] <- 1
+  # RAS/IPF scales multiplicatively, so a cell that is genuinely 0 going in
+  # stays 0 through every iteration; but the seeding line above treats the
+  # diagonal (self-trade, always 0) like any other unobserved zero, which
+  # would let IPF allocate a spurious i -> i flow to hit the row/column
+  # totals. Re-zero it so self-trade can never re-enter the balanced matrix.
+  sub <- .zero_diagonal(sub)
   sub <- .ipf_2d(sub, exports[active], imports[active])
 
   result <- matrix(
@@ -248,6 +254,18 @@ get_bilateral_trade <- function(example = FALSE, cbs = NULL) {
   # TODO: Adapt this to our needs
   k_trust_factor <- 0.1
   trade_matrix[na_mask] <- estimate[na_mask] * k_trust_factor
+  # The diagonal (a country trading with itself) starts NA from
+  # .build_trade_matrix() and would otherwise be filled by the estimate above,
+  # like any other missing cell -- but self-trade is never a real flow.
+  .zero_diagonal(trade_matrix)
+}
+
+# Force the diagonal of a country x country trade matrix to exactly 0. A
+# country never trades with itself; used both after estimating missing trade
+# (.fill_missing_trade()) and after IPF's zero-seeding step (.balance_matrix())
+# so self-trade can never re-enter the matrix.
+.zero_diagonal <- function(trade_matrix) {
+  diag(trade_matrix) <- 0
   trade_matrix
 }
 

--- a/tests/testthat/test_bilateral_trade.R
+++ b/tests/testthat/test_bilateral_trade.R
@@ -193,12 +193,16 @@ testthat::test_that(".fill_missing_trade only fills NA entries of matrix", {
     ncol = 3
   )
 
+  # Regression for #152: a country never trades with itself, so the
+  # diagonal is always forced to 0 -- including the pre-existing 140/100
+  # values at [1,1]/[2,2], which .fill_missing_trade() now treats as
+  # self-trade rather than ordinary (non-NA, left-alone) cells.
   expected <- matrix(
     # fmt: skip
     c(
-      140.00, 7.65, 2.45,
-      50.00, 100.00, 2.96,
-      3.64, 4.55, 1.46
+      0.00, 7.65, 2.45,
+      50.00, 0.00, 2.96,
+      3.64, 4.55, 0.00
     ),
     byrow = TRUE,
     ncol = 3
@@ -216,13 +220,25 @@ testthat::test_that(".fill_missing_trade only fills NA entries of matrix", {
     testthat::expect_equal(expected, tolerance = 1e-2)
 })
 
-testthat::test_that(".fill_missing_trade does nothing for non-NA matrices", {
+testthat::test_that(".fill_missing_trade zeroes the diagonal even when the rest is unchanged", {
   original <- matrix(
     # fmt: skip
     c(
       140, 40, 30,
       50, 100, 77,
       11, 324, 23
+    ),
+    byrow = TRUE,
+    ncol = 3
+  )
+  # Regression for #152: off-diagonal non-NA cells stay untouched, but the
+  # diagonal (self-trade) is always forced to 0.
+  expected <- matrix(
+    # fmt: skip
+    c(
+      0, 40, 30,
+      50, 0, 77,
+      11, 324, 0
     ),
     byrow = TRUE,
     ncol = 3
@@ -237,7 +253,7 @@ testthat::test_that(".fill_missing_trade does nothing for non-NA matrices", {
 
   original |>
     .fill_missing_trade(total_trade) |>
-    testthat::expect_equal(original, tolerance = 1e-2)
+    testthat::expect_equal(expected, tolerance = 1e-2)
 })
 
 testthat::test_that(".fill_missing_trade fills with 0s if row sum is already past CBS report", {
@@ -250,11 +266,13 @@ testthat::test_that(".fill_missing_trade fills with 0s if row sum is already pas
     byrow = TRUE,
     ncol = 2
   )
+  # Regression for #152: both diagonal entries are forced to 0 (self-trade),
+  # on top of the pre-existing "row sum already past target" 0-fill.
   expected <- matrix(
     # fmt: skip
     c(
-      140, 0,
-      0, 100
+      0, 0,
+      0, 0
     ),
     byrow = TRUE,
     ncol = 2
@@ -334,6 +352,40 @@ testthat::test_that(".balance_matrix aligns targets by country code", {
 
   testthat::expect_equal(as.numeric(rowSums(result)), c(10, 0, 0))
   testthat::expect_equal(as.numeric(colSums(result)), c(0, 10, 0))
+})
+
+testthat::test_that(".balance_matrix never allocates self-trade on the diagonal", {
+  # Regression for #152: .fill_missing_trade()'s na_mask includes the
+  # diagonal, so a large trader (big exports AND big imports) previously got
+  # a spurious i -> i flow seeded by .estimate_bilateral_trade() and then
+  # preserved (often inflated) by IPF's sub[sub == 0] <- 1 seeding step,
+  # stealing mass from its real trading partners. Uses a matrix that
+  # reproduces the exact reported failure mode: country 1 is the largest
+  # trader (1000 export / 900 import) with a mostly-unobserved (NA) row.
+  n <- 4
+  code_int <- c(10L, 20L, 30L, 40L)
+  btd <- tibble::tribble(
+    ~from_code, ~to_code, ~value,
+    10L, 20L, 500,
+    10L, 30L, 300,
+    20L, 10L, 400,
+    30L, 10L, 200,
+    40L, 20L, 50
+  )
+  total_trade <- tibble::tribble(
+    ~area_code, ~export, ~import, ~balanced_export, ~balanced_import,
+    10L, 1000, 900, 1000, 900,
+    20L, 200, 700, 200, 700,
+    30L, 150, 350, 150, 350,
+    40L, 80, 100, 80, 100
+  )
+
+  result <- btd |>
+    .build_trade_matrix(n, code_int) |>
+    .fill_missing_trade(total_trade) |>
+    .balance_matrix(total_trade)
+
+  testthat::expect_equal(as.numeric(diag(result)), rep(0, n))
 })
 
 testthat::test_that(".build_trade_matrix completes missing countries", {


### PR DESCRIPTION
## Summary

`.build_trade_matrix()` leaves the diagonal `NA` (a country never trades with itself). `.fill_missing_trade()`'s `na_mask` included the diagonal, so it got filled with a nonzero estimate from `.estimate_bilateral_trade()` like any other missing cell. `.balance_matrix()`'s IPF-seeding line (`sub[sub == 0] <- 1`) then preserved and often inflated it, since a large trader has both big exports and big imports — self-trade frequently ended up one of the largest entries in its row, stealing mass from real trading partners while row/column totals still "balanced."

**Verified the severity directly** with a 4-country synthetic fixture modeling a large trader (1000 export / 900 import, mostly-unobserved row): it got **361.95 of spurious self-trade out of its 1000 export target — 36% of its total trade.**

## Fix

Added a small `.zero_diagonal()` helper, called in two places:
1. At the end of `.fill_missing_trade()`, so self-trade is never filled with an estimate.
2. Inside `.balance_matrix()`, right before the IPF call — re-zeroing the diagonal *after* the `sub[sub == 0] <- 1` seeding step specifically excludes it.

RAS/IPF (`.ras_iterate()` / `.ipf_2d()`) scales multiplicatively, so a genuinely-zero cell going in stays zero through every iteration — meaning the "missing" self-trade mass correctly redistributes to the country's real partners instead of vanishing or reappearing.

I considered applying this only at the orchestration layer (`.process_bilateral_trade()`'s pipe chain) instead of inside these two functions, to avoid touching what looked like generic matrix utilities. But `.balance_matrix()`'s bug specifically comes from its *internal* `sub[sub == 0] <- 1` seeding step — no amount of external pre-processing can stop that line from re-introducing a nonzero diagonal, since it only checks `value == 0`, not "is this the diagonal." Since these two functions have no other real caller than this trade-balancing pipeline, fixing them internally is both necessary (for `.balance_matrix()`) and more robust (protects any future caller from a matrix whose diagonal wasn't already `NA`).

## Test changes

Three existing tests had synthetic fixtures with non-zero diagonal values used purely as generic test data (unrelated to self-trade semantics) — their expected matrices needed recomputing to reflect the corrected, self-trade-free behavior. The two existing `.balance_matrix` tests were **unaffected**, since they only assert marginal row/column sums, which IPF still satisfies regardless of what the diagonal does.

Added a dedicated regression test reproducing the exact large-trader scenario end-to-end (`.build_trade_matrix() |> .fill_missing_trade() |> .balance_matrix()`), asserting the diagonal is `0`. I verified all four new/changed assertions fail with the original (pre-fix) values — including the `361.95` self-trade figure — when the fix is temporarily reverted, then pass once restored.

## Test plan

- [x] New regression test passes: `.balance_matrix never allocates self-trade on the diagonal`
- [x] 3 existing tests updated with correctly recomputed expected values (diagonal forced to 0)
- [x] Verified all 4 assertions fail with the exact pre-fix values when the fix is reverted
- [x] Full `test_bilateral_trade.R` (29/29) plus downstream `test_build_trade.R`, `test_fabio_fixes.R`, `test_footprint_balance.R`, `test_footprint.R`, `test_io_model.R`, `test_polity_output_coverage.R` — 118 tests total, 0 failures
- [x] `lintr` clean on changed files
- [x] `air format .` applied

Fixes #152.

🤖 Generated with [Claude Code](https://claude.com/claude-code)