### PR TITLE
fix(trade): keep intra-aggregate distinct-origin bilateral flows in build_detailed_trade

### DIFF
--- a/R/build_trade.R
+++ b/R/build_trade.R
@@ -144,8 +144,17 @@ build_detailed_trade <- function(
   items_full <- data.table::as.data.table(whep::items_full)
   items_bridge <- unique(items_full[, .(item_cbs, item_cbs_code)])
 
-  # If the DTM has item names, map through cbs_trade_codes
-  if ("item" %in% names(dt)) {
+  # Prefer the stable trade item *code* join. The code bridge is also more
+  # complete than the name bridge, so this maps more items. Fall back to
+  # joining by item *name* only when no code column is present -- that path is
+  # brittle to label drift, so warn when it is used (relates to #170).
+  if ("item_code_trade" %in% names(dt)) {
+    dt <- merge(dt, bridge, by = "item_code_trade", all.x = TRUE)
+  } else if ("item" %in% names(dt)) {
+    cli::cli_warn(
+      "No trade item code column; joining trade items to CBS items by name,
+       which is brittle to label drift."
+    )
     name_bridge <- unique(cbs_trade[, .(item_trade, item_cbs)])
     dt <- merge(
       dt,
@@ -154,8 +163,6 @@ build_detailed_trade <- function(
       by.y = "item_trade",
       all.x = TRUE
     )
-  } else if ("item_code_trade" %in% names(dt)) {
-    dt <- merge(dt, bridge, by = "item_code_trade", all.x = TRUE)
   }
 
   .warn_unmapped_items(dt)
@@ -246,12 +253,28 @@ build_detailed_trade <- function(
   )
   dt <- dt[, .(value = sum(value, na.rm = TRUE)), by = by_cols]
 
-  # Remove self-trade at polity level
-
-  dt <- dt[area_code != area_code_partner]
+  # Remove self-trade at polity level, but only for genuine single-country
+  # polities. Distinct FAOSTAT areas that collapse to an *aggregate* polity
+  # (e.g. the 62 territories mapped to Rest of World, 999) are different
+  # contemporaneous countries, so a flow between two of them (say American
+  # Samoa -> Andorra) is legitimate bilateral trade, not self-trade -- yet both
+  # collapse to 999, so a naive `a == a` filter would delete it (deepens #152).
+  # Genuine self-trade (same original area) was already dropped upstream in
+  # .read_and_clean_dtm(); here we keep a collapsed `a -> a` row only when `a`
+  # is an aggregate bucket, so its distinct-origin flows survive (aggregated).
+  aggregate_codes <- .aggregate_polity_codes()
+  dt <- dt[area_code != area_code_partner | area_code %in% aggregate_codes]
   dt[value == 0, value := NA_real_]
   dt <- dt[!is.na(value)]
   dt
+}
+
+# Polity codes that are artificial aggregates (e.g. Rest of World, 999) rather
+# than real single countries. Distinct areas collapsing to such a bucket are
+# different countries, so self-loops on them must not be treated as self-trade.
+.aggregate_polity_codes <- function() {
+  crosswalk <- data.table::as.data.table(polity_area_crosswalk)
+  unique(crosswalk[polity_type == "aggregate", polity_area_code])
 }
 
 .compute_country_shares <- function(dt) {

--- a/R/utils.R
+++ b/R/utils.R
@@ -636,6 +636,7 @@ utils::globalVariables(
     "polity_end_year",
     "polity_name",
     "polity_start_year",
+    "polity_type",
     "pop",
     "Pop_Mpeop_yg",
     "Pop_share",

--- a/tests/testthat/test_build_trade.R
+++ b/tests/testthat/test_build_trade.R
@@ -146,8 +146,12 @@ testthat::test_that("unmapped item names warn and are dropped", {
     Value = c(100, 200)
   )
 
+  # Name-only input also triggers the brittle name-join fallback warning.
   testthat::expect_warning(
-    result <- build_detailed_trade(raw_trade = raw),
+    testthat::expect_warning(
+      result <- build_detailed_trade(raw_trade = raw),
+      "by name"
+    ),
     "not found in CBS mapping"
   )
 
@@ -286,6 +290,47 @@ testthat::test_that("polity self-trade is removed after aggregation", {
   testthat::expect_equal(nrow(result), 0)
 })
 
+testthat::test_that("intra-aggregate distinct-origin trade survives collapse", {
+  # American Samoa (5) and Andorra (6) both collapse to the Rest of World
+  # aggregate polity (999). A real flow 5 -> 6 becomes 999 -> 999, which the
+  # naive polity-level self-trade filter would delete. It must survive: these
+  # are two different countries, not genuine self-trade (deepens #152).
+  raw <- data.table::data.table(
+    `Reporter Country Code` = c(5L),
+    `Partner Country Code` = c(6L),
+    `Item Code` = c(15L),
+    Element = c("Import Quantity"),
+    Year = c(2020L),
+    Unit = c("tonnes"),
+    Value = c(100)
+  )
+
+  result <- build_detailed_trade(raw_trade = raw)
+
+  testthat::expect_equal(nrow(result), 1)
+  testthat::expect_equal(result$area_code, 999)
+  testthat::expect_equal(result$area_code_partner, 999)
+  testthat::expect_equal(result$value, 100)
+})
+
+testthat::test_that("genuine self-trade within an aggregate is still removed", {
+  # A flow from American Samoa (5) to itself is real self-trade and must be
+  # dropped even though 5 collapses to the Rest of World aggregate (999).
+  raw <- data.table::data.table(
+    `Reporter Country Code` = c(5L),
+    `Partner Country Code` = c(5L),
+    `Item Code` = c(15L),
+    Element = c("Import Quantity"),
+    Year = c(2020L),
+    Unit = c("tonnes"),
+    Value = c(100)
+  )
+
+  result <- build_detailed_trade(raw_trade = raw)
+
+  testthat::expect_equal(nrow(result), 0)
+})
+
 testthat::test_that("zero-value rows are dropped", {
   raw <- data.table::data.table(
     `Reporter Country Code` = c(2L, 2L),
@@ -315,7 +360,12 @@ testthat::test_that("item name column maps through cbs_trade_codes names", {
     Value = c(100)
   )
 
-  result <- build_detailed_trade(raw_trade = raw)
+  # The name-join path is a brittle fallback used only without item codes, so
+  # it now warns (relates to #170).
+  testthat::expect_warning(
+    result <- build_detailed_trade(raw_trade = raw),
+    "by name"
+  )
 
   testthat::expect_equal(nrow(result), 1)
   testthat::expect_equal(result$item_cbs_code, 2511)


### PR DESCRIPTION
## Problem

In `R/build_trade.R`, `.aggregate_dtm_to_polities()` removed polity-level self-trade **after** both reporter and partner were collapsed to `polity_area_code`:

```r
dt <- dt[area_code != area_code_partner]
```

62 distinct FAOSTAT areas collapse to the **Rest of World aggregate polity `999`** (and there are 9 aggregate polity codes total: `15, 151, 901–906, 999`). So a **legitimate** bilateral flow between two *different* such areas — e.g. American Samoa `5` -> Andorra `6`, both -> `999` — became an indistinguishable `999 -> 999` row and was deleted as if it were self-trade.

This is a **different location** from #273 (which zeroes the matrix diagonal in `R/bilateral_trade.R`, the IPF balancer). It deepens #152.

## Fix

- Genuine self-trade (same original area) is still dropped upstream in `.read_and_clean_dtm()` — unchanged.
- The post-collapse removal now keeps a collapsed `a -> a` row **only when `a` is an aggregate polity** (`polity_type == "aggregate"` in `polity_area_crosswalk`), so its distinct-origin flows survive (aggregated). Real single-country polities whose temporal aliases collapse together (e.g. Ethiopia `238` + Ethiopia PDR `62` -> `238`) still have their spurious `238 -> 238` self-loop removed, as before.

Added helper `.aggregate_polity_codes()`; declared `polity_type` in `utils::globalVariables()`.

## Also (relates to #170)

`.map_dtm_to_cbs_items()` now **prefers the stable trade item code join** over the item-name join (the code bridge is also more complete than the name bridge). The brittle name-join is kept only as a fallback for inputs without a code column, and now emits a warning when used.

## Tests

`tests/testthat/test_build_trade.R`:
- `5 -> 6` (both collapse to `999`) survives as a `999 -> 999` flow with its value preserved.
- Genuine self-trade `5 -> 5` within an aggregate is still removed.
- Existing `238 -> 62` national self-trade removal still asserted (unchanged behaviour).
- Name-join test updated to assert the new fallback warning.

All 64 tests in the file pass; `lintr` clean on changed files; `air format .` applied.

Closes #303
Deepens #152. Complementary to #273.

🤖 Generated with [Claude Code](https://claude.com/claude-code)