### PR TITLE
fix(code-names): deduplicate item lookups so a shared code can't fan out

### DIFF
--- a/R/code_names.R
+++ b/R/code_names.R
@@ -280,6 +280,10 @@ add_item_prod_code <- function(
     dplyr::select(
       !!name_column := item_cbs_name,
       !!code_column := item_cbs_code
+    ) |>
+    dplyr::distinct(
+      dplyr::across(dplyr::all_of(code_column)),
+      .keep_all = TRUE
     )
 }
 
@@ -288,5 +292,9 @@ add_item_prod_code <- function(
     dplyr::select(
       !!name_column := item_prod_name,
       !!code_column := item_prod_code
+    ) |>
+    dplyr::distinct(
+      dplyr::across(dplyr::all_of(code_column)),
+      .keep_all = TRUE
     )
 }

--- a/tests/testthat/test_code_names.R
+++ b/tests/testthat/test_code_names.R
@@ -242,3 +242,41 @@ testthat::test_that("add_item_prod_code correctly sets new column in table", {
       )
     )
 })
+
+testthat::test_that("add_item_prod_name does not fan out on a duplicate item_prod_code", {
+  # Regression for #236: whep::items_prod has a real non-unique key --
+  # item_prod_code 1807 maps to two unrelated names ("Citrus Fruit, Total"
+  # and "Sheep and Goat Meat"). Without a distinct() guard on the lookup,
+  # every input row with that code was duplicated by the left_join, silently
+  # doubling any downstream sum()/.by aggregation.
+  dup_names <- whep::items_prod |>
+    dplyr::filter(item_prod_code == 1807) |>
+    dplyr::pull(item_prod_name)
+  testthat::expect_gt(length(dup_names), 1)
+
+  table <- tibble::tibble(item_prod_code = c(1807, 27), value = c(100, 200))
+
+  out <- add_item_prod_name(table)
+
+  testthat::expect_equal(nrow(out), nrow(table))
+  testthat::expect_equal(sum(out$value), sum(table$value))
+})
+
+testthat::test_that(".get_cbs_items and .get_prod_items never return a duplicate key", {
+  # Same class of bug as the add_item_prod_name() test above, checked as a
+  # standing invariant on the lookup tables themselves: matching
+  # .get_polities()'s existing distinct() pattern, neither lookup may return
+  # more than one row per code, regardless of whether the underlying
+  # whep::items_cbs/items_prod happen to contain a duplicate key today.
+  cbs_items <- whep:::.get_cbs_items("item_cbs_name", "item_cbs_code")
+  prod_items <- whep:::.get_prod_items("item_prod_name", "item_prod_code")
+
+  testthat::expect_equal(
+    nrow(cbs_items),
+    dplyr::n_distinct(cbs_items$item_cbs_code)
+  )
+  testthat::expect_equal(
+    nrow(prod_items),
+    dplyr::n_distinct(prod_items$item_prod_code)
+  )
+})


### PR DESCRIPTION
## Summary

`.get_prod_items()`/`.get_cbs_items()` (`R/code_names.R`) built their code → name lookup with a bare `dplyr::select()` and no `distinct()`, unlike the sibling `.get_polities()`, which deduplicates before joining. `whep::items_prod` has a non-unique key: `item_prod_code == 1807` maps to two unrelated names, **"Citrus Fruit, Total"** and **"Sheep and Goat Meat"**. The accessor's `left_join` fanned out on that code, turning every input row carrying it into two output rows with the same value — silently double-counting it under any downstream `sum()`/`.by` aggregation.

**Verified directly**: a 2-row input (codes 1807 and 27) produced **3** output rows via `add_item_prod_name()`, with the code-1807 value duplicated across both names and the column total inflated from **300 to 400**. Reverting the fix reproduces this exactly.

## Changes

- `R/code_names.R`: added the same `distinct(dplyr::across(dplyr::all_of(code_column)), .keep_all = TRUE)` guard already used by `.get_polities()`, to both `.get_cbs_items()` and `.get_prod_items()`.
- `tests/testthat/test_code_names.R`:
  1. A regression test using the **real, confirmed** `items_prod` duplicate (1807) — asserts `add_item_prod_name()` no longer fans out and the value total stays correct.
  2. A standing invariant test asserting neither `.get_cbs_items()` nor `.get_prod_items()` can ever return more than one row per code — this keeps the guard checked even if `whep::items_cbs` (which has no live duplicate today) later develops one.

I verified both new assertions fail with the exact original fan-out (3 rows, value 400 / duplicate `item_prod_code`) when the fix is temporarily reverted, then pass once restored.

## Test plan

- [x] New regression test passes: `add_item_prod_name does not fan out on a duplicate item_prod_code`
- [x] New invariant test passes: `.get_cbs_items and .get_prod_items never return a duplicate key`
- [x] Verified both fail with the exact original fan-out when the fix is reverted
- [x] Full `test_code_names.R` suite passes (8/8, 0 failures/warnings)
- [x] `lintr` clean on changed files
- [x] `air format .` applied

Fixes #236.

🤖 Generated with [Claude Code](https://claude.com/claude-code)