### PR TITLE
fix(io): retain import-sourced losses when endogenizing into Z

### DIFF
--- a/R/io_model.R
+++ b/R/io_model.R
@@ -968,27 +968,21 @@ build_io_model <- function(
   }
 
   n_fd <- length(fd_cols)
-  n_items <- dims$n_items
 
-  # Extract losses columns from Y, aggregate by product within
-  # each country, and place on the domestic sub-block diagonal
-  for (a in seq_len(dims$n_areas)) {
-    y_col <- (a - 1L) * n_fd + losses_idx
-    rows <- ((a - 1L) * n_items + 1L):(a * n_items)
-    losses_vec <- as.numeric(y_mat[rows, y_col])
-
-    # Add losses to the diagonal of the country's sub-block
-    for (k in seq_along(losses_vec)) {
-      if (losses_vec[k] != 0) {
-        global_row <- (a - 1L) * n_items + k
-        z_mat[global_row, global_row] <-
-          z_mat[global_row, global_row] + losses_vec[k]
-      }
-    }
-  }
+  # Y was expanded by trade shares, so a consuming country's losses
+  # are spread across every source block of its losses column
+  # (domestic on the diagonal block, imported on off-diagonal ones).
+  # Sum each sector's losses across all consuming countries and add
+  # them to that sector's own diagonal (self-use). This retains
+  # import-sourced losses on Z and conserves total output X, whereas
+  # reading only the domestic diagonal block would discard them.
+  losses_col_indices <- seq(losses_idx, ncol(y_mat), by = n_fd)
+  losses_per_row <- Matrix::rowSums(
+    y_mat[, losses_col_indices, drop = FALSE]
+  )
+  Matrix::diag(z_mat) <- Matrix::diag(z_mat) + losses_per_row
 
   # Remove losses columns from Y
-  losses_col_indices <- seq(losses_idx, ncol(y_mat), by = n_fd)
   y_mat <- y_mat[, -losses_col_indices, drop = FALSE]
   fd_cols <- fd_cols[-losses_idx]
 

--- a/tests/testthat/test_io_model.R
+++ b/tests/testthat/test_io_model.R
@@ -441,3 +441,43 @@ testthat::test_that(".fix_negative_output returns both X and Y", {
     rowSums(z) + rowSums(y)
   )
 })
+
+testthat::test_that(".endogenize_losses conserves X across source blocks", {
+  # 2 countries x 2 items. Rows/cols indexed (source, item):
+  # 1=(A1,I1) 2=(A1,I2) 3=(A2,I1) 4=(A2,I2). fd_cols = food, losses,
+  # so Y columns are (consume A1, food/losses, consume A2, food/losses).
+  dims <- list(n_areas = 2L, n_items = 2L)
+  fd_cols <- c("food", "losses")
+
+  z0 <- diag(c(20, 10, 15, 12))
+  # Row 1 carries an imported loss: item I1 sourced from A1 but
+  # consumed (and lost) in A2 -> col 4. That off-diagonal-block loss
+  # is what the old domestic-only code silently discarded.
+  y0 <- rbind(
+    c(10, 3, 5, 7),
+    c(4, 1, 0, 0),
+    c(0, 0, 8, 2),
+    c(2, 0, 6, 5)
+  )
+
+  x_before <- rowSums(z0) + rowSums(y0)
+  total_losses <- sum(y0[, c(2, 4)])
+
+  endo <- .endogenize_losses(z0, y0, dims, fd_cols)
+  x_after <- Matrix::rowSums(endo$Z) + Matrix::rowSums(endo$Y)
+
+  # Total output is conserved (fails with the domestic-only version,
+  # which loses the imported 7 on row 1).
+  testthat::expect_equal(as.numeric(x_after), as.numeric(x_before))
+
+  # All losses removed from Y are absorbed onto the Z diagonal.
+  absorbed <- sum(Matrix::diag(endo$Z) - diag(z0))
+  testthat::expect_equal(absorbed, total_losses)
+
+  # Row 1 gains both its domestic (3) and imported (7) losses.
+  testthat::expect_equal(Matrix::diag(endo$Z)[1] - z0[1, 1], 10)
+
+  # Losses columns are dropped from Y and fd_cols.
+  testthat::expect_equal(endo$fd_cols, "food")
+  testthat::expect_equal(ncol(endo$Y), 2L)
+})


### PR DESCRIPTION
## Problem

`.endogenize_losses()` in `R/io_model.R` moves the `losses` final-demand
column onto the Z diagonal (FABIO self-use convention). But it read losses
**only from each country's domestic diagonal source block**
(`rows <- ((a-1)*n_items+1):(a*n_items)`), then deleted the entire losses
column across **all** source blocks.

Because `Y` is expanded by trade shares (`.expand_with_shares`), a consuming
country's losses on **imported** goods live in the off-diagonal source
blocks of its losses column. Those imported losses were therefore discarded
rather than endogenized, so `rowSums(Z) + rowSums(Y)` (total output X) shrank
and footprints under-traced.

## Fix

Sum each sector's losses across **all** consuming countries' losses columns
(row-wise over the losses columns of the trade-share-expanded Y) and add the
total to that sector's own diagonal (self-use), before dropping the losses
columns. This keeps import-sourced losses on Z and conserves total output X
through the endogenization step. The change is localized to
`.endogenize_losses`.

## Verification

Added a test in `tests/testthat/test_io_model.R` with a synthetic
2-country/2-item `Z`+`Y` containing an imported loss (item sourced from A1,
consumed and lost in A2). It asserts:

- `rowSums(Z)+rowSums(Y)` is conserved after endogenizing (fails with the old
  domestic-only code, which loses the imported value; passes now).
- Total losses removed from Y equal the total absorbed onto the Z diagonal.
- The affected row gains both its domestic and imported losses.

All 23 tests in `test_io_model.R` pass; `air format .` applied.

Closes #153. Contributes to the footprint-conservation loss identified in #119.

🤖 Generated with [Claude Code](https://claude.com/claude-code)