### PR TITLE
fix(code-names): current polity for shared ISO3 + dedup on join key

### DIFF
--- a/R/code_names.R
+++ b/R/code_names.R
@@ -34,7 +34,12 @@ add_area_name <- function(
   code_column = "area_code",
   name_column = "area_name"
 ) {
-  polities <- .get_polities(name_column, code_column, table)
+  polities <- .get_polities(
+    name_column,
+    code_column,
+    join_column = code_column,
+    table = table
+  )
 
   table |>
     dplyr::left_join(polities, {{ code_column }})
@@ -74,7 +79,11 @@ add_area_code <- function(
   name_column = "area_name",
   code_column = "area_code"
 ) {
-  polities <- .get_polities(name_column, code_column)
+  polities <- .get_polities(
+    name_column,
+    code_column,
+    join_column = name_column
+  )
 
   table |>
     dplyr::left_join(polities, {{ name_column }})
@@ -232,19 +241,23 @@ add_item_prod_code <- function(
     dplyr::left_join(items, {{ name_column }})
 }
 
-.get_polities <- function(name_column, code_column, table = NULL) {
+.get_polities <- function(name_column, code_column, join_column, table = NULL) {
   key_column <- .resolve_polity_key(table, code_column)
-  areas <- .current_area_lookup(include_unmapped = TRUE)
 
-  areas |>
+  .current_area_lookup(include_unmapped = TRUE) |>
     tibble::as_tibble() |>
+    dplyr::arrange(
+      dplyr::desc(polity_end_year),
+      dplyr::desc(polity_start_year),
+      dplyr::desc(area_code)
+    ) |>
     dplyr::select(
       !!name_column := area_name,
       !!code_column := dplyr::all_of(key_column)
     ) |>
     dplyr::filter(!is.na(.data[[code_column]])) |>
     dplyr::distinct(
-      dplyr::across(dplyr::all_of(code_column)),
+      dplyr::across(dplyr::all_of(join_column)),
       .keep_all = TRUE
     )
 }

--- a/tests/testthat/test_code_names.R
+++ b/tests/testthat/test_code_names.R
@@ -84,6 +84,41 @@ testthat::test_that("add_area_code correctly sets new column in table", {
     )
 })
 
+testthat::test_that("add_area_name returns current country name for shared ISO3", {
+  # Regression for #237: FABIO/FAOSTAT reuse one ISO3 across a defunct area and
+  # its successor (e.g. ETH -> both "Ethiopia PDR" (area 62) and the current
+  # "Ethiopia" (area 238); SDN -> "Sudan (former)" and current "Sudan"). The
+  # ISO3 join must resolve to the current polity, not the historical one.
+  table <- tibble::tibble(area_code = c("ETH", "SDN"))
+
+  table |>
+    add_area_name() |>
+    dplyr::pull(area_name) |>
+    testthat::expect_equal(c("Ethiopia", "Sudan"))
+})
+
+testthat::test_that("add_area_code does not fan out on a duplicated area_name", {
+  # Regression for #238: add_area_code() joins by name, so the lookup must be
+  # deduplicated on the name key (not the code key). Guard as an invariant so a
+  # future crosswalk with a repeated area_name cannot silently fan out rows.
+  polities <- whep:::.get_polities(
+    "area_name",
+    "area_code",
+    join_column = "area_name"
+  )
+
+  testthat::expect_equal(
+    nrow(polities),
+    dplyr::n_distinct(polities$area_name)
+  )
+
+  table <- tibble::tibble(area_name = c("Armenia", "Afghanistan"))
+  table |>
+    add_area_code() |>
+    nrow() |>
+    testthat::expect_equal(nrow(table))
+})
+
 testthat::test_that("add_item_cbs_name correctly sets new column in table", {
   table <- tibble::tibble(item_cbs_code = c(2559, 2744, 9876))
 


### PR DESCRIPTION
## What

Two fixes in `R/code_names.R`, both in the `.get_polities()` helper backing `add_area_name()` / `add_area_code()`.

### `Closes #237` — shared ISO3 returned the defunct polity name
When `add_area_name()` is given ISO3 codes, `.resolve_polity_key()` switches the join key to `area_iso3c`. But multiple FAOSTAT area codes share one ISO3 (a defunct area and its successor), e.g. `ETH` -> area 62 "Ethiopia PDR" **and** area 238 "Ethiopia"; `SDN` -> area 206 "Sudan (former)" **and** area 276 "Sudan". The lookup inherited `.current_area_lookup()`'s `area_code`-ascending order, so `distinct()` kept the smaller (historical) area code and returned the **defunct** name.

Fix: `arrange()` by polity recency (`polity_end_year`, `polity_start_year`) then `area_code` descending before `distinct()`, so the current polity ("Ethiopia", "Sudan") wins.

### `Closes #238` — dedup on the wrong key (latent)
`.get_polities()` always deduplicated on `code_column`, but `add_area_code()` joins by `name_column`. Dedup now happens on the actual join key for each direction, preventing row fan-out should a future crosswalk contain a repeated `area_name`.

## Not in scope
`#236` (item lookup fan-out on a duplicated item code) is handled separately by **#274** and is left untouched here.

## Tests
Extended `tests/testthat/test_code_names.R`:
- shared-ISO3 codes resolve to the current country name (`ETH` -> "Ethiopia", `SDN` -> "Sudan", not the "PDR"/"(former)" variants);
- name-direction lookup is one row per name (no fan-out invariant).

All 21 tests in the file pass; `air format` and `lintr` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)