### PR TITLE
fix(n_prov_destiny): assign aquaculture feed nitrogen to a destiny (no mass leak)

### DIFF
--- a/R/n_prov_destiny.R
+++ b/R/n_prov_destiny.R
@@ -26,8 +26,8 @@
 #'   Semi-natural agroecosystems, Livestock, Fish, Agro-industry, Deposition,
 #'   Fixation, Synthetic, People (waste water), Livestock (manure).
 #'   - `destiny`: The destiny category of N: population_food,
-#'   population_other_uses, livestock_mono, livestock_rum (feed), export,
-#'   Cropland (for N soil inputs).
+#'   population_other_uses, livestock_mono, livestock_rum, livestock_aqua
+#'   (feed), export, Cropland (for N soil inputs).
 #'   - `mg_n`: Nitrogen amount in megagrams (Mg).
 #'
 #' @export
@@ -122,8 +122,8 @@ create_n_prov_destiny <- function(example = FALSE) {
 #'   Semi-natural agroecosystems, Livestock, Fish, Agro-industry, Deposition,
 #'   Fixation, Synthetic, People (waste water), Livestock (manure).
 #'   - `destiny`: The destiny category of N: population_food,
-#'   population_other_uses, livestock_mono, livestock_rum (feed), export,
-#'   Cropland (for N soil inputs).
+#'   population_other_uses, livestock_mono, livestock_rum, livestock_aqua
+#'   (feed), export, Cropland (for N soil inputs).
 #'   - `mg_n`: Nitrogen amount in megagrams (Mg).
 #'   - `province_name`: Set to "Spain" for all national-level rows.
 #'
@@ -144,7 +144,8 @@ create_n_nat_destiny <- function(example = FALSE) {
           "population_food",
           "population_other_uses",
           "livestock_rum",
-          "livestock_mono"
+          "livestock_mono",
+          "livestock_aqua"
         )
     ) |>
     dplyr::group_by(year, item, destiny) |>
@@ -181,7 +182,8 @@ create_n_nat_destiny <- function(example = FALSE) {
               "population_food",
               "population_other_uses",
               "livestock_rum",
-              "livestock_mono"
+              "livestock_mono",
+              "livestock_aqua"
             )
         ],
         na.rm = TRUE
