### PR TITLE
fix(nue): count excretion once in livestock mass balance

### DIFF
--- a/R/n_soil_inputs_nue.R
+++ b/R/n_soil_inputs_nue.R
@@ -307,7 +307,22 @@ calculate_nue_livestock <- function(example = FALSE) {
     ) |>
     dplyr::rename_with(tolower)
 
-  nue_livestock <- intake_n |>
+  .combine_nue_livestock(intake_n, prod_n, excretion_n)
+}
+
+#' @title Combine livestock N flows into NUE and mass balance
+#' @description Joins per-category feed and excretion N with per-item product
+#' N. Per-item `nue` is computed row-wise, while `mass_balance` is computed at
+#' the `(year, province_name, livestock_cat)` level so excretion (which is a
+#' category-level flow) is counted once rather than once per produced item.
+#' @param intake_n Feed N per year, province, and livestock category.
+#' @param prod_n Product N per year, province, livestock category, and item.
+#' @param excretion_n Excreted N per year, province, and livestock category.
+#' @return A tibble with per-item `nue` and category-level `mass_balance`.
+#' @keywords internal
+#' @noRd
+.combine_nue_livestock <- function(intake_n, prod_n, excretion_n) {
+  intake_n |>
     dplyr::inner_join(
       prod_n,
       by = c("year", "province_name", "livestock_cat")
@@ -318,7 +333,8 @@ calculate_nue_livestock <- function(example = FALSE) {
     ) |>
     dplyr::mutate(
       nue = prod_n / feed_n * 100,
-      mass_balance = (prod_n + excretion_n) / feed_n
+      mass_balance = (sum(prod_n) + excretion_n) / feed_n,
+      .by = c(year, province_name, livestock_cat)
     ) |>
     dplyr::select(
       year,
@@ -331,8 +347,6 @@ calculate_nue_livestock <- function(example = FALSE) {
       nue,
       mass_balance
     )
-
-  nue_livestock
 }
 
 #' @title System NUE

--- a/tests/testthat/test_n_soil_inputs_nue.R
+++ b/tests/testthat/test_n_soil_inputs_nue.R
@@ -127,7 +127,7 @@ test_that(".combine_nue_livestock does not double-count excretion", {
   expect_equal(nrow(out), 2)
 
   # Mass balance is a single category-level value: excretion counted once.
-  # (sum(products) + excretion) / feed = (30 + 10 + 55) / 100.
+  # Summed products plus excretion, over feed: 30 plus 10 plus 55, over 100.
   expect_equal(unique(out$mass_balance), (30 + 10 + 55) / 100)
 
   # Per-item nue is a valid decomposition summing to total products / feed.

--- a/tests/testthat/test_n_soil_inputs_nue.R
+++ b/tests/testthat/test_n_soil_inputs_nue.R
@@ -103,6 +103,37 @@ test_that("calculate_nue_crops computes NUE correctly", {
   expect_equal(nue$nue, 5 / 5 * 100)
 })
 
+# .combine_nue_livestock
+test_that(".combine_nue_livestock does not double-count excretion", {
+  # Pigs produce multiple items, so the product join fans out to 2 rows.
+  intake_n <- tibble::tribble(
+    ~year, ~province_name, ~livestock_cat, ~feed_n,
+    2000, "A", "Pigs", 100
+  )
+
+  prod_n <- tibble::tribble(
+    ~year, ~province_name, ~livestock_cat, ~item, ~prod_n,
+    2000, "A", "Pigs", "Meat", 30,
+    2000, "A", "Pigs", "Offals", 10
+  )
+
+  excretion_n <- tibble::tribble(
+    ~year, ~province_name, ~livestock_cat, ~excretion_n,
+    2000, "A", "Pigs", 55
+  )
+
+  out <- .combine_nue_livestock(intake_n, prod_n, excretion_n)
+
+  expect_equal(nrow(out), 2)
+
+  # Mass balance is a single category-level value: excretion counted once.
+  # (sum(products) + excretion) / feed = (30 + 10 + 55) / 100.
+  expect_equal(unique(out$mass_balance), (30 + 10 + 55) / 100)
+
+  # Per-item nue is a valid decomposition summing to total products / feed.
+  expect_equal(sum(out$nue), (30 + 10) / 100 * 100)
+})
+
 # calculate_system_nue
 test_that("calculate_system_nue computes system NUE correctly", {
   soil_inputs <- tibble::tribble(


### PR DESCRIPTION
## Summary

`calculate_nue_livestock` (`R/n_soil_inputs_nue.R`) double-counted excretion in the `mass_balance` diagnostic via a join fan-out:

- `intake_n` (feed N) is keyed by `(year, province_name, livestock_cat)`.
- `prod_n` (product N) is keyed by `(..., livestock_cat, item)`.
- The `inner_join` on 3 keys fanned `feed_n` out to one row per item, and the subsequent `left_join(excretion_n)` (category-level) duplicated the **full** `excretion_n` onto every item row.

For multi-item categories (e.g. Pigs → meat + offals + fats), each row got `mass_balance = (this_item_prod_n + FULL_excretion_n) / feed_n`. No row equalled the true `(Σ products + excretion) / feed`, and summing rows counted excretion `k` times.

## Fix

- Extracted `.combine_nue_livestock()` for testability.
- `mass_balance` is now computed at the `(year, province_name, livestock_cat)` level as `(sum(prod_n) + excretion_n) / feed_n` via a grouped `mutate(.by = ...)`, so excretion is counted exactly once.
- Per-item `nue = prod_n / feed_n * 100` is unchanged (a valid per-item decomposition).

## Test

Added `.combine_nue_livestock does not double-count excretion` in `tests/testthat/test_n_soil_inputs_nue.R`: a Pigs category with two produced items (a fan-out case). Asserts `mass_balance` is a single category-level value `(30 + 10 + 55) / 100 = 0.95` and that per-item `nue` sums to total products / feed. Verified passing.

Closes #199

🤖 Generated with [Claude Code](https://claude.com/claude-code)