### PR TITLE
fix(spatialize): constrain type-aware allocation to matching LUH2 cells

### DIFF
--- a/R/spatialize.R
+++ b/R/spatialize.R
@@ -322,6 +322,20 @@ build_gridded_landuse <- function(
       )
     ]
 
+    # `type_cropland` is stored sparse: cells lacking a crop's LUH2 type have
+    # no row and join to `type_ha = NA`. Zero those so a crop cannot be placed
+    # in a cell lacking its type. Otherwise they would keep the inherited total
+    # cropland and both leak allocation and inflate `type_pot`, masking the
+    # whole-group fallback below.
+    grid_cp_tc[
+      is.na(type_ha),
+      `:=`(
+        cropland_ha = 0,
+        irrigated_ha = 0,
+        rainfed_ha = 0
+      )
+    ]
+
     # Check which (country, crop) have type potential; fallback where zero
     grid_cp_tc[,
       type_pot := sum(harvest_fraction * cropland_ha, na.rm = TRUE),

--- a/tests/testthat/test_spatialize.R
+++ b/tests/testthat/test_spatialize.R
@@ -369,6 +369,115 @@ testthat::test_that("build_gridded_landuse handles cells with no pattern gracefu
   testthat::expect_equal(total, 100, tolerance = 1e-6)
 })
 
+# Type-aware allocation ---------------------------------------------------------
+
+testthat::test_that("type-aware allocation excludes cells lacking the crop's LUH2 type", {
+  country_areas <- tibble::tribble(
+    ~year, ~area_code, ~item_prod_code, ~harvested_area_ha,
+    2000L,         1L,             15L,               1000
+  )
+  # Crop pattern is present in both cells.
+  crop_patterns <- tibble::tribble(
+    ~lon, ~lat, ~item_prod_code, ~harvest_fraction,
+    0.25, 50.25,             15L,               0.5,
+    0.75, 50.25,             15L,               0.5
+  )
+  gridded_cropland <- tibble::tribble(
+    ~lon, ~lat, ~year, ~cropland_ha,
+    0.25, 50.25, 2000L, 500,
+    0.75, 50.25, 2000L, 500
+  )
+  country_grid <- tibble::tribble(
+    ~lon, ~lat, ~area_code,
+    0.25, 50.25, 1L,
+    0.75, 50.25, 1L
+  )
+  # Crop 15 maps to c3ann, present only in the first cell (sparse table:
+  # the second cell has no c3ann row).
+  type_mapping <- tibble::tribble(
+    ~item_prod_code, ~luh2_type,
+    15L, "c3ann"
+  )
+  type_cropland <- tibble::tribble(
+    ~lon, ~lat, ~year, ~luh2_type, ~type_ha, ~type_irrig_ha,
+    0.25, 50.25, 2000L, "c3ann", 500, 0
+  )
+
+  result <- whep::build_gridded_landuse(
+    country_areas,
+    crop_patterns,
+    gridded_cropland,
+    country_grid,
+    config = list(
+      type_cropland = type_cropland,
+      type_mapping = type_mapping
+    )
+  )
+
+  # The cell lacking the crop's LUH2 type must get zero allocation.
+  cell_lacking_type <- result |>
+    dplyr::filter(lon == 0.75) |>
+    dplyr::summarise(total = sum(rainfed_ha + irrigated_ha)) |>
+    dplyr::pull(total)
+  testthat::expect_equal(cell_lacking_type, 0, tolerance = 1e-6)
+
+  # The full country total lands in the cell that has the type.
+  cell_with_type <- result |>
+    dplyr::filter(lon == 0.25) |>
+    dplyr::summarise(total = sum(rainfed_ha + irrigated_ha)) |>
+    dplyr::pull(total)
+  testthat::expect_equal(cell_with_type, 1000, tolerance = 1e-6)
+})
+
+testthat::test_that("type-aware allocation falls back to total cropland when no cell has the type", {
+  country_areas <- tibble::tribble(
+    ~year, ~area_code, ~item_prod_code, ~harvested_area_ha,
+    2000L,         1L,             15L,               1000
+  )
+  crop_patterns <- tibble::tribble(
+    ~lon, ~lat, ~item_prod_code, ~harvest_fraction,
+    0.25, 50.25,             15L,               0.5,
+    0.75, 50.25,             15L,               0.5
+  )
+  gridded_cropland <- tibble::tribble(
+    ~lon, ~lat, ~year, ~cropland_ha,
+    0.25, 50.25, 2000L, 500,
+    0.75, 50.25, 2000L, 500
+  )
+  country_grid <- tibble::tribble(
+    ~lon, ~lat, ~area_code,
+    0.25, 50.25, 1L,
+    0.75, 50.25, 1L
+  )
+  type_mapping <- tibble::tribble(
+    ~item_prod_code, ~luh2_type,
+    15L, "c3ann"
+  )
+  # No cell has c3ann for this crop (a different type is present).
+  type_cropland <- tibble::tribble(
+    ~lon, ~lat, ~year, ~luh2_type, ~type_ha, ~type_irrig_ha,
+    0.25, 50.25, 2000L, "c4ann", 500, 0,
+    0.75, 50.25, 2000L, "c4ann", 500, 0
+  )
+
+  result <- whep::build_gridded_landuse(
+    country_areas,
+    crop_patterns,
+    gridded_cropland,
+    country_grid,
+    config = list(
+      type_cropland = type_cropland,
+      type_mapping = type_mapping
+    )
+  )
+
+  # Whole-group fallback: total is conserved via total cropland.
+  total <- result |>
+    dplyr::summarise(total = sum(rainfed_ha + irrigated_ha)) |>
+    dplyr::pull(total)
+  testthat::expect_equal(total, 1000, tolerance = 1e-6)
+})
+
 # Multiple years ----------------------------------------------------------------
 
 testthat::test_that("build_gridded_landuse handles multiple years", {


### PR DESCRIPTION
Closes #192

## Problem

In `.spatialize_year()` (`R/spatialize.R`, `use_type_aware` branch), `type_cropland` is stored **sparse** (only rows with `type_ha > 0`). Cells where a crop's LUH2 type is absent join to `type_ha = NA` and kept the **total** cropland inherited from the base grid. As a result:

- A crop was allocated into cells lacking its LUH2 type, weighted by *total* (not type) cropland.
- `type_pot` was computed over those leaked total-cropland cells and stayed positive, so the whole-group fallback (`type_pot <= 0`) never fired.

Net effect: the flagship `whep` preset (`use_type_constraint = TRUE` by default) did **not** actually restrict crops to their LUH2 type.

## Fix

Zero `cropland_ha` / `irrigated_ha` / `rainfed_ha` for NA-`type_ha` cells **before** the group-fallback check, so a crop cannot be placed in a cell lacking its type. The whole-group fallback (restore original total cropland when no cell has the type at all) still fires correctly because `.orig_*` columns are preserved.

## Tests

Two tests added in `tests/testthat/test_spatialize.R`:

1. A crop mapped to a type present in only one cell gets **zero** allocation in the cell lacking that type (full total lands in the type cell). Verified this test fails without the fix.
2. When no cell has the crop's type, the whole-group fallback to total cropland still conserves the national total.

All 37 tests in `test_spatialize.R` pass; `lintr` clean. Scoped narrowly to the type-aware leak to avoid overlap with #300.

🤖 Generated with [Claude Code](https://claude.com/claude-code)