### PR TITLE
fix(tests): green CRAN suite — correct stale CBS "known-failing" note

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -78,7 +78,7 @@ The PR must pass these GitHub Actions checks:
    - To verify: compare `ls man/*.Rd` topics against `_pkgdown.yml` contents. Every `.Rd` file (except `whep-package.Rd`) must have a matching entry.
    - Run locally: `Rscript -e "pkgdown::build_reference_index()"`
 
-5. **Tests**: `devtools::test()` — 2 pre-existing failures in `test_commodity_balance_sheet.R` are expected (pin format, `skip_on_ci`).
+5. **Tests**: `devtools::test()` — the whole suite must be 100% green (a failing test is a hard `R CMD check --as-cran` ERROR). `test_commodity_balance_sheet.R` uses small self-contained fixtures (no pins, no network) and passes.
 
 ## Before committing
 


### PR DESCRIPTION
Closes #185

## Summary

Issue #185 flagged that `CLAUDE.md` documented "2 pre-existing failures in `test_commodity_balance_sheet.R` (pin format, `skip_on_ci`)" as expected — and that a failing test is a hard `R CMD check --as-cran` ERROR blocking CRAN.

**Verification first.** I ran the CBS file and the full suite locally via `pkgload::load_all()` + `testthat::test_dir(stop_on_failure = FALSE)`:

- `test_commodity_balance_sheet.R`: all tests pass.
- Full suite: **3052 pass / 0 fail / 0 error / 1 skip** (the sole skip is `test_harmonize.R:85`, reason "On CRAN").

The suite is already 100% green. The CBS tests were rewritten from remote pins to small self-contained fixtures in commit `d41b02b` ("Make tests use small fixtures instead of remote data") and no longer touch pins or the network — exactly as the issue suspected. The "2 known failures" note is stale.

## What changed

Corrected the stale note at `CLAUDE.md` line 81 so it no longer implies red tests are acceptable, and states the suite must be 100% green.

## What I deliberately did NOT do

I did not add `skip` guards to `test_commodity_balance_sheet.R`. Those tests run offline and pass; skipping passing tests would silently hide working coverage and fabricate a failure that does not exist. Per the issue's own guidance ("fix it, don't skip") and the CRAN green-suite gate, the correct action is to keep the tests running and correct the misleading documentation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)