### PR TITLE
fix(lpjml): make default weighting reachable in make_lpjml_covariate

### DIFF
--- a/R/lpjml_covariate.R
+++ b/R/lpjml_covariate.R
@@ -43,11 +43,14 @@ make_lpjml_covariate <- function(
   if (is.function(weighting)) {
     return(weighting)
   }
-  if (!is.character(weighting) || length(weighting) != 1L) {
+  if (!is.character(weighting)) {
     cli::cli_abort(
       "{.arg weighting} must be {.val total_cropland}, {.val crop_pattern}, or a function."
     )
   }
+  # `match.arg()` resolves the default (the full choices vector) to its first
+  # element and validates single-string values, so it must run before any
+  # length check on `weighting`.
   weighting <- match.arg(weighting, c("total_cropland", "crop_pattern"))
   years <- .lpjml_normalize_years(years)
 

--- a/tests/testthat/test_lpjml_covariate.R
+++ b/tests/testthat/test_lpjml_covariate.R
@@ -73,6 +73,22 @@ testthat::test_that("total cropland covariate reads local prepared inputs", {
   testthat::expect_equal(values[[3]], 0)
 })
 
+testthat::test_that("covariate defaults to total cropland when weighting omitted", {
+  tmp <- withr::local_tempdir()
+  .write_lpjml_covariate_inputs(tmp)
+
+  covariate <- whep::make_lpjml_covariate(
+    input_dir = tmp,
+    years = 2000L
+  )
+  values <- covariate(.lpjml_covariate_points(), 2000L)
+
+  testthat::expect_length(values, 3L)
+  testthat::expect_gt(values[[1]], 0)
+  testthat::expect_gt(values[[2]], values[[1]])
+  testthat::expect_equal(values[[3]], 0)
+})
+
 testthat::test_that("crop-pattern covariate combines LUH2 type and crop pattern", {
   tmp <- withr::local_tempdir()
   .write_lpjml_covariate_inputs(tmp)


### PR DESCRIPTION
## What

`make_lpjml_covariate()` aborted when called without an explicit `weighting` argument. The length guard rejected the default value (the full choices vector `c("total_cropland", "crop_pattern")`, length 2) before `match.arg()` could resolve it, so the documented default mode was unreachable and callers were forced to always pass an explicit single string.

## Fix

- Drop the `length(weighting) != 1L` check from the pre-guard. `match.arg()` already resolves the default (an `arg` identical to `choices` returns the first choice) and validates single-string values, so it must run first.
- Keep the friendly `is.character` guard for non-string, non-function input.

## Test

Add a test asserting the covariate builds and evaluates correctly with `weighting` omitted (default `total_cropland` applies). Full `test_lpjml_covariate.R` suite passes (17 passing, 0 failures).

Closes #159

🤖 Generated with [Claude Code](https://claude.com/claude-code)