### PR TITLE
fix(production): gap-fill stock shares for split-species slaughter

### DIFF
--- a/R/build_production.R
+++ b/R/build_production.R
@@ -1215,7 +1215,14 @@ build_primary_production <- function(
   if (nrow(needs_split) == 0L) {
     return(no_split)
   }
-  shares <- .compute_stock_shares(years)
+  # Stock shares come from the faostat-emissions-livestock pin, which lags
+  # QCL slaughter by 1-2 years. Carry the latest known share forward (and
+  # interpolate/back-fill) so split species keep their slaughter counts in
+  # QCL's most recent years, mirroring the value_st fill in
+  # .combine_livestock(). Without this the inner_join drops those years and
+  # cattle/swine/chicken slaughtered_heads silently vanish.
+  shares <- .compute_stock_shares(years) |>
+    .carry_forward_shares(sort(unique(needs_split$year)))
   split_result <- needs_split |>
     dplyr::select(-item_cbs_code) |>
     dplyr::distinct() |>
@@ -1224,6 +1231,21 @@ build_primary_production <- function(
     dplyr::select(year, area, area_code, item_cbs_code, value)
 
   dplyr::bind_rows(no_split, split_result)
+}
+
+.carry_forward_shares <- function(shares, target_years) {
+  shares |>
+    tidyr::complete(
+      year = target_years,
+      tidyr::nesting(area_code, Item_Code, item_cbs_code)
+    ) |>
+    fill_linear(
+      share,
+      time_col = year,
+      .by = c("area_code", "Item_Code", "item_cbs_code")
+    ) |>
+    dplyr::filter(!is.na(share)) |>
+    dplyr::select(year, area_code, Item_Code, item_cbs_code, share)
 }
 
 .compute_stock_shares <- function(years) {

--- a/tests/testthat/test_build_production.R
+++ b/tests/testthat/test_build_production.R
@@ -651,7 +651,6 @@ test_that("build_primary_production output has no duplicate keys", {
   expect_equal(nrow(keys), nrow(dplyr::distinct(keys)))
 })
 
-
 # -- .split_stock_share ---------------------------------------------------------
 
 test_that(".split_stock_share splits proportionally when both sub-items have data", {
@@ -734,4 +733,37 @@ test_that(".split_stock_share keeps groups (year, area, item_prod_code) independ
   result <- .split_stock_share(data)
 
   expect_equal(result$value_comb, c(0, 100, 50, 150))
+})
+
+test_that(".carry_forward_shares extends shares to QCL's latest years", {
+  # Shares from the emissions pin lag QCL by 1-2 years: here they stop at
+  # 2021 while slaughter data (target_years) runs to 2023.
+  shares <- tibble::tribble(
+    ~year, ~area_code, ~Item_Code, ~item_cbs_code, ~share,
+    2020L, 203L, 866L, 867L, 0.4,
+    2020L, 203L, 866L, 868L, 0.6,
+    2021L, 203L, 866L, 867L, 0.3,
+    2021L, 203L, 866L, 868L, 0.7
+  )
+  target_years <- 2020:2023
+
+  result <- whep:::.carry_forward_shares(shares, target_years)
+
+  # Every target year is covered for both split sub-items.
+  expect_equal(sort(unique(result$year)), 2020:2023)
+  expect_equal(nrow(result), 8L)
+
+  # Latest known share (2021) is carried forward to 2022 and 2023.
+  latest <- result |>
+    dplyr::filter(year %in% c(2022L, 2023L)) |>
+    dplyr::arrange(year, item_cbs_code)
+  expect_equal(latest$share, c(0.3, 0.7, 0.3, 0.7))
+
+  # Shares still sum to 1 within each (year, area_code, Item_Code).
+  sums <- result |>
+    dplyr::summarise(
+      total = sum(share),
+      .by = c(year, area_code, Item_Code)
+    )
+  expect_equal(sums$total, rep(1, 4))
 })


### PR DESCRIPTION
## Root cause

`.split_slaughter_by_shares()` (`R/build_production.R`) does an `inner_join` of QCL slaughter counts against stock shares from `.compute_stock_shares()`, which are built only from the `faostat-emissions-livestock` pin. That pin lags QCL by 1–2 years, so for the most recent years no share row exists to join against. As a result, split species (cattle → dairy/non-dairy from Item_Code 866, swine → market/breeding from 1034, chickens → layers/broilers from 1057) silently lose their `slaughtered_heads` in the latest 1–2 years, while non-split species keep them. `.combine_livestock()` already `fill_linear`s `value_st` for exactly this reason; the slaughter path did not.

## Fix

Add a small pure helper `.carry_forward_shares(shares, target_years)` that `tidyr::complete()`s the shares over QCL's full year range and `fill_linear()`s the `share` per `(area_code, Item_Code, item_cbs_code)`, carrying the latest known share forward (and interpolating / back-filling). Shares still sum to 1 within each `(year, area_code, Item_Code)`, so split totals are preserved. `.split_slaughter_by_shares()` now joins against the filled shares, so split-species output covers the same year range as the input.

## Test

Added `test_that(".carry_forward_shares extends shares to QCL's latest years", ...)` in `tests/testthat/test_build_production.R`: shares stop at 2021, target years run to 2023, asserts all target years are covered, the 2021 share is carried forward to 2022–2023, and shares sum to 1 per group. `devtools::test()` on the file: 79 passed, 0 failed. `air format .` and `lintr` clean.

Closes #145

🤖 Generated with [Claude Code](https://claude.com/claude-code)