### PR TITLE
fix(footprint): share A-matrix cap between paths and footprint

### DIFF
--- a/R/footprint_paths.R
+++ b/R/footprint_paths.R
@@ -24,6 +24,9 @@
 #'   intensities.
 #' @param value_added_floor Minimum non-intermediate leakage share used when
 #'   constructing technical coefficients from `z_mat`.
+#' @param max_column_sum Maximum allowed column sum in A. Must match the value
+#'   used by [compute_footprint()] (default `100`) so the path decomposition
+#'   and the footprint it decomposes share an identical A cap.
 #' @param conserve_extensions If `TRUE`, rescale positive paths within each
 #'   origin area/item so their sum does not exceed the corresponding positive
 #'   extension total.
@@ -46,6 +49,7 @@ compute_footprint_paths <- function(
   origin_item = NULL,
   output_tol = 1e-8,
   value_added_floor = 1e-3,
+  max_column_sum = 100,
   conserve_extensions = TRUE,
   min_value = 0
 ) {
@@ -58,6 +62,7 @@ compute_footprint_paths <- function(
     fd_labels,
     output_tol,
     value_added_floor,
+    max_column_sum,
     conserve_extensions,
     min_value
   )
@@ -103,7 +108,8 @@ compute_footprint_paths <- function(
   a_mat <- .technical_coefficients(
     z_mat,
     x_vec,
-    value_added_floor = value_added_floor
+    value_added_floor = value_added_floor,
+    max_column_sum = max_column_sum
   )
   ia <- Matrix::Diagonal(n) - a_mat
   lu_fact <- .factor_ia(ia)
@@ -325,6 +331,7 @@ compute_footprint_paths <- function(
   fd_labels,
   output_tol,
   value_added_floor,
+  max_column_sum,
   conserve_extensions,
   min_value
 ) {
@@ -339,6 +346,7 @@ compute_footprint_paths <- function(
     value_added_floor = value_added_floor,
     conserve_extensions = conserve_extensions
   )
+  .validate_max_column_sum(max_column_sum)
   if (!is.data.frame(fd_labels) || nrow(fd_labels) != ncol(y_mat)) {
     cli::cli_abort(
       "{.arg fd_labels} must be a data frame with one row per Y column."
@@ -422,6 +430,7 @@ compute_fp_product_paths <- function(
   origin_item = NULL,
   output_tol = 1e-8,
   value_added_floor = 1e-3,
+  max_column_sum = 100,
   conserve_extensions = TRUE,
   min_value = 0
 ) {
@@ -434,6 +443,7 @@ compute_fp_product_paths <- function(
     fd_labels,
     output_tol,
     value_added_floor,
+    max_column_sum,
     conserve_extensions,
     min_value
   )
@@ -479,7 +489,8 @@ compute_fp_product_paths <- function(
   a_mat <- .technical_coefficients(
     z_mat,
     x_vec,
-    value_added_floor = value_added_floor
+    value_added_floor = value_added_floor,
+    max_column_sum = max_column_sum
   )
   ia_t <- Matrix::t(Matrix::Diagonal(n) - a_mat)
   lu_fact <- .factor_ia(ia_t)
@@ -749,8 +760,11 @@ add_footprint_product_stage <- function(
     ))
   }
 
-  area_names <- whep::regions_full |>
-    dplyr::select(product_area = code, product_area_name = name) |>
+  area_names <- .label_reporting_polity_lookup(labels) |>
+    dplyr::transmute(
+      product_area = .data$area_code,
+      product_area_name = .data$reporting_polity_name
+    ) |>
     dplyr::distinct(.data$product_area, .keep_all = TRUE) |>
     data.table::as.data.table()
 

--- a/man/compute_footprint_paths.Rd
+++ b/man/compute_footprint_paths.Rd
@@ -15,6 +15,7 @@ compute_footprint_paths(
   origin_item = NULL,
   output_tol = 1e-08,
   value_added_floor = 0.001,
+  max_column_sum = 100,
   conserve_extensions = TRUE,
   min_value = 0
 )
@@ -41,6 +42,10 @@ intensities.}
 
 \item{value_added_floor}{Minimum non-intermediate leakage share used when
 constructing technical coefficients from \code{z_mat}.}
+
+\item{max_column_sum}{Maximum allowed column sum in A. Must match the value
+used by \code{\link[=compute_footprint]{compute_footprint()}} (default \code{100}) so the path decomposition
+and the footprint it decomposes share an identical A cap.}
 
 \item{conserve_extensions}{If \code{TRUE}, rescale positive paths within each
 origin area/item so their sum does not exceed the corresponding positive

--- a/man/compute_fp_product_paths.Rd
+++ b/man/compute_fp_product_paths.Rd
@@ -15,6 +15,7 @@ compute_fp_product_paths(
   origin_item = NULL,
   output_tol = 1e-08,
   value_added_floor = 0.001,
+  max_column_sum = 100,
   conserve_extensions = TRUE,
   min_value = 0
 )
@@ -41,6 +42,10 @@ intensities.}
 
 \item{value_added_floor}{Minimum non-intermediate leakage share used when
 constructing technical coefficients from \code{z_mat}.}
+
+\item{max_column_sum}{Maximum allowed column sum in A. Must match the value
+used by \code{\link[=compute_footprint]{compute_footprint()}} (default \code{100}) so the path decomposition
+and the footprint it decomposes share an identical A cap.}
 
 \item{conserve_extensions}{If \code{TRUE}, rescale positive paths within each
 origin area/item so their sum does not exceed the corresponding positive

--- a/tests/testthat/test_footprint_paths.R
+++ b/tests/testthat/test_footprint_paths.R
@@ -40,6 +40,69 @@ testthat::test_that("compute_footprint_paths decomposes first intermediate use",
   testthat::expect_equal(intermediate$value, 50)
 })
 
+testthat::test_that("path totals reconcile with footprint under equal cap", {
+  # Column 2 of A sums to 100 / 50 = 2, i.e. within (0.999, 100]. The old
+  # path default cap of 0.999 would clip it while compute_footprint's cap of
+  # 100 would not, breaking reconciliation. With a shared cap the path totals
+  # must equal the footprint totals exactly.
+  z_mat <- matrix(c(0, 100, 0, 0), nrow = 2, byrow = TRUE)
+  x_vec <- c(100, 50)
+  y_mat <- matrix(c(0, 50), nrow = 2)
+  extensions <- c(100, 0)
+  labels <- tibble::tibble(
+    area_code = c(1L, 1L),
+    item_cbs_code = c(10L, 20L)
+  )
+  fd_labels <- tibble::tibble(area_code = 2L, fd_col = "food")
+
+  fp <- compute_footprint(
+    x_vec = x_vec,
+    y_mat = y_mat,
+    extensions = extensions,
+    labels = labels,
+    z_mat = z_mat,
+    fd_labels = fd_labels,
+    conserve_extensions = FALSE
+  )
+  paths <- compute_footprint_paths(
+    z_mat = z_mat,
+    x_vec = x_vec,
+    y_mat = y_mat,
+    extensions = extensions,
+    labels = labels,
+    fd_labels = fd_labels,
+    conserve_extensions = FALSE
+  )
+  product_paths <- compute_fp_product_paths(
+    z_mat = z_mat,
+    x_vec = x_vec,
+    y_mat = y_mat,
+    extensions = extensions,
+    labels = labels,
+    fd_labels = fd_labels,
+    conserve_extensions = FALSE
+  )
+
+  testthat::expect_equal(sum(fp$value), 100)
+  testthat::expect_equal(sum(paths$value), sum(fp$value))
+  testthat::expect_equal(sum(product_paths$value), sum(fp$value))
+})
+
+testthat::test_that("compute_footprint_paths validates max_column_sum", {
+  testthat::expect_error(
+    compute_footprint_paths(
+      z_mat = matrix(0, nrow = 1, ncol = 1),
+      x_vec = 1,
+      y_mat = matrix(1, nrow = 1),
+      extensions = 1,
+      labels = tibble::tibble(area_code = 1L, item_cbs_code = 1L),
+      fd_labels = tibble::tibble(area_code = 1L, fd_col = "food"),
+      max_column_sum = -1
+    ),
+    "max_column_sum"
+  )
+})
+
 testthat::test_that("compute_footprint_paths returns empty output for absent origin", {
   paths <- compute_footprint_paths(
     z_mat = matrix(0, nrow = 1, ncol = 1),
@@ -153,6 +216,39 @@ testthat::test_that("add_footprint_product_stage splits by supplier shares", {
     20
   )
   testthat::expect_equal(unique(result$product_item), 20L)
+})
+
+testthat::test_that("product_area_name matches crosswalk polity name", {
+  footprints <- tibble::tibble(
+    origin_area = 231L,
+    origin_item = 10L,
+    target_area = 231L,
+    target_area_name = "United States of America",
+    target_item = 20L,
+    target_fd = "food",
+    value = 100
+  )
+  y_mat <- Matrix::Matrix(c(60, 40), nrow = 2, sparse = TRUE)
+  labels <- tibble::tibble(
+    area_code = c(231L, 68L),
+    item_cbs_code = c(20L, 20L)
+  )
+  fd_labels <- tibble::tibble(area_code = 231L, fd_col = "food")
+
+  result <- add_footprint_product_stage(
+    footprints,
+    y_mat,
+    labels,
+    fd_labels,
+    max_product_areas = 2
+  )
+
+  testthat::expect_equal(nrow(result), 2)
+  testthat::expect_false("Other" %in% result$product_area_name)
+  testthat::expect_equal(
+    result$product_area_name,
+    result$product_polity_name
+  )
 })
 
 testthat::test_that("add_footprint_product_stage fills fallback product area code", {


### PR DESCRIPTION
## Summary

Two fixes in `R/footprint_paths.R`:

1. **#154 — A-matrix cap mismatch.** `compute_footprint_paths()` and `compute_fp_product_paths()` called `.technical_coefficients()` without `max_column_sum`, so it defaulted to `1 - value_added_floor` (0.999), whereas `compute_footprint()` uses `max_column_sum = 100`. Feed-conversion sectors whose A column sum falls in (0.999, 100] were clipped more aggressively in the path decomposition than in the footprint, so Sankey path totals did not reconcile with the footprint they decompose. Both path functions now expose `max_column_sum` (default `100`, matching `compute_footprint()`), thread it into `.technical_coefficients()`, and validate it via `.validate_max_column_sum()`. Because both functions now build the identical capped A (and hence the identical model-consistent output `x' = L y`), the per-origin path total equals the footprint total exactly.

2. **#289 — inconsistent product area name.** `.fd_product_area_shares()` derived `product_area_name` from `whep::regions_full$name`, while every other polity name in the same `add_footprint_product_stage()` output (including `product_polity_name`) comes from the polity crosswalk (`reporting_polity_name`). A row could carry `product_area_name` != `product_polity_name` for the same code. The name is now sourced from `.label_reporting_polity_lookup(labels)` (crosswalk `reporting_polity_name`, keyed by area code), so the two agree.

## Tests

Extended `tests/testthat/test_footprint_paths.R`:
- path totals (both path functions) reconcile with `compute_footprint()` under the shared cap, using a system whose A column sum (2) lies in (0.999, 100];
- `max_column_sum` validation is enforced;
- `product_area_name` equals `product_polity_name` for kept supplier rows.

All 38 tests in the file pass. `air format .` clean, `devtools::document()` run, `lintr` clean on the changed file.

Closes #154
Closes #289

🤖 Generated with [Claude Code](https://claude.com/claude-code)