### PR TITLE
fix(supply_use): drop NA production before crop-product aggregation

### DIFF
--- a/R/supply_use.R
+++ b/R/supply_use.R
@@ -278,8 +278,12 @@ build_supply_use <- function(example = FALSE) {
 .build_supply_crop_product <- function(crop_prod_items, primary_prod) {
   double_process_map <- .double_crop_process_map()
 
+  # Drop NA production before aggregating, matching the feed-intake guard in
+  # .build_redistribute_intake(). A single NA would otherwise poison the whole
+  # group sum, and an all-NA group must be absent rather than a misleading zero
+  # supply that downstream seed-share allocation reads as real.
   primary_prod |>
-    dplyr::filter(unit == "tonnes") |>
+    dplyr::filter(unit == "tonnes", !is.na(value)) |>
     dplyr::inner_join(crop_prod_items, "item_prod_code") |>
     dplyr::left_join(
       double_process_map,
@@ -292,7 +296,7 @@ build_supply_use <- function(example = FALSE) {
       )
     ) |>
     dplyr::summarise(
-      value = sum(value),
+      value = sum(value, na.rm = TRUE),
       .by = c(year, area_code, proc_cbs_code, item_cbs_code)
     )
 }

--- a/tests/testthat/test_supply_use.R
+++ b/tests/testthat/test_supply_use.R
@@ -291,6 +291,32 @@ testthat::test_that(".build_supply_crop_product summarises crop production", {
   testthat::expect_equal(row_20$value, 40)
 })
 
+testthat::test_that(".build_supply_crop_product ignores NA production", {
+  crop_prod_items <- tibble::tibble(
+    item_prod_code = c(1, 2)
+  )
+  primary_prod <- tibble::tribble(
+    ~year, ~area_code, ~item_prod_code, ~item_cbs_code, ~live_anim_code, ~unit, ~value,
+    2000, 1, 1, 10, NA, "tonnes", 50,
+    2000, 1, 2, 10, NA, "tonnes", NA,
+    2000, 1, 1, 20, NA, "tonnes", NA
+  )
+
+  result <- .build_supply_crop_product(
+    crop_prod_items,
+    primary_prod
+  )
+
+  # An NA in the item 10 group must not poison the real value of 50.
+  row_10 <- result |>
+    dplyr::filter(item_cbs_code == 10)
+  testthat::expect_equal(row_10$value, 50)
+
+  # An all-NA group must be absent, not a misleading zero supply row.
+  testthat::expect_equal(nrow(result), 1)
+  testthat::expect_false(20 %in% result$item_cbs_code)
+})
+
 testthat::test_that(".build_supply_crop_product keeps field coproducts in one process", {
   crop_prod_items <- tibble::tibble(
     item_prod_code = c(329L, 767L)


### PR DESCRIPTION
## What

`.build_supply_crop_product()` (`R/supply_use.R`) aggregated production with `sum(value)` and no `na.rm`, unlike every other aggregation in the file. A single NA production value poisoned the entire group sum, producing an NA supply row.

Downstream, `.build_use_crop_production()` applies `replace_na(supply_value, 0)`, so the same process was simultaneously "unknown supply" on the supply side and "zero supply" for seed-share allocation — inconsistent, NA-leaking output.

## Fix

Filter `!is.na(value)` before aggregating, matching the existing feed-intake guard in `.build_redistribute_intake()` (`feed_intake_build.R`).

This is preferred over a bare `na.rm = TRUE` because it is semantically correct in both cases:
- a **partial-NA** group still sums its real values;
- an **all-NA** group becomes absent rather than a misleading `0` supply row that seed-share allocation would read as a real zero.

## Test

Added a test in `tests/testthat/test_supply_use.R` asserting a group with one NA still sums the real values, and an all-NA group produces no row. Full `test_supply_use.R` suite passes.

Closes #206

🤖 Generated with [Claude Code](https://claude.com/claude-code)