### PR TITLE
fix(regions): detect aggregates via polity crosswalk, not regions_full iso3c

### DIFF
--- a/R/grassland_land_extension.R
+++ b/R/grassland_land_extension.R
@@ -98,16 +98,18 @@ build_grassland_land_extension <- function(
 }
 
 # FAOSTAT "Permanent meadows and pastures" area (item 6655), filtered live from
-# the faostat-landuse pin (Value is in 1000 ha). Aggregate FAOSTAT regions are
-# dropped by keeping only codes that map to a real country in regions_full.
+# the faostat-landuse pin (Value is in 1000 ha). Raw FAOSTAT reporting areas are
+# mapped to WHEP polities through polity_area_crosswalk and collapsed to
+# polity_area_code, the same country basis the LUH2 grassland source already
+# uses. Statistical aggregates that overlap their components (e.g. FAOSTAT
+# "China" 351, "World", continents) are unmapped in the crosswalk and dropped
+# here, so they cannot double-count. This replaces an earlier `!is.na(iso3c)`
+# heuristic on regions_full, which reinvented aggregate detection and left the
+# two grassland sources keyed on different area codes (raw FAOSTAT vs polity).
 .grassland_occupation_faostat <- function(landuse = NULL) {
   if (is.null(landuse)) {
     landuse <- whep_read_file("faostat-landuse")
   }
-  valid_codes <- whep::regions_full |>
-    dplyr::filter(!is.na(.data$iso3c)) |>
-    dplyr::pull(.data$code) |>
-    unique()
   landuse |>
     dplyr::filter(.data[["Item Code"]] == 6655, .data$Element == "Area") |>
     dplyr::transmute(
@@ -116,11 +118,23 @@ build_grassland_land_extension <- function(
       item_cbs_code = 3000L,
       impact_u = round(.data$Value * 1000, 1)
     ) |>
-    dplyr::filter(
-      !is.na(.data$impact_u),
-      .data$impact_u > 0,
-      .data$area_code %in% valid_codes
-    )
+    dplyr::filter(!is.na(.data$impact_u), .data$impact_u > 0) |>
+    .grassland_faostat_to_polities()
+}
+
+# Collapse raw FAOSTAT reporting areas to WHEP polity_area_code via the canonical
+# crosswalk, dropping unmapped statistical aggregates. Keeps the extension grain
+# (year, area_code, item_cbs_code); area_code is now a polity_area_code, matching
+# the LUH2 source.
+.grassland_faostat_to_polities <- function(occupation) {
+  occupation |>
+    add_polity_code(code_column = "area_code", year_column = "year") |>
+    dplyr::filter(!is.na(.data$polity_code)) |>
+    dplyr::summarise(
+      impact_u = sum(.data$impact_u, na.rm = TRUE),
+      .by = c(year, polity_area_code, item_cbs_code)
+    ) |>
+    dplyr::rename(area_code = polity_area_code)
 }
 
 .fallow_item_cbs <- function() {

--- a/R/residue_destiny.R
+++ b/R/residue_destiny.R
@@ -142,9 +142,27 @@ build_residue_feed_avail <- function(
       !is.na(.data$input_region),
       !is.na(.data$recovery_region)
     ) |>
-    dplyr::distinct(.data$input_region, .keep_all = TRUE)
+    dplyr::distinct(.data$input_region, .data$recovery_region)
+  .assert_unique_region_map(lookup)
   mapped <- lookup$recovery_region[match(region, lookup$input_region)]
   dplyr::coalesce(mapped, region)
+}
+
+# Guard the krausmann -> HANPP region map against silent fan-out: the earlier
+# distinct(input_region, .keep_all = TRUE) kept the first HANPP region whenever a
+# Krausmann label spanned several, hiding the ambiguity. The map is 1:1 today, so
+# abort loudly if a future regions_full change breaks that (relates to #170).
+.assert_unique_region_map <- function(lookup) {
+  dupes <- unique(lookup$input_region[duplicated(lookup$input_region)])
+  if (length(dupes) > 0L) {
+    cli::cli_abort(
+      c(
+        "Each {.field region_krausmann} must map to one {.field region_HANPP}.",
+        i = "Ambiguous label{?s}: {.val {dupes}}."
+      )
+    )
+  }
+  invisible(lookup)
 }
 
 .residue_destiny_shares <- function(x) {

--- a/tests/testthat/test_grassland_land_extension.R
+++ b/tests/testthat/test_grassland_land_extension.R
@@ -35,7 +35,7 @@ testthat::test_that("faostat_pasture filters item 6655 from the landuse pin", {
     ~`Area Code`, ~`Item Code`, ~Element, ~Year, ~Value,
     10, 6655, "Area", 2000, 50000, # Australia perm. pasture (1000 ha)
     10, 6620, "Area", 2000, 9999, # cropland -> excluded (wrong item)
-    351, 6655, "Area", 2000, 40000 # China aggregate (NA iso3c) -> excluded
+    351, 6655, "Area", 2000, 40000 # China aggregate -> unmapped, excluded
   )
 
   result <- whep::build_grassland_land_extension(
@@ -48,6 +48,51 @@ testthat::test_that("faostat_pasture filters item 6655 from the landuse pin", {
   testthat::expect_equal(result$impact_u, 5e7)
   testthat::expect_true(all(result$item_cbs_code == 3000L))
   testthat::expect_equal(result$method_grassland, "occupation")
+})
+
+testthat::test_that("faostat_pasture drops aggregates via the polity crosswalk", {
+  # China 351 is a statistical aggregate (its NA iso3c also has no polity), while
+  # dissolved-state reporting areas (Czechoslovakia 51, USSR 228) DO carry an
+  # iso3c but only overlap successors out of time, so they map to real polities
+  # and must be kept. The old `!is.na(iso3c)` heuristic could not tell these
+  # apart from a true aggregate; the crosswalk can.
+  landuse <- tibble::tribble(
+    ~`Area Code`, ~`Item Code`, ~Element, ~Year, ~Value,
+    68, 6655, "Area", 1985, 1000, # France -> real polity, kept
+    51, 6655, "Area", 1985, 2000, # Czechoslovakia -> real polity (1985), kept
+    351, 6655, "Area", 1985, 9999 # China aggregate -> unmapped, dropped
+  )
+
+  result <- whep::build_grassland_land_extension(
+    source = "faostat_pasture",
+    data = list(landuse = landuse)
+  )
+
+  testthat::expect_false(351L %in% result$area_code)
+  testthat::expect_true(all(c(68L, 51L) %in% result$area_code))
+})
+
+testthat::test_that("faostat_pasture collapses ROW territories to a polity key", {
+  # Small territories FABIO buckets into Rest of World (e.g. American Samoa 5,
+  # Andorra 6) carry an iso3c, so the old filter kept them under their raw
+  # FAOSTAT codes -- a different key basis than the LUH2 source. The crosswalk
+  # collapses them into the ROW polity_area_code (999), preserving their area but
+  # aligning both sources on polity_area_code.
+  landuse <- tibble::tribble(
+    ~`Area Code`, ~`Item Code`, ~Element, ~Year, ~Value,
+    5, 6655, "Area", 2000, 3, # American Samoa, bucketed into ROW
+    6, 6655, "Area", 2000, 7 # Andorra, also bucketed into ROW
+  )
+
+  result <- whep::build_grassland_land_extension(
+    source = "faostat_pasture",
+    data = list(landuse = landuse)
+  )
+
+  testthat::expect_equal(result$area_code, 999L)
+  # ROW carries both territories: (3 + 7) thousand ha = 10000 ha.
+  testthat::expect_equal(result$impact_u, 1e4)
+  testthat::expect_false(any(c(5L, 6L) %in% result$area_code))
 })
 
 testthat::test_that("active_grazing caps area at grazing intake over yield", {

--- a/tests/testthat/test_residue_destiny.R
+++ b/tests/testthat/test_residue_destiny.R
@@ -62,6 +62,25 @@ test_that("calculate_residue_destinies conserves mass with an unmatched region",
   testthat::expect_equal(out$residue_soil_dm_t, 100)
 })
 
+test_that("region-map guard rejects a krausmann label with two HANPP regions", {
+  # The real regions_full map is 1:1, so calculate_residue_destinies works; the
+  # guard exists so a future fan-out (one Krausmann label -> several HANPP
+  # regions) aborts loudly instead of silently keeping the first (relates #170).
+  fan_out <- tibble::tibble(
+    input_region = c("Western Europe", "Western Europe"),
+    recovery_region = c("West Europe", "North America and Oceania")
+  )
+  testthat::expect_error(
+    whep:::.assert_unique_region_map(fan_out),
+    "region_HANPP"
+  )
+  one_to_one <- tibble::tibble(
+    input_region = c("Western Europe", "Eastern Asia"),
+    recovery_region = c("West Europe", "East Asia")
+  )
+  testthat::expect_no_error(whep:::.assert_unique_region_map(one_to_one))
+})
+
 test_that("krausmann split accepts regions_full recovery labels", {
   out <- whep::calculate_residue_destinies(tibble::tibble(
     item_prod_code = "15",


### PR DESCRIPTION
## Summary

Routes two footprint helpers through the canonical polity crosswalk (`polity_area_crosswalk`) instead of `regions_full` name / `iso3c` heuristics.

### Grassland extension (MEDIUM)

`.grassland_occupation_faostat()` dropped FAOSTAT aggregates with a `!is.na(iso3c)` whitelist on `regions_full`. This reinvented aggregate detection and keyed the FAOSTAT-pasture source on **raw FAOSTAT `area_code`**, while the default LUH2 source is already collapsed to `polity_area_code` — so a downstream join by `area_code` saw inconsistent keys between the two sources.

Now the FAOSTAT source maps through `add_polity_code()`, drops unmapped statistical aggregates, and collapses to `polity_area_code`, matching `.aggregate_to_polities()` and the LUH2 source:

- FAOSTAT "China" 351, "World", continents are unmapped in the crosswalk and dropped (no double-count).
- Dissolved-state reporting areas (Czechoslovakia 51, USSR 228, Yugoslavia 248) map to real polities and are kept.
- Rest-of-World territories (e.g. American Samoa 5, Andorra 6) collapse into the ROW polity (`999`), preserving their area but aligning both sources on `polity_area_code`.

### Residue destiny (LOW, relates #170)

`.residue_recovery_region()` mapped `region_krausmann -> region_HANPP` with keep-first `distinct(input_region, .keep_all = TRUE)`, silently letting the first HANPP region win on fan-out. The map is 1:1 today; added `.assert_unique_region_map()` to abort loudly if that ever breaks.

## Tests

- `test_grassland_land_extension.R`: added coverage that aggregates are dropped via the crosswalk (China 351 out, France 68 and Czechoslovakia 51 kept) and that ROW territories collapse to `polity_area_code` 999. Existing FAOSTAT/LUH2 tests still pass.
- `test_residue_destiny.R`: added a guard test (fan-out aborts, 1:1 passes).
- Both files: `[ FAIL 0 ]` (20 and 16 passing). Formatted with `air`; changed files lint-clean. No exported API or roxygen changes.

Closes #306

🤖 Generated with [Claude Code](https://claude.com/claude-code)
