### PR TITLE
fix(production): key pre-1962 yield & fodder joins and dissolved dedup by code

### DIFF
--- a/R/build_production.R
+++ b/R/build_production.R
@@ -497,23 +497,20 @@ build_primary_production <- function(
 
 .read_int_yields <- function(years = NULL) {
   cli::cli_progress_step("Reading international yields")
-  regions <- data.table::as.data.table(whep::regions_full)[,
-    .(code, polity_name)
-  ]
-
+  # The raw `area_code` is already a `polity_area_code`, matching the
+  # production `area_code`. Key the proxy by code (not by the periodized
+  # polity name) so the merge in `.add_historical_yields()` matches.
   dt <- .read_input("international-yields", years = years, year_col = "year")
   dt[, item_prod_code := as.character(item_code)]
-  data.table::setnames(dt, "area_code", "code")
+  dt[, area_code := as.integer(area_code)]
   dt[, item_code := NULL]
 
   dt <- dt[
     year < 1962 & !is.na(yield) & yield != 0 & yield < 100
   ]
-  dt <- merge(dt, regions, by = "code", all.x = TRUE, sort = FALSE)
-  data.table::setnames(dt, "polity_name", "area")
   dt <- dt[,
     .(yield = mean(yield, na.rm = TRUE)),
-    by = c("year", "area", "item_prod_code")
+    by = c("year", "area_code", "item_prod_code")
   ]
   dt <- dt[!is.nan(yield)]
   dt
@@ -527,7 +524,6 @@ build_primary_production <- function(
   items <- whep::items_full
   crops_eu <- whep::crops_eurostat
   biomass <- whep::biomass_coefs
-  regions <- whep::regions_full
 
   # Old FAO fodder data
   i_fodder <- .read_fodder_old(years = years)
@@ -709,6 +705,20 @@ build_primary_production <- function(
   fodder_euadb,
   items_prod
 ) {
+  # `.read_fodder_euadb()` labels rows with the plain `polity_name`, but
+  # `fodder` carries periodized names, so a name-keyed join fragments rows.
+  # Rekey EU AgriDB onto the FAO name for the same (year, area_code) so the
+  # joins below match on a consistent (year, area_code, area) key.
+  fao_area <- fodder |>
+    dplyr::filter(!is.na(area)) |>
+    dplyr::distinct(year, area_code, area) |>
+    dplyr::rename(fao_area = area)
+
+  fodder_euadb <- fodder_euadb |>
+    dplyr::left_join(fao_area, by = c("year", "area_code")) |>
+    dplyr::mutate(area = dplyr::coalesce(fao_area, area)) |>
+    dplyr::select(-fao_area)
+
   euadb_area <- fodder_euadb |>
     dplyr::filter(Unit == "Mha") |>
     dplyr::mutate(ha_euadb = value * 1e6) |>
@@ -2213,27 +2223,21 @@ build_primary_production <- function(
 .filter_dissolved_countries <- function(df) {
   force(df)
   cli::cli_progress_step("Filtering dissolved countries")
+  # Key on `area_code` (polity_area_code), not `area`: after
+  # `.aggregate_to_polities()` the `area` names are periodized
+  # (e.g. "Czechoslovakia (1947-1993)"), so name conditions never fire.
   df |>
     dplyr::filter(
-      !(area == "Czechoslovakia" & year > 1992),
-      !(area %in%
-        c(
-          "Czech Republic",
-          "Czechia",
-          "Slovakia"
-        ) &
-        year < 1993),
-      !(area %in%
-        c(
-          "Lithuania",
-          "Latvia",
-          "Estonia",
-          "Slovenia",
-          "Croatia"
-        ) &
-        year < 1992),
-      !(area == "Belgium-Luxembourg" & year > 1999),
-      !(area %in% c("Belgium", "Luxembourg") & year < 2000)
+      # Czechoslovakia (51) after its 1992 dissolution
+      !(area_code == 51L & year > 1992),
+      # Czechia (167) and Slovakia (199) before 1993
+      !(area_code %in% c(167L, 199L) & year < 1993),
+      # Baltics, Slovenia (198), Croatia (98) before 1992
+      !(area_code %in% c(126L, 119L, 63L, 198L, 98L) & year < 1992),
+      # Belgium-Luxembourg (15) after its 1999 split
+      !(area_code == 15L & year > 1999),
+      # Belgium (255) and Luxembourg (256) before 2000
+      !(area_code %in% c(255L, 256L) & year < 2000)
     )
 }
 
@@ -2713,6 +2717,7 @@ build_primary_production <- function(
   wide[, source := dplyr::coalesce(source_prod, source_any)]
   wide[, source_prod := NULL]
   wide[, source_any := NULL]
+  wide[, area_code := as.integer(area_code)]
   wide <- merge(
     wide,
     if (data.table::is.data.table(int_yields)) {
@@ -2720,7 +2725,7 @@ build_primary_production <- function(
     } else {
       data.table::as.data.table(int_yields)
     },
-    by = c("year", "area", "item_prod_code"),
+    by = c("year", "area_code", "item_prod_code"),
     all.x = TRUE,
     sort = FALSE
   )

--- a/R/utils.R
+++ b/R/utils.R
@@ -322,6 +322,7 @@ utils::globalVariables(
     "area_code_p",
     "area_code_partner",
     "area_ha",
+    "fao_area",
     "area_iso3c",
     "area_mha",
     "Area",

--- a/tests/testthat/test_build_production.R
+++ b/tests/testthat/test_build_production.R
@@ -46,22 +46,102 @@
 # -- filter_dissolved_countries ------------------------------------------------
 
 test_that(".filter_dissolved_countries removes dissolved polities", {
+  # `area` is periodized after `.aggregate_to_polities()`; the filter must
+  # key on `area_code` (Czechoslovakia = 51), not on the plain name.
   df <- tibble::tribble(
     ~year, ~area, ~area_code, ~value,
     2000L, "Spain", 203L, 10,
-    2000L, "Czechoslovakia", 999L, 20,
-    1990L, "Czechoslovakia", 999L, 30
+    2000L, "Czechoslovakia (1947-1993)", 51L, 20,
+    1990L, "Czechoslovakia (1947-1993)", 51L, 30
   )
 
   result <- whep:::.filter_dissolved_countries(df)
   # Czechoslovakia after 1992 should be removed
   expect_false(
-    any(result$area == "Czechoslovakia" & result$year > 1992)
+    any(result$area_code == 51L & result$year > 1992)
   )
   # Czechoslovakia before 1993 should be kept
   expect_true(
-    any(result$area == "Czechoslovakia" & result$year == 1990)
+    any(result$area_code == 51L & result$year == 1990)
   )
+})
+
+test_that(".filter_dissolved_countries dedups at the 1992/1993 boundary", {
+  # Both the dissolved polity and its successors present in the overlap
+  # years. Czechoslovakia (51) must go for 1993, successors for 1992.
+  df <- tibble::tribble(
+    ~year, ~area, ~area_code, ~value,
+    1993L, "Czechoslovakia (1947-1993)", 51L, 20,
+    1993L, "Czechia", 167L, 10,
+    1993L, "Slovakia", 199L, 11,
+    1992L, "Czechia", 167L, 9,
+    1992L, "Slovakia", 199L, 8
+  )
+
+  result <- whep:::.filter_dissolved_countries(df)
+  # dissolved parent removed after 1992
+  expect_false(any(result$area_code == 51L))
+  # successors removed before 1993
+  expect_false(any(result$area_code %in% c(167L, 199L) & result$year < 1993))
+  # successors kept in 1993
+  expect_true(any(result$area_code == 167L & result$year == 1993))
+  expect_true(any(result$area_code == 199L & result$year == 1993))
+})
+
+
+# -- add_historical_yields (pre-1962 yield proxy) ------------------------------
+
+test_that(".add_historical_yields back-casts a periodized-name country", {
+  # China's periodized `area` ("China (PRC)") never equals the plain proxy
+  # name, so the proxy must join by `area_code` (41). If it matches, the
+  # pre-1961 tonnes are back-cast from the yield-growth proxy.
+  df <- tibble::tribble(
+    ~year, ~area, ~area_code, ~item_prod, ~item_prod_code, ~item_cbs, ~item_cbs_code, ~land_use, ~live_anim, ~live_anim_code, ~unit, ~value, ~source,
+    1961L, "China (PRC)", 41L, "Wheat", "15", "Wheat", 2511L, "cropland", NA_character_, NA_integer_, "tonnes", 6000, "FAOSTAT_prod",
+    1961L, "China (PRC)", 41L, "Wheat", "15", "Wheat", 2511L, "cropland", NA_character_, NA_integer_, "ha", 100, "FAOSTAT_prod",
+    1960L, "China (PRC)", 41L, "Wheat", "15", "Wheat", 2511L, "cropland", NA_character_, NA_integer_, "tonnes", 0, "FAOSTAT_prod",
+    1960L, "China (PRC)", 41L, "Wheat", "15", "Wheat", 2511L, "cropland", NA_character_, NA_integer_, "ha", 100, "FAOSTAT_prod"
+  )
+  int_yields <- tibble::tribble(
+    ~year, ~area_code, ~item_prod_code, ~yield,
+    1960L, 41L, "15", 2.0,
+    1961L, 41L, "15", 2.5
+  )
+
+  result <- whep:::.add_historical_yields(df, int_yields) |>
+    tibble::as_tibble()
+  # proxy joined by code → yield attached for the periodized-name country
+  expect_true(all(!is.na(result$yield)))
+  # 1960 tonnes back-cast from proxy: 100 * (60 * 2.0/2.5) = 4800
+  tonnes_1960 <- result$tonnes[result$year == 1960L]
+  expect_equal(tonnes_1960, 4800)
+})
+
+
+# -- merge_euadb_fodder --------------------------------------------------------
+
+test_that(".merge_euadb_fodder merges EU rows by code, not fragmenting", {
+  # FAO fodder uses periodized names; EU AgriDB uses plain names. The merge
+  # must align them by `area_code` so a matched crop stays a single row.
+  fodder <- tibble::tribble(
+    ~year, ~area, ~area_code, ~item_prod, ~item_prod_code, ~t, ~t_dm, ~ha,
+    2010L, "Foo (1990-2020)", 100L, "Grass", "3001", 5, 4, 10
+  )
+  fodder_euadb <- tibble::tribble(
+    ~year, ~area, ~area_code, ~Name_Eurostat, ~Label, ~Unit, ~value,
+    2010L, "Foo", 100L, "GrassEuro", "Area", "Mha", 5,
+    2010L, "Foo", 100L, "GrassEuro", "Yield", "kgN/ha", 200
+  )
+  items_prod <- tibble::tribble(
+    ~item_prod, ~item_prod_code, ~Name_Eurostat,
+    "Grass", "3001", "GrassEuro"
+  )
+
+  result <- whep:::.merge_euadb_fodder(fodder, fodder_euadb, items_prod)
+  # single merged row for the matched crop (not two fragments)
+  expect_equal(nrow(result), 1L)
+  expect_false(is.na(result$ha))
+  expect_false(is.na(result$ha_euadb))
 })
 
 
@@ -400,7 +480,7 @@ test_that(".add_historical_yields preserves direct historical tonnes", {
   )
   int_yields <- tibble::tibble(
     year = 1950L,
-    area = "Spain",
+    area_code = 203L,
     item_prod_code = "15",
     yield = 999
   )


### PR DESCRIPTION
## Summary

After `.aggregate_to_polities()`, the production `area` column holds **periodized** polity names while `area_code` holds the `polity_area_code`. Three helpers in `R/build_production.R` still keyed on the `area` *name*, so they silently mismatched. Both sides already share `polity_area_code` (0 code mismatches), so this PR switches them to **code** joins.

- **HIGH** — `.read_int_yields()` / `.add_historical_yields()`: the pre-1962 international-yield proxy was joined by the flat `polity_name` vs periodized production `area` (~103/226 codes mismatched: China, Russia/USSR, Turkey, Poland, Vietnam, Korea, Yugoslavia, Czechoslovakia…), so the proxy was `NA` and the pre-1961 back-cast degraded for all major producers. The raw international-yields `area_code` is already a `polity_area_code`, so the name mapping (and its `regions_full` dependency) is removed and the merge keys on `area_code`.
- **MEDIUM-HIGH** — `.filter_dissolved_countries()`: filtered by plain names that never equal the periodized `area`, so the dedup was a no-op and dissolved polities double-counted at the boundary. Now keyed on `area_code` (Czechoslovakia 51; Czechia 167 / Slovakia 199; Baltics 126/119/63, Slovenia 198, Croatia 98; Belgium-Luxembourg 15; Belgium 255 / Luxembourg 256).
- **MEDIUM** — `.merge_euadb_fodder()`: EU AgriDB rows (flat names) `full_join`ed onto periodized FAO fodder fragmented. Now EU AgriDB names are aligned to the FAO periodized name by `area_code` before the join. Also removed the dead `regions <- whep::regions_full` in `.build_fodder()`.

## Tests (`tests/testthat/test_build_production.R`)

- `.add_historical_yields` back-casts a periodized-name country (China, code 41) — proxy joins by code and 1960 tonnes are back-cast from the yield-growth proxy.
- `.filter_dissolved_countries` dedups at the 1992/1993 boundary by code.
- `.merge_euadb_fodder` merges a matched EU crop into a single row (no fragmentation).
- Updated the two pre-existing tests that fed name-keyed fixtures.

All `test_build_production.R` tests pass locally (`pkgload::load_all` + `testthat`); `lintr` clean on changed files; `air format .` applied.

Scoped to the affected helpers to avoid overlap with the other open `build_production.R` PRs (#275 double-count, #285 slaughter gap-fill).

Closes #308

🤖 Generated with [Claude Code](https://claude.com/claude-code)