### PR TITLE
fix(livestock): match IPCC region crosswalk to real gleam_region values

### DIFF
--- a/R/livestock_enteric.R
+++ b/R/livestock_enteric.R
@@ -103,8 +103,11 @@
 #'
 #' The IPCC 2019 Refinement EF tables (10.10, 10.14) use their own region
 #' taxonomy, distinct from the GLEAM regions in gleam_geographic_hierarchy.
-#' Eight GLEAM regions map directly; two are judgement calls: GLEAM "Russia"
-#' to IPCC "Eastern Europe" and "Near East and North Africa" to "Middle East".
+#' The gleam_region keys below match the values actually shipped in
+#' gleam_geographic_hierarchy. Most GLEAM regions map directly; two are
+#' judgement calls: GLEAM "Russian Federation" to IPCC "Eastern Europe" and
+#' "West Asia & Northern Africa" to "Middle East". "Antarctica" has no IPCC
+#' EF region and is intentionally left unmapped (no livestock countries).
 #' @noRd
 .add_ipcc_region <- function(data) {
   crosswalk <- tibble::tribble(
@@ -112,21 +115,21 @@
     ~region,
     "North America",
     "North America",
-    "Russia",
+    "Russian Federation",
     "Eastern Europe",
     "Western Europe",
     "Western Europe",
     "Eastern Europe",
     "Eastern Europe",
-    "Near East and North Africa",
+    "West Asia & Northern Africa",
     "Middle East",
-    "East and Southeast Asia",
+    "East Asia",
     "Asia",
     "Oceania",
     "Oceania",
     "South Asia",
     "Indian Subcontinent",
-    "Latin America and Caribbean",
+    "Central & South America",
     "Latin America",
     "Sub-Saharan Africa",
     "Africa"

--- a/tests/testthat/test_livestock_enteric.R
+++ b/tests/testthat/test_livestock_enteric.R
@@ -92,6 +92,41 @@ testthat::test_that("Tier 1 uses regional EF when iso3 is supplied", {
   testthat::expect_false("region" %in% names(result))
 })
 
+# .add_ipcc_region --------------------------------------------------------------
+
+testthat::test_that("IPCC region crosswalk covers all GLEAM regions", {
+  # Regression for #268: four crosswalk keys ("Russia",
+  # "Near East and North Africa", "East and Southeast Asia",
+  # "Latin America and Caribbean") never matched the real gleam_region
+  # values, leaving 90/204 countries with region = NA.
+  hierarchy <- whep::gleam_geographic_hierarchy |>
+    dplyr::distinct(iso3)
+
+  result <- whep:::.add_ipcc_region(hierarchy)
+
+  # Antarctica (ATF, SGS) has no IPCC EF region and is the only allowed gap.
+  unmapped <- result |>
+    dplyr::filter(is.na(region)) |>
+    dplyr::pull(iso3)
+  testthat::expect_setequal(unmapped, c("ATF", "SGS"))
+})
+
+testthat::test_that("IPCC region resolves representative countries", {
+  result <- tibble::tribble(
+    ~iso3,
+    "RUS",
+    "SAU",
+    "CHN",
+    "BRA"
+  ) |>
+    whep:::.add_ipcc_region()
+
+  testthat::expect_equal(
+    result$region,
+    c("Eastern Europe", "Middle East", "Asia", "Latin America")
+  )
+})
+
 # .calc_enteric_ch4_tier2 -------------------------------------------------------
 
 testthat::test_that("Tier 2 enteric is in IPCC range for dairy", {


### PR DESCRIPTION
## Root cause

`.add_ipcc_region()` (`R/livestock_enteric.R`) hardcoded a crosswalk from
`gleam_geographic_hierarchy$gleam_region` to the IPCC EF region vocabulary,
but four of its `gleam_region` keys never matched the values actually shipped
in `gleam_geographic_hierarchy` (`data/livestock_coefs.rda`):

| crosswalk key (wrong) | real `gleam_region` value |
|---|---|
| `Russia` | `Russian Federation` |
| `Near East and North Africa` | `West Asia & Northern Africa` |
| `East and Southeast Asia` | `East Asia` |
| `Latin America and Caribbean` | `Central & South America` |

Because those keys never joined, `.add_ipcc_region()` returned `region = NA`
for **90 of 204 countries (44%)** — all of Russia/former-USSR, the Middle
East/North Africa, East Asia, and Central & South America.

Downstream this was silent, not fatal:
- `.join_cattle_ef()` (Tier-1 enteric CH4) substituted the **Global** EF
  instead of the correct regional one.
- `.calc_weighted_mcf()` (Tier-2 manure CH4) has no NA fallback, so
  `coalesce()` substituted a flat weighted MCF of 0.02 for those countries
  (same failure mode as #174, but far broader in scope).

## Fix

Correct the four `gleam_region` keys to the real values. The target IPCC
`region` vocabulary was already correct (it matches
`ipcc_2019_enteric_ef_cattle$region`), so only the keys change. `Antarctica`
(ISO3 `ATF`, `SGS`) has no IPCC EF region and stays intentionally unmapped.

## Test

Added a regression test asserting `.add_ipcc_region()` leaves only Antarctica
(`ATF`, `SGS`) unmapped across the full `gleam_geographic_hierarchy`, plus a
spot-check that representative countries (RUS, SAU, CHN, BRA) resolve to their
correct IPCC regions. All 18 tests in `test_livestock_enteric.R` pass locally.

Closes #268

🤖 Generated with [Claude Code](https://claude.com/claude-code)