@@ -1179,13 +1181,14 @@ create_n_nat_destiny <- function(example = FALSE) {
 
 #' @title Split local consumption
 #' @description Splits local consumption into population food, other uses,
-#' and livestock. Livestock feed is split into livestock_rum (ruminants) and
-#' livestock_mono (monogastric).
+#' and livestock. Livestock feed is split into livestock_rum (ruminants),
+#' livestock_mono (monogastric), and livestock_aqua (aquaculture, the
+#' residual feed share).
 #' @param local_vs_import A dataset containing local and imported consumption.
 #' @param feed_share_rum_mono A dataset with feed shares between ruminants
 #' and monogastric animals.
 #' @return A dataset with consumption split into population_food,
-#' livestock_rum, livestock_mono, and population_other_uses.
+#' livestock_rum, livestock_mono, livestock_aqua, and population_other_uses.
 #' @keywords internal
 #' @noRd
 .split_local_consumption <- function(local_vs_import, feed_share_rum_mono) {
@@ -1199,6 +1202,11 @@ create_n_nat_destiny <- function(example = FALSE) {
       population_other_uses = local_consumption * other_uses_share,
       livestock_rum = local_consumption * feed_share * share_rum,
       livestock_mono = local_consumption * feed_share * share_mono,
+      # Aquaculture is the residual feed share (1 - rum - mono), so that all
+      # feed N is assigned a destiny and no N mass leaks (see issue #148).
+      livestock_aqua = local_consumption *
+        feed_share *
+        (1 - share_rum - share_mono),
       Origin = Box
     ) |>
     tidyr::pivot_longer(
@@ -1206,7 +1214,8 @@ create_n_nat_destiny <- function(example = FALSE) {
         population_food,
         population_other_uses,
         livestock_rum,
-        livestock_mono
+        livestock_mono,
+        livestock_aqua
       ),
       names_to = "Destiny",
       values_to = "MgN"
@@ -1215,8 +1224,8 @@ create_n_nat_destiny <- function(example = FALSE) {
 
 #' @title Split imported consumption
 #' @description Splits imports by consumption and assigns origins.
-#' Livestock feed is split into livestock_rum (ruminants) and livestock_mono
-#' (monogastric).
+#' Livestock feed is split into livestock_rum (ruminants), livestock_mono
+#' (monogastric), and livestock_aqua (aquaculture, the residual feed share).
 #' COMMENT: pmin prevents imported N for food and other uses from becoming
 #' unrealistically high.
 #' For human consumption, imports usually replace local supply instead of
@@ -1248,6 +1257,11 @@ create_n_nat_destiny <- function(example = FALSE) {
       population_other_uses = base_amount_food_other * other_uses_share,
       livestock_rum = import_consumption * feed_share * share_rum,
       livestock_mono = import_consumption * feed_share * share_mono,
+      # Aquaculture is the residual feed share (1 - rum - mono), so that all
+      # feed N is assigned a destiny and no N mass leaks (see issue #148).
+      livestock_aqua = import_consumption *
+        feed_share *
+        (1 - share_rum - share_mono),
       Origin = "Outside",
       Irrig_cat = NA_character_
     ) |>
@@ -1257,6 +1271,7 @@ create_n_nat_destiny <- function(example = FALSE) {
       population_other_uses = sum(population_other_uses, na.rm = TRUE),
       livestock_rum = sum(livestock_rum, na.rm = TRUE),
       livestock_mono = sum(livestock_mono, na.rm = TRUE),
+      livestock_aqua = sum(livestock_aqua, na.rm = TRUE),
       .by = c("Year", "Province_name", "Item", "Box", "Origin", "Irrig_cat")
     ) |>
     tidyr::pivot_longer(
@@ -1264,7 +1279,8 @@ create_n_nat_destiny <- function(example = FALSE) {
         population_food,
         population_other_uses,
         livestock_rum,
-        livestock_mono
+        livestock_mono,
+        livestock_aqua
       ),
       names_to = "Destiny",
       values_to = "MgN"

--- a/R/utils.R
+++ b/R/utils.R
@@ -547,6 +547,7 @@ utils::globalVariables(
     "livestock_cat",
     "Livestock_cat",
     "Livestock_density",
+    "livestock_aqua",
     "livestock_mono",
     "Livestock_name",
     "livestock_rum",

--- a/man/create_n_nat_destiny.Rd
+++ b/man/create_n_nat_destiny.Rd
@@ -23,8 +23,8 @@ Semi-natural agroecosystems, Livestock, Fish, or Agro-industry.
 Semi-natural agroecosystems, Livestock, Fish, Agro-industry, Deposition,
 Fixation, Synthetic, People (waste water), Livestock (manure).
 \item \code{destiny}: The destiny category of N: population_food,
-population_other_uses, livestock_mono, livestock_rum (feed), export,
-Cropland (for N soil inputs).
+population_other_uses, livestock_mono, livestock_rum, livestock_aqua
+(feed), export, Cropland (for N soil inputs).
 \item \code{mg_n}: Nitrogen amount in megagrams (Mg).
 \item \code{province_name}: Set to "Spain" for all national-level rows.
 }

--- a/man/create_n_prov_destiny.Rd
+++ b/man/create_n_prov_destiny.Rd
@@ -24,8 +24,8 @@ Semi-natural agroecosystems, Livestock, Fish, or Agro-industry.
 Semi-natural agroecosystems, Livestock, Fish, Agro-industry, Deposition,
 Fixation, Synthetic, People (waste water), Livestock (manure).
 \item \code{destiny}: The destiny category of N: population_food,
-population_other_uses, livestock_mono, livestock_rum (feed), export,
-Cropland (for N soil inputs).
+population_other_uses, livestock_mono, livestock_rum, livestock_aqua
+(feed), export, Cropland (for N soil inputs).
 \item \code{mg_n}: Nitrogen amount in megagrams (Mg).
 }
 }

--- a/tests/testthat/test_n_prov_destiny.R
+++ b/tests/testthat/test_n_prov_destiny.R
@@ -713,6 +713,32 @@ test_that(".split_local_consumption splits by shares and feed type", {
   expect_equal(unique(out$Origin), "Cropland")
 })
 
+test_that(".split_local_consumption assigns aquaculture feed (no N leak)", {
+  # share_rum + share_mono < 1, so an aquaculture feed slice exists.
+  # All local consumption must be assigned a destiny (issue #148).
+  local_import <- tibble::tribble(
+    ~Year, ~Province_name, ~Item, ~Box, ~Irrig_cat, ~local_consumption, ~import_consumption, ~food_share, ~feed_share, ~other_uses_share,
+    2000, "A", "Wheat", "Cropland", "irrig", 100, 0, 0.4, 0.5, 0.1
+  )
+
+  feed_shares <- tibble::tribble(
+    ~Year, ~Province_name, ~Item, ~share_rum, ~share_mono,
+    2000, "A", "Wheat", 0.5, 0.2
+  )
+
+  out <- .split_local_consumption(local_import, feed_shares)
+
+  vals <- out |>
+    dplyr::select(Destiny, MgN) |>
+    tibble::deframe()
+
+  # aquaculture is the residual feed share (1 - 0.5 - 0.2 = 0.3)
+  expect_equal(vals[["livestock_aqua"]], 100 * 0.5 * 0.3, tolerance = 1e-12)
+
+  # total destiny N equals local consumption: no mass leaks
+  expect_equal(sum(out$MgN), 100, tolerance = 1e-12)
+})
+
 
 # .split_import_consumption ----------------------------------------------------
 
@@ -795,6 +821,36 @@ test_that(".split_import_consumption aggregates duplicates from Irrig_cat", {
     dplyr::pull(MgN) |>
     sum()
   expect_equal(food_total, 25)
+})
+
+test_that(".split_import_consumption assigns aquaculture feed (no N leak)", {
+  # Pure feed import with share_rum + share_mono < 1: the aquaculture slice
+  # of imported feed must be assigned a destiny (issue #148).
+  local_vs_import <- tibble::tribble(
+    ~Year, ~Province_name, ~Item, ~Box, ~Irrig_cat, ~local_consumption, ~import_consumption, ~food_share, ~feed_share, ~other_uses_share,
+    2000, "A", "Wheat", "Cropland", "irrig", 200, 100, 0, 1, 0
+  )
+
+  feed_shares <- tibble::tribble(
+    ~Year, ~Province_name, ~Item, ~share_rum, ~share_mono,
+    2000, "A", "Wheat", 0.5, 0.2
+  )
+
+  out <- .split_import_consumption(local_vs_import, feed_shares)
+
+  vals <- out |>
+    dplyr::filter(
+      Destiny != "population_food",
+      Destiny != "population_other_uses"
+    ) |>
+    dplyr::select(Destiny, MgN) |>
+    tibble::deframe()
+
+  # aquaculture residual feed share = 1 - 0.5 - 0.2 = 0.3
+  expect_equal(vals[["livestock_aqua"]], 100 * 1 * 0.3, tolerance = 1e-12)
+
+  # all imported feed N is assigned to a livestock destiny: no leak
+  expect_equal(sum(out$MgN), 100, tolerance = 1e-12)
 })
 
 


### PR DESCRIPTION
## Root cause

In `.add_feed`, feed shares are computed against `feed_total = ruminant + monogastric + aquaculture`, and downstream `feed_share` (in `.calculate_consumption_shares`) is `feed / consumption_total` where `feed` also includes aquaculture. But `.split_local_consumption` and `.split_import_consumption` only emitted `livestock_rum` and `livestock_mono` destinies:

```
livestock_rum + livestock_mono = consumption * feed_share * (share_rum + share_mono)
```

Since `share_rum + share_mono = (rum + mono) / (rum + mono + aqua) < 1` whenever aquaculture feed > 0, the aquaculture slice `feed_share * (1 - share_rum - share_mono)` was counted in `consumption` (driving trade) but assigned to **no destiny**. Result: `sum(destiny mg_n) < consumption` — a net nitrogen mass leak. The existing code comment ("Aquaculture share is implicit (1 - rum - mono)") flagged it but nothing captured it.

## Fix

- Emit a `livestock_aqua` destiny in both `.split_local_consumption` and `.split_import_consumption`, equal to the residual feed share `consumption * feed_share * (1 - share_rum - share_mono)`. This closes the balance: `population_food + population_other_uses + livestock_rum + livestock_mono + livestock_aqua == consumption`.
- Include `livestock_aqua` in the national-level consumption and share filters in `create_n_nat_destiny()` so national trade stays consistent with the provincial destinies.
- Register `livestock_aqua` in `utils::globalVariables()`; update roxygen destiny docs.

The residual formulation (rather than threading a new `share_aqua` column) keeps the diff tight, matches the documented intent, and guarantees the three feed shares sum to 1.

## Tests

Added two invariant tests in `tests/testthat/test_n_prov_destiny.R` (local and import paths) with `share_rum + share_mono < 1`, asserting the aquaculture slice is assigned to `livestock_aqua` and that `sum(destiny mg_n) == consumption` (no leak). Full `test_n_prov_destiny.R` passes locally (offline).

Closes #148

🤖 Generated with [Claude Code](https://claude.com/claude-code)