### PR TITLE
fix(io): disambiguate cbs_wide cache key from get_wide_cbs()

### DIFF
--- a/R/io_model.R
+++ b/R/io_model.R
@@ -111,7 +111,7 @@ build_io_model <- function(
     })
 
     if (is.null(cbs)) {
-      cbs <- .cache_get(.io_cache_key("cbs_wide", build_years), {
+      cbs <- .cache_get(.io_cache_key("cbs_wide_io", build_years), {
         cli::cli_progress_step("Adding livestock CBS rows")
         wide <- .pivot_cbs_wide(cbs_built)
         livestock_cbs <- get_livestock_cbs(primary_prod_build) |>

--- a/tests/testthat/test_io_model.R
+++ b/tests/testthat/test_io_model.R
@@ -292,6 +292,13 @@ testthat::test_that("IO default build helpers scope cache keys by requested year
     .io_cache_key("primary_prod", c(2001, 1999)),
     "primary_prod__1999__2001"
   )
+  # The IO model caches a plain (no reporting-polity columns, no QC)
+  # cbs_wide object; get_wide_cbs() caches the reporting version under
+  # the bare "cbs_wide" slot. Their keys must never collide (issue #243).
+  testthat::expect_false(.io_cache_key("cbs_wide_io", NULL) == "cbs_wide")
+  testthat::expect_false(
+    .io_cache_key("cbs_wide_io", c(1999, 2001)) == "cbs_wide"
+  )
 })
 
 testthat::test_that("sparse default IO builds run requested years independently", {


### PR DESCRIPTION
## Root cause

`.io_cache_key(key, years)` returns the **bare** `key` when `years` is `NULL` (`R/io_model.R`), and `build_io_model()` defaults to `years = NULL`. So its `cbs_wide` producer wrote into the same bare `"cbs_wide"` slot in `.build_cache` that `get_wide_cbs()` uses — but the two objects are **not** equivalent:

- `get_wide_cbs()` runs `bind_rows(...) |> .add_reporting_polity_columns()` and `.qc_supply_use_balance()`, adding `reporting_polity_code`, `reporting_polity_name`, `reporting_polity_has_geometry`, `polity_area_code`.
- `build_io_model()` does `bind_rows(wide, livestock_cbs)` only — no reporting-polity columns, no QC.

Whichever ran first won the shared slot. Calling `build_io_model()` (defaults) then `get_wide_cbs()` in one session made `get_wide_cbs()` short-circuit and return the IO version, silently violating its documented contract (missing `reporting_polity_*` / `polity_area_code`) and skipping the supply-use QC check.

## Fix

Give the IO producer a distinct cache key `"cbs_wide_io"` so the two structurally different objects never share a slot. The IO block keeps caching its plain version; `get_wide_cbs()` keeps its reporting + QC version under the bare `"cbs_wide"` key. Minimal one-token change plus a regression assertion.

## Test

Extended the existing `.io_cache_key` helper test in `tests/testthat/test_io_model.R` to assert the IO `cbs_wide` key (both `years = NULL` and dense-year forms) never equals the bare `"cbs_wide"` slot. The full collision cannot be exercised offline (both producers require remote build data), so the regression guard targets the key construction, which is where the bug lived.

Closes #243

🤖 Generated with [Claude Code](https://claude.com/claude-code)