### PR TITLE
fix(harmonize): renormalize 1:n shares in partially-observed years

### DIFF
--- a/R/harmonize.R
+++ b/R/harmonize.R
@@ -281,7 +281,10 @@ harmonize_interpolate <- function(data, ...) {
 #
 # Expand `data_groups` to all years between `start_year`
 # and `end_year`, join simple values and compute value shares per
-# year. Missing years are filled using `linear_fill()`.
+# year. Missing years are filled using `linear_fill()`. Shares are
+# then renormalized to sum to 1 within each `(item, year)` group so
+# that 1:n splits conserve mass in partially observed years (where
+# some members lack a simple value and their share is interpolated).
 .calc_complex_shares <- function(
   data_groups,
   df_simple,
@@ -313,6 +316,15 @@ harmonize_interpolate <- function(data, ...) {
       value_share,
       year,
       .by = c("item", "item_code_harm", grouping_names)
+    ) |>
+    dplyr::mutate(
+      share_sum = sum(value_share, na.rm = TRUE),
+      value_share = dplyr::if_else(
+        share_sum > 0,
+        value_share / share_sum,
+        value_share
+      ),
+      .by = c("item", "year", dplyr::all_of(grouping_names))
     ) |>
     dplyr::select(
       item,

--- a/R/utils.R
+++ b/R/utils.R
@@ -792,6 +792,7 @@ utils::globalVariables(
     "total_trade",
     "total_value",
     "Total_value",
+    "share_sum",
     "target_area",
     "target_area_name",
     "target_fd",

--- a/tests/testthat/test_harmonize.R
+++ b/tests/testthat/test_harmonize.R
@@ -262,6 +262,38 @@ test_that("harmonize_interpolate interpolates shares linearly", {
     expect_equal(c(7, 3))
 })
 
+test_that("1:n split conserves mass in a partially observed year", {
+  # Harm set {1, 2, 3}. Years 2000 and 2002 are fully observed; 2001
+  # only observes members 1 and 2 (member 3's simple value is
+  # missing), so member 3's share is interpolated. Without
+  # renormalization the shares in 2001 sum to more than 1, inflating
+  # the 1:n split. The total mass in 2001 must equal the simple input
+  # (10 + 10) plus the single 1:n observation (30), i.e. 50.
+  input <- tibble::tribble(
+    ~item, ~item_code_harm, ~year, ~value, ~type,
+    "wheat", 1, 2000, 10, "simple",
+    "rice", 2, 2000, 10, "simple",
+    "barley", 3, 2000, 10, "simple",
+    "wheat", 1, 2001, 10, "simple",
+    "rice", 2, 2001, 10, "simple",
+    "wheatricebarley", 1, 2001, 30, "1:n",
+    "wheatricebarley", 2, 2001, 30, "1:n",
+    "wheatricebarley", 3, 2001, 30, "1:n",
+    "wheat", 1, 2002, 10, "simple",
+    "rice", 2, 2002, 10, "simple",
+    "barley", 3, 2002, 10, "simple"
+  )
+
+  result <- input |>
+    whep::harmonize_interpolate() |>
+    dplyr::filter(year == 2001)
+
+  result |>
+    dplyr::pull(value) |>
+    sum() |>
+    expect_equal(50)
+})
+
 test_that("harmonize_interpolate preserves simple values unchanged", {
   input <- tibble::tribble(
     ~item, ~item_code_harm, ~year, ~value, ~type,


### PR DESCRIPTION
## Root cause

`.calc_complex_shares()` (`R/harmonize.R`) computes each member's `value_share` as `value / sum(value)` over the members *observed* in a given year, then gap-fills missing years by interpolation. In a partially-observed year, only some members have a simple value, so the observed members' shares already sum to 1, while a missing member's share is interpolated from neighbouring years and added on top. The shares in that year then sum to more than 1, so a 1:n split invents mass (and, symmetrically, can destroy it).

Example from #149: harm set {1,2,3}; in a year where only members 1 and 2 are observed (10, 10) the shares are 0.5/0.5, and member 3's share interpolates to ~0.3 → shares sum to 1.3 → a value of 20 is split into 26.

## Fix

After gap-filling, renormalize `value_share` to sum to 1 within each `(item, year)` group (including any extra grouping columns), guarding against a zero share sum to avoid division by zero (the shares are left untouched when they sum to 0). This restores mass conservation for 1:n splits.

## Test

Added a mass-conservation property test in `tests/testthat/test_harmonize.R`: a 1:n split into {1,2,3} where the split year observes only members 1 and 2. The total harmonized mass in that year must equal the simple input plus the single 1:n observation (50). Verified the test fails (60, mass inflated) without the fix and passes with it; all existing `test_harmonize.R` tests still pass.

Closes #149

🤖 Generated with [Claude Code](https://claude.com/claude-code)