### PR TITLE
fix(energy): preserve country-years lacking slaughter shares

### DIFF
--- a/R/energy_co2_extension.R
+++ b/R/energy_co2_extension.R
@@ -23,7 +23,9 @@
 #' its factors by production system and climate zone but the package has no
 #' country-level system or climate shares, the intensities are collapsed to one
 #' value per country by an unweighted mean across systems and climate zones;
-#' this choice is recorded in `method_energy`.
+#' this choice is recorded in `method_energy`. A meat group with carcass output
+#' but no slaughtered-head counts keeps its energy CO2e, split equally across
+#' the group's live-animal sectors, and triggers a warning.
 #'
 #' `gleam_geographic_hierarchy` is the country universe of the whole extension,
 #' so a reporting area absent from it gets no energy intensity and its meat
@@ -689,11 +691,21 @@ build_energy_co2_extension <- function(
 # ---- attribution to live-animal sectors -----------------------------------
 
 # Spread each (year, area_code, grp) CO2e across its live-animal sectors in
-# proportion to slaughtered head counts.
+# proportion to slaughtered head counts. Every group is expanded to its full
+# sector set from the sector map (via a left join to head counts) so a
+# country-year is never silently dropped for lacking `slaughtered_heads` rows;
+# when a group has no head counts its CO2e is split equally across its sectors.
 .energy_allocate_to_sectors <- function(co2e, primary_prod) {
-  shares <- .energy_slaughter_shares(primary_prod)
-  co2e |>
-    dplyr::inner_join(shares, by = c("year", "area_code", "grp")) |>
+  heads <- .energy_slaughter_heads(primary_prod)
+  allocated <- co2e |>
+    dplyr::inner_join(.energy_sector_map(), by = "grp") |>
+    dplyr::left_join(
+      heads,
+      by = c("year", "area_code", "grp", "item_cbs_code")
+    ) |>
+    .energy_apply_head_shares()
+  .energy_warn_missing_shares(allocated)
+  allocated |>
     dplyr::mutate(impact_u = .data$co2e_kg * .data$share) |>
     dplyr::summarise(
       impact_u = sum(.data$impact_u, na.rm = TRUE),
@@ -701,7 +713,9 @@ build_energy_co2_extension <- function(
     )
 }
 
-.energy_slaughter_shares <- function(primary_prod) {
+# Slaughtered head counts per (year, area_code, grp, item_cbs_code); may be
+# absent for a group when `primary_prod` has no matching rows.
+.energy_slaughter_heads <- function(primary_prod) {
   sector_map <- .energy_sector_map()
   primary_prod |>
     dplyr::filter(
@@ -712,12 +726,38 @@ build_energy_co2_extension <- function(
     dplyr::summarise(
       heads = sum(.data$value, na.rm = TRUE),
       .by = c("year", "area_code", "grp", "item_cbs_code")
-    ) |>
+    )
+}
+
+# Within each (year, area_code, grp), turn head counts into allocation shares.
+# When the group has no positive head count, fall back to an equal split across
+# its sectors (this also guards the `0 / 0 = NaN` share case).
+.energy_apply_head_shares <- function(allocated) {
+  allocated |>
     dplyr::mutate(
-      share = .data$heads / sum(.data$heads),
+      total_heads = sum(.data$heads, na.rm = TRUE),
+      share = dplyr::if_else(
+        .data$total_heads > 0,
+        dplyr::coalesce(.data$heads, 0) / .data$total_heads,
+        1 / dplyr::n()
+      ),
       .by = c("year", "area_code", "grp")
-    ) |>
-    dplyr::select("year", "area_code", "grp", "item_cbs_code", "share")
+    )
+}
+
+# Warn once when any group lacked head counts and used the equal-split fallback.
+.energy_warn_missing_shares <- function(allocated) {
+  missing <- allocated |>
+    dplyr::filter(.data$total_heads == 0) |>
+    dplyr::distinct(.data$year, .data$area_code, .data$grp)
+  n <- nrow(missing)
+  if (n > 0) {
+    cli::cli_warn(c(
+      "!" = "{n} country-year meat group{?s} lack slaughtered-head counts.",
+      "i" = "Their energy CO2e was split equally across the group's sectors."
+    ))
+  }
+  invisible(allocated)
 }
 
 # ---- finalise --------------------------------------------------------------

--- a/man/build_energy_co2_extension.Rd
+++ b/man/build_energy_co2_extension.Rd
@@ -65,7 +65,9 @@ sectors in proportion to their slaughtered head counts. Because GLEAM reports
 its factors by production system and climate zone but the package has no
 country-level system or climate shares, the intensities are collapsed to one
 value per country by an unweighted mean across systems and climate zones;
-this choice is recorded in \code{method_energy}.
+this choice is recorded in \code{method_energy}. A meat group with carcass output
+but no slaughtered-head counts keeps its energy CO2e, split equally across
+the group's live-animal sectors, and triggers a warning.
 
 \code{gleam_geographic_hierarchy} is the country universe of the whole extension,
 so a reporting area absent from it gets no energy intensity and its meat

--- a/tests/testthat/test_energy_co2_extension.R
+++ b/tests/testthat/test_energy_co2_extension.R
@@ -330,6 +330,29 @@ testthat::test_that("area -> iso3 needs no tie-break across polity periods", {
   testthat::expect_false(351L %in% area2iso$area_code)
 })
 
+testthat::test_that("carcass with no slaughter heads is not dropped", {
+  # Bovine carcass output but zero slaughtered-head rows for the group.
+  prod <- tibble::tribble(
+    ~year, ~area_code, ~item_cbs_code, ~unit, ~value,
+    2000L, 231L, 2731L, "tonnes", 1e7
+  )
+  testthat::expect_warning(
+    result <- whep::build_energy_co2_extension(
+      data = list(primary_prod = prod)
+    ),
+    "slaughtered-head"
+  )
+
+  # The group's CO2e survives and is split equally across both sectors.
+  testthat::expect_setequal(result$item_cbs_code, c(961L, 946L))
+  testthat::expect_true(all(result$impact_u > 0))
+  testthat::expect_false(any(is.na(result$impact_u)))
+  testthat::expect_equal(
+    result$impact_u[result$item_cbs_code == 961L],
+    result$impact_u[result$item_cbs_code == 946L]
+  )
+})
+
 testthat::test_that("only the gleam method is available", {
   testthat::expect_error(
     whep::build_energy_co2_extension(method = "fao"),


### PR DESCRIPTION
## Problem

`.energy_allocate_to_sectors()` (`R/energy_co2_extension.R`) joined
group-level CO2e to slaughter-head shares with `inner_join`, so any
`(year, area, grp)` with carcass production but no `slaughtered_heads`
rows in `primary_prod` lost its **entire** energy CO2e with no warning.
A second route: when a group's `sum(heads) == 0`, `share = 0/0 = NaN`,
`impact_u` became `NaN`, `sum(..., na.rm = TRUE)` turned it to 0, and the
`impact_u > 0` filter in `.energy_finalise_extension()` dropped it. This
compounds #145 (slaughter counts vanishing for split species in recent
years).

## Fix

- Enumerate each meat group's live-animal sectors from the sector map via
  an `inner_join` on `grp` (every group in the CO2e table has a sector
  entry, so nothing is dropped), then `left_join` the head counts.
- Compute shares within `(year, area, grp)`; when the group has no
  positive head count, fall back to an equal split across its sectors.
  This preserves the country-year and guards the `0/0 = NaN` case.
- Warn via `cli::cli_warn()` when the equal-split fallback is used.

## Tests

Added `carcass with no slaughter heads is not dropped`: a bovine carcass
row with zero head-count rows now survives, warns, and is split equally
across sectors 961/946. Full `test_energy_co2_extension.R` passes (17
checks), lint clean on the changed file.

Closes #196

🤖 Generated with [Claude Code](https://claude.com/claude-code)