### PR TITLE
fix(clean_faostat): keep constant series unchanged when smooth = TRUE

### DIFF
--- a/R/clean_faostat.R
+++ b/R/clean_faostat.R
@@ -343,8 +343,9 @@
       is_cf <- !is.na(qc_carry_forward) & qc_carry_forward
       anchor <- !is_cf & !is.na(val)
       n_anchor <- cumsum(anchor)
-      anchor_start <- max(0L, max(n_anchor[anchor]) - anchor_years + 1L)
-      use_anchor <- anchor & n_anchor > anchor_start
+      n_max <- if (any(anchor)) max(n_anchor[anchor]) else 0L
+      anchor_start <- max(0L, n_max - anchor_years + 1L)
+      use_anchor <- anchor & n_anchor >= anchor_start
       list(val, time, is_cf, anchor, n_anchor, anchor_start, use_anchor)
     },
     by = by
@@ -359,11 +360,19 @@
         fit <- stats::coef(stats::lm(ay ~ ax))
         slope <- fit[2]
         intercept <- fit[1]
-      } else {
+        smoothed <- pmax(intercept + slope * .time, 0)
+      } else if (length(ax) == 1) {
         slope <- 0
-        intercept <- mean(ay, na.rm = TRUE)
+        intercept <- ay
+        smoothed <- pmax(intercept + slope * .time, 0)
+      } else {
+        # No anchor points (e.g. a fully-constant series where every row
+        # is flagged carry-forward): leave the series unchanged instead of
+        # producing NaN from mean(numeric(0)).
+        slope <- NA_real_
+        intercept <- NA_real_
+        smoothed <- .val
       }
-      smoothed <- pmax(intercept + slope * .time, 0)
       list(slope, intercept, smoothed)
     },
     by = by

--- a/tests/testthat/test_clean_faostat.R
+++ b/tests/testthat/test_clean_faostat.R
@@ -1,0 +1,64 @@
+# test_clean_faostat.R — unit tests for R/clean_faostat.R helpers
+
+# -- Fixtures ------------------------------------------------------------------
+
+.make_constant_series <- function() {
+  tibble::tibble(
+    area = "Smallland",
+    item_prod = "Minor crop",
+    year = 2000:2010,
+    value = 100
+  )
+}
+
+.make_tail_series <- function() {
+  # Rising trend 2000-2005, then a flat carry-forward tail 2005-2010.
+  tibble::tibble(
+    area = "Bigland",
+    item_prod = "Wheat",
+    year = 2000:2010,
+    value = c(10, 20, 30, 40, 50, 60, 60, 60, 60, 60, 60)
+  )
+}
+
+# -- smooth_carry_forward: constant series -------------------------------------
+
+test_that(".smooth_carry_forward leaves a constant series unchanged", {
+  by <- c("area", "item_prod")
+
+  flagged <- .make_constant_series() |>
+    whep:::.flag_cf_and_spikes(by = by)
+
+  # Sanity: a nonzero constant tail is entirely flagged as carry-forward.
+  expect_true(all(flagged$qc_carry_forward))
+
+  smoothed <- whep:::.smooth_carry_forward(flagged, by = by) |>
+    tibble::as_tibble()
+
+  expect_false(any(is.nan(smoothed$value)))
+  expect_equal(smoothed$value, rep(100, 11))
+})
+
+# -- smooth_carry_forward: genuine carry-forward tail --------------------------
+
+test_that(".smooth_carry_forward smooths a flat tail via anchor trend", {
+  by <- c("area", "item_prod")
+
+  flagged <- .make_tail_series() |>
+    whep:::.flag_cf_and_spikes(by = by)
+
+  smoothed <- whep:::.smooth_carry_forward(flagged, by = by) |>
+    tibble::as_tibble()
+
+  expect_false(any(is.nan(smoothed$value)))
+  # Non-flagged rising rows are untouched.
+  keep <- !flagged$qc_carry_forward
+  expect_equal(smoothed$value[keep], flagged$value[keep])
+  # The flat tail (years 2005-2010) is replaced by the anchor trend
+  # value = 10 * (year - 2000) + 10, extrapolated past the last anchor.
+  tail <- flagged$qc_carry_forward
+  expect_equal(
+    smoothed$value[tail],
+    10 * (smoothed$year[tail] - 2000) + 10
+  )
+})


### PR DESCRIPTION
## Root cause

With `smooth = TRUE`, a fully-constant nonzero series of length ≥ `min_run` is flagged `carry_forward` on *every* row (the whole series is one tail run). In `.smooth_carry_forward()` the anchor mask is then all-`FALSE`, so:

- `max(n_anchor[anchor])` warns on an empty vector and returns `-Inf`;
- `use_anchor` is empty;
- the linear-fit fallback sets `intercept = mean(numeric(0)) = NaN`;
- step 3 replaces the entire series with `NaN`.

The effect: `build_primary_production(smooth_carry_forward = TRUE)` wiped out every flat series (common for small countries and minor items).

## Fix

- Guard the empty-anchor case: when there are no anchor points, leave the series unchanged instead of extrapolating a `NaN` line. Also handle the single-anchor case explicitly (flat carry at that value).
- Fix the off-by-one in the anchor-window selection noted in the issue: `n_anchor >= anchor_start` (was `>`), so the last `anchor_years` points are used rather than `anchor_years - 1`. Compute the window max safely via `if (any(anchor))` to avoid the empty-`max()` warning.

## Test

New `tests/testthat/test_clean_faostat.R`:

- a constant series routed through `.flag_cf_and_spikes()` → `.smooth_carry_forward()` returns the constant (no `NaN`);
- a genuine flat carry-forward tail is still smoothed to the anchor trend line (regression guard for the normal path). 6/6 assertions pass.

Closes #151

🤖 Generated with [Claude Code](https://claude.com/claude-code)