### PR TITLE
fix(prices): palm-kernel replacement deletes genuine data via cross-product filter

### DIFF
--- a/R/prices.R
+++ b/R/prices.R
@@ -428,11 +428,13 @@ build_cbs_prices <- function(
           item_cbs_code = 2562L,
           price = x2562
         )]
-        # Remove existing 2562 rows for those years and replace
+        # Replace only the specific (year, element) rows being
+        # estimated. A keyed anti-join avoids the cross-product of
+        # {years} x {elements} that would delete genuine prices for
+        # untouched (year, element) pairs.
         dt <- dt[
-          !(item_cbs_code == 2562L &
-            year %in% pk_new$year &
-            element %in% pk_new$element)
+          !pk_new,
+          on = c("year", "element", "item_cbs_code")
         ]
         items <- data.table::as.data.table(whep::items_full)
         pk_new[,

--- a/tests/testthat/test_prices.R
+++ b/tests/testthat/test_prices.R
@@ -732,6 +732,87 @@ testthat::test_that("build_cbs_prices estimates palm kernel from palm oil ratio"
   testthat::expect_true(all(pk$price > 0))
 })
 
+testthat::test_that(".estimate_missing_prices keeps untouched element-years", {
+  # Asymmetric gaps: import 2562 missing 2018-2019, export missing only
+  # 2018. The buggy cross-product filter (year %in% . & element %in% .)
+  # would also delete the genuine 2019 export price, which is not among
+  # the estimated pairs. A keyed anti-join must preserve it.
+  dt <- data.table::data.table(
+    year = c(
+      2018L,
+      2019L,
+      2020L,
+      2018L,
+      2019L,
+      2020L,
+      2019L,
+      2020L,
+      2020L
+    ),
+    item_cbs = c(
+      rep("Palm Oil", 6),
+      rep("Palm kernels", 3)
+    ),
+    item_cbs_code = c(rep(2577L, 6), rep(2562L, 3)),
+    element = c(
+      "export",
+      "export",
+      "export",
+      "import",
+      "import",
+      "import",
+      "export",
+      "export",
+      "import"
+    ),
+    tonnes = rep(1000, 9),
+    kdollars = c(
+      500,
+      600,
+      550,
+      450,
+      500,
+      500,
+      500,
+      500,
+      400
+    ),
+    price = c(
+      0.5,
+      0.6,
+      0.55,
+      0.45,
+      0.5,
+      0.5,
+      0.5,
+      0.5,
+      0.4
+    )
+  )
+
+  result <- .estimate_missing_prices(dt)
+
+  # Genuine 2019 export palm-kernel price must survive untouched.
+  kept <- result |>
+    dplyr::filter(
+      item_cbs_code == 2562L,
+      element == "export",
+      year == 2019L
+    )
+  testthat::expect_equal(nrow(kept), 1)
+  testthat::expect_equal(kept$price, 0.5)
+
+  # Estimation still fills the genuinely missing 2018 export price.
+  estimated <- result |>
+    dplyr::filter(
+      item_cbs_code == 2562L,
+      element == "export",
+      year == 2018L
+    )
+  testthat::expect_equal(nrow(estimated), 1)
+  testthat::expect_true(estimated$price > 0)
+})
+
 # Proxy price tests ------------------------------------------------------------
 
 testthat::test_that("build_cbs_prices creates soy hulls proxy from soyabean cake", {


### PR DESCRIPTION
## Problem

`.estimate_missing_prices()` (`R/prices.R`) replaced existing palm-kernel (CBS item `2562`) rows before appending ratio-estimated prices using:

```r
dt[!(item_cbs_code == 2562L &
     year %in% pk_new$year &
     element %in% pk_new$element)]
```

`year %in% pk_new$year & element %in% pk_new$element` tests each column against its own value set independently — the **cross-product** of `{years} x {elements}`, not the matched `(year, element)` pairs actually being replaced.

With asymmetric import/export gaps this deletes genuine prices. Example: import `2562` backfilled for 2018-2019 and export backfilled only for 2018 gives `pk_new = {(2018,import),(2019,import),(2018,export)}`. The filter then also drops the genuine `(2019, export)` price (its year and its element each appear in the sets) — and nothing replaces it.

## Fix

Replace the cross-product filter with a keyed anti-join on the actual `(year, element, item_cbs_code)` triples in `pk_new`:

```r
dt <- dt[!pk_new, on = c("year", "element", "item_cbs_code")]
```

Only the specific estimated pairs are removed; untouched element-years survive.

## Test

Added a regression test in `tests/testthat/test_prices.R` exercising `.estimate_missing_prices()` with asymmetric import/export gaps. It asserts the genuine 2019 export palm-kernel price survives untouched while the genuinely missing 2018 export price is still estimated. Verified the test fails on the old filter (genuine row deleted) and passes on the fix. All 71 tests in `test_prices.R` pass.

Closes #156

🤖 Generated with [Claude Code](https://claude.com/claude-code)