### PR TITLE
fix(grassland): stop active_grazing zeroing temporary grassland (3002)

### DIFF
--- a/R/grassland_land_extension.R
+++ b/R/grassland_land_extension.R
@@ -132,6 +132,12 @@ build_grassland_land_extension <- function(
 }
 
 # Cap grassland area at the area implied by grazing intake and usable yield.
+# Grass intake from get_feed_intake() is booked under permanent grassland
+# (item_cbs 3000) only, while occupation spans all grass items (e.g. 3002
+# temporary grassland). Capping must therefore compare total grazing intake
+# against total grassland area per year/area, then split the capped total back
+# across items in proportion to their occupation, otherwise items with no
+# matching intake row (like 3002) would be silently zeroed.
 .grassland_active_grazing <- function(
   occupation,
   feed_intake,
@@ -141,22 +147,30 @@ build_grassland_land_extension <- function(
     dplyr::filter(.data$feed_type == "grass") |>
     dplyr::summarise(
       grazing_intake_dm_t = sum(.data$intake_dry_matter, na.rm = TRUE),
-      .by = c(year, area_code, item_cbs_code)
+      .by = c(year, area_code)
     ) |>
     dplyr::mutate(
       year = as.integer(.data$year),
-      area_code = as.integer(.data$area_code),
-      item_cbs_code = as.integer(.data$item_cbs_code)
+      area_code = as.integer(.data$area_code)
     )
 
   occupation |>
-    dplyr::left_join(intake, by = c("year", "area_code", "item_cbs_code")) |>
+    dplyr::mutate(
+      occupation_total = sum(.data$impact_u, na.rm = TRUE),
+      .by = c(year, area_code)
+    ) |>
+    dplyr::left_join(intake, by = c("year", "area_code")) |>
     dplyr::mutate(
       grazing_intake_dm_t = tidyr::replace_na(.data$grazing_intake_dm_t, 0),
-      impact_u = pmin(
-        .data$impact_u,
+      capped_total = pmin(
+        .data$occupation_total,
         .data$grazing_intake_dm_t / usable_grass_yield_dm_t_ha,
         na.rm = TRUE
+      ),
+      impact_u = dplyr::if_else(
+        .data$occupation_total > 0,
+        .data$impact_u * .data$capped_total / .data$occupation_total,
+        0
       ),
       method_grassland = "active_grazing"
     ) |>

--- a/tests/testthat/test_grassland_land_extension.R
+++ b/tests/testthat/test_grassland_land_extension.R
@@ -76,6 +76,45 @@ testthat::test_that("active_grazing caps area at grazing intake over yield", {
   testthat::expect_true(all(result$method_grassland == "active_grazing"))
 })
 
+testthat::test_that("active_grazing keeps temporary grassland (item 3002)", {
+  # Grass intake is booked under item 3000 only, but occupation also carries
+  # temporary grassland (item 3002). Capping against total grassland must keep
+  # 3002 instead of zeroing it (issue #195).
+  primary_prod <- tibble::tribble(
+    ~year, ~area_code, ~item_cbs_code, ~unit, ~value,
+    2000L, 30L, 3000L, "ha", 600, # permanent grassland
+    2000L, 30L, 3002L, "ha", 400, # temporary grassland, no intake row
+    2000L, 40L, 3000L, "ha", 600, # capped case, permanent
+    2000L, 40L, 3002L, "ha", 400 # capped case, temporary
+  )
+  feed_intake <- tibble::tribble(
+    ~year, ~area_code, ~item_cbs_code, ~feed_type, ~intake_dry_matter,
+    2000L, 30L, 3000L, "grass", 3000, # 3000 / 2 = 1500 ha, above total 1000
+    2000L, 40L, 3000L, "grass", 1000 # 1000 / 2 = 500 ha, below total 1000
+  )
+
+  result <- whep::build_grassland_land_extension(
+    source = "luh2",
+    grassland_metric = "active_grazing",
+    usable_grass_yield_dm_t_ha = 2,
+    data = list(primary_prod = primary_prod, feed_intake = feed_intake)
+  )
+
+  # Uncapped area: temporary grassland keeps its full area, not zeroed.
+  uncapped_temp <- dplyr::filter(
+    result,
+    area_code == 30L,
+    item_cbs_code == 3002L
+  )
+  testthat::expect_equal(uncapped_temp$impact_u, 400)
+
+  # Capped area: 500 ha total split 600:400 -> 300 permanent, 200 temporary.
+  capped_perm <- dplyr::filter(result, area_code == 40L, item_cbs_code == 3000L)
+  capped_temp <- dplyr::filter(result, area_code == 40L, item_cbs_code == 3002L)
+  testthat::expect_equal(capped_perm$impact_u, 300)
+  testthat::expect_equal(capped_temp$impact_u, 200)
+})
+
 testthat::test_that("active_grazing rejects invalid usable grass yield", {
   primary_prod <- tibble::tribble(
     ~year, ~area_code, ~item_cbs_code, ~unit, ~value,


### PR DESCRIPTION
## Root cause

In `.grassland_active_grazing()` (`R/grassland_land_extension.R`), the grazing
cap joined intake to occupation on `by = c("year", "area_code",
"item_cbs_code")`. But `get_feed_intake()` books **all** grass feed under
permanent grassland (`item_cbs_code` 3000), while LUH2 occupation also carries
temporary grassland (item 3002). Temporary-grassland rows therefore found no
matching intake row, `replace_na(..., 0)` set their intake to 0, and
`pmin(area, 0) = 0` silently dropped every hectare of temporary grassland
whenever `grassland_metric = "active_grazing"` — a systematic under-count.

## Fix

Cap **total** grazing intake against **total** grassland area per
`(year, area_code)`, then split the capped total back across the grass items in
proportion to their occupation. This keeps temporary grassland (3002)
contributing to the extension instead of zeroing it, while preserving the
existing per-item output keying and the total-area cap behaviour.

## Tests

Added `active_grazing keeps temporary grassland (item 3002)` covering both an
uncapped case (3002 keeps its full area) and a capped case (total area split
proportionally across 3000/3002). All existing grassland tests still pass
(`test_grassland_land_extension.R`: 18 assertions, 0 failures, offline).

Closes #195

🤖 Generated with [Claude Code](https://claude.com/claude-code)