### PR TITLE
fix(cbs): key source selection on area_code, not periodized name

### DIFF
--- a/R/build_cbs.R
+++ b/R/build_cbs.R
@@ -1569,8 +1569,13 @@ build_processing_coefs <- function(
 
 .select_best_source <- function(cbs_raw_all) {
   # Pivot sources into columns — avoids grouped summarise + nth overhead.
+  # Key on the integer `area_code`, not the `area` name: sources disagree on
+  # the name for the same code (plain name vs periodized polity name, e.g.
+  # code 41 -> "China, mainland" vs "China (PRC)"). Keying on the name would
+  # scatter the sources for one country into separate groups so both survive
+  # selection and get summed downstream (double-counting production). The
+  # human-readable name is re-attached from a per-code lookup at the end.
   key_cols <- c(
-    "area",
     "area_code",
     "year",
     "item_cbs",
@@ -1578,7 +1583,6 @@ build_processing_coefs <- function(
     "element"
   )
   group_cols <- c(
-    "area",
     "area_code",
     "item_cbs",
     "item_cbs_code",
@@ -1586,7 +1590,9 @@ build_processing_coefs <- function(
   )
 
   dt_raw <- data.table::as.data.table(cbs_raw_all)
-  dt_raw <- dt_raw[!is.na(area), c(key_cols, "source", "value"), with = FALSE]
+  dt_raw <- dt_raw[!is.na(area)]
+  area_lookup <- unique(dt_raw[, .(area_code, area)], by = "area_code")
+  dt_raw <- dt_raw[, c(key_cols, "source", "value"), with = FALSE]
 
   # Pivot only primary sources (3 cols) instead of all sources.
   # Avoids expensive frankv over many source columns.
@@ -1702,6 +1708,8 @@ build_processing_coefs <- function(
     element %in% clamp_elems & (value < 0 | is.infinite(value)),
     value := 0
   ]
+
+  wide[area_lookup, area := i.area, on = "area_code"]
 
   wide <- wide |>
     dplyr::select(

--- a/R/utils.R
+++ b/R/utils.R
@@ -240,6 +240,7 @@ utils::globalVariables(
     # data.table update-join (dt[lookup, col := i.col, on = ...]) symbols
     "i..has_np",
     "i.dest_share_global",
+    "i.area",
     "i.domestic_supply",
     "i.harvest_fraction",
     "i.other_mean",

--- a/tests/testthat/test_build_cbs.R
+++ b/tests/testthat/test_build_cbs.R
@@ -249,6 +249,27 @@ test_that(".select_best_source prioritises FAOSTAT_prod source", {
   )
 })
 
+test_that(".select_best_source keys on area_code, not periodized name", {
+  # Sources disagree on the `area` name for the same `area_code` (plain name
+  # vs periodized polity name). They must still compete on the integer code
+  # instead of both surviving and being summed downstream (100 + 90 = 190).
+  cbs_raw_all <- tibble::tribble(
+    ~area, ~area_code, ~item_cbs, ~item_cbs_code, ~element, ~year, ~value, ~source,
+    "China, mainland", 41L, "Wheat", 2511L, "production", 2010L, 100, "FAOSTAT_prod",
+    "China (PRC)", 41L, "Wheat", 2511L, "production", 2010L, 90, "FAOSTAT_FBS_New"
+  )
+
+  selected <- whep:::.select_best_source(cbs_raw_all)
+  prod <- selected |> dplyr::filter(element == "production")
+  expect_equal(nrow(prod), 1L)
+  expect_equal(prod$value, 100)
+
+  formatted <- whep:::.format_cbs_output(selected)
+  prod_fmt <- formatted |> dplyr::filter(element == "production")
+  expect_equal(nrow(prod_fmt), 1L)
+  expect_equal(prod_fmt$value, 100)
+})
+
 
 # -- .test_cbs -----------------------------------------------------------------
 


### PR DESCRIPTION
## Problem

`build_commodity_balances()` silently **double-counts production** (and every
other CBS element) for any polity whose name is periodized — 103 of 226 shared
FAOSTAT codes (China, Russia, Turkey, Poland, Romania, Vietnam, Egypt,
Finland, …), all years 1961–2023, wherever the two sources report different
values.

## Root cause

Two input streams disagree on the `area` **string** for the same `area_code`:

- primary path → `add_area_name()` → plain name (code 41 → `"China, mainland"`);
- FBS/CBS path → `.aggregate_to_polities()` (`R/read_raw_inputs.R:343-347`) →
  periodized `polity_name` (code 41 → `"China (PRC)"`).

`.assemble_cbs_sources()` binds both. `.select_best_source()` grouped/dcast on
the `area` **name**, so `FAOSTAT_prod` and `FAOSTAT_FBS_New` for one country
landed in **different groups** and both survived instead of competing.
`.format_cbs_output()` then dedups/sums by `(year, area_code, item_cbs_code,
element)` **without** `area`, summing the two survivors → `100 + 90 = 190`
instead of `100`. The two helpers disagreed on the key (name vs code).

## Fix

Make `.select_best_source()` group/dcast on the integer `area_code` instead of
the `area` name, and re-attach a canonical per-code name at the end. Both
sources now compete on the code (best-source wins), and `.format_cbs_output()`
already keys on the code — so the helpers agree. This also follows the
CLAUDE.md rule against carrying name+code pairs through intermediates: names
are attached only at the output stage.

The legitimate multi-source logic (FBS_Old→FBS_New rescaling, source priority,
clamping) is unchanged — only the group/dcast key changes from name to code.

## Verification

Reproduced before the fix (`.select_best_source` returns 2 rows,
`.format_cbs_output` → 190) and confirmed after (1 row, `FAOSTAT_prod` wins →
100). Added a regression test in `tests/testthat/test_build_cbs.R`
(`.select_best_source keys on area_code, not periodized name`). Full
`test_build_cbs.R` passes. `air format .` applied.

Closes #291
Related #120

🤖 Generated with [Claude Code](https://claude.com/claude-code)
