### PR TITLE
fix(faostat): remove \dontrun from get_faostat_data() via offline example fixture

### DIFF
--- a/R/scrape_faostat.R
+++ b/R/scrape_faostat.R
@@ -1,4 +1,4 @@
-#' Scrapes activity_data from FAOSTAT and slightly post-processes it
+#' Scrape activity data from FAOSTAT and post-process it
 #'
 #' @description
 #' Important: Dynamically allows for the introduction of subsets as `"..."`.
@@ -10,17 +10,22 @@
 #'   to be one of `c('livestock','crop_area','crop_yield','crop_production')`.
 #' @param ... can be whichever column name from `get_faostat_bulk`,
 #'   particularly `year`, `area` or `ISO3_CODE`.
+#' @param example Logical. If `TRUE`, return a small hardcoded example
+#'   `tibble` instead of scraping FAOSTAT. Useful for offline demos and
+#'   documentation. Default `FALSE`.
 #'
-#' @returns `data.frame` of FAOSTAT for `activity_data`; default is for
-#'   all years and countries.
+#' @returns `tibble` of FAOSTAT for `activity_data` with columns `area`,
+#'   `item`, `element`, `year`, `value`, `unit` and `ISO3_CODE`; default is
+#'   for all years and countries.
 #'
 #' @export
 #'
 #' @examples
-#' \dontrun{
-#' get_faostat_data("livestock", year = 2010, area = "Portugal")
-#' }
-get_faostat_data <- function(activity_data, ...) {
+#' get_faostat_data(example = TRUE)
+get_faostat_data <- function(activity_data, ..., example = FALSE) {
+  if (example) {
+    return(.example_get_faostat_data())
+  }
   # Some functions from FAOSTAT pkg don't work by only using prefixed functions.
   # It is detached again at the end of this function call.
   # Also this is another way to write require("FAOSTAT") without triggering

--- a/R/toy_examples.R
+++ b/R/toy_examples.R
@@ -515,3 +515,19 @@
     137L, 2732L, 18430, "grazing_feed_allocation"
   )
 }
+
+.example_get_faostat_data <- function() {
+  tibble::tribble(
+    ~area, ~item, ~element, ~year, ~value, ~unit, ~ISO3_CODE,
+    "Portugal", "Asses", "stocks", 2010L, 1500, "An", "PRT",
+    "Portugal", "Cattle, dairy", "stocks", 2010L, 245000, "An", "PRT",
+    "Portugal", "Cattle, non-dairy", "stocks", 2010L, 1180000, "An", "PRT",
+    "Portugal", "Chickens, broilers", "stocks", 2010L, 27000, "1000 An", "PRT",
+    "Portugal", "Goats", "stocks", 2010L, 412000, "An", "PRT",
+    "Portugal", "Horses", "stocks", 2010L, 22000, "An", "PRT",
+    "Portugal", "Mules and hinnies", "stocks", 2010L, 3200, "An", "PRT",
+    "Portugal", "Sheep", "stocks", 2010L, 2230000, "An", "PRT",
+    "Portugal", "Swine, breeding", "stocks", 2010L, 340000, "An", "PRT",
+    "Portugal", "Swine, market", "stocks", 2010L, 1980000, "An", "PRT"
+  )
+}

--- a/man/get_faostat_data.Rd
+++ b/man/get_faostat_data.Rd
@@ -2,9 +2,9 @@
 % Please edit documentation in R/scrape_faostat.R
 \name{get_faostat_data}
 \alias{get_faostat_data}
-\title{Scrapes activity_data from FAOSTAT and slightly post-processes it}
+\title{Scrape activity data from FAOSTAT and post-process it}
 \usage{
-get_faostat_data(activity_data, ...)
+get_faostat_data(activity_data, ..., example = FALSE)
 }
 \arguments{
 \item{activity_data}{activity data required from FAOSTAT; needs
@@ -12,10 +12,15 @@ to be one of \code{c('livestock','crop_area','crop_yield','crop_production')}.}
 
 \item{...}{can be whichever column name from \code{get_faostat_bulk},
 particularly \code{year}, \code{area} or \code{ISO3_CODE}.}
+
+\item{example}{Logical. If \code{TRUE}, return a small hardcoded example
+\code{tibble} instead of scraping FAOSTAT. Useful for offline demos and
+documentation. Default \code{FALSE}.}
 }
 \value{
-\code{data.frame} of FAOSTAT for \code{activity_data}; default is for
-all years and countries.
+\code{tibble} of FAOSTAT for \code{activity_data} with columns \code{area},
+\code{item}, \code{element}, \code{year}, \code{value}, \code{unit} and \code{ISO3_CODE}; default is
+for all years and countries.
 }
 \description{
 Important: Dynamically allows for the introduction of subsets as \code{"..."}.
@@ -24,7 +29,5 @@ Note: overhead by individually scraping FAOSTAT code QCL for crop data;
 it's fine.
 }
 \examples{
-\dontrun{
-get_faostat_data("livestock", year = 2010, area = "Portugal")
-}
+get_faostat_data(example = TRUE)
 }

--- a/tests/testthat/test_scrape_faostat.R
+++ b/tests/testthat/test_scrape_faostat.R
@@ -36,6 +36,19 @@ testthat::test_that(".activity_data_choices returns expected values", {
   testthat::expect_true("crop_production" %in% choices)
 })
 
+testthat::test_that("get_faostat_data(example = TRUE) returns offline fixture", {
+  result <- whep::get_faostat_data(example = TRUE)
+
+  testthat::expect_s3_class(result, "tbl_df")
+  testthat::expect_named(
+    result,
+    c("area", "item", "element", "year", "value", "unit", "ISO3_CODE")
+  )
+  testthat::expect_type(result$value, "double")
+  testthat::expect_type(result$year, "integer")
+  testthat::expect_gt(nrow(result), 0)
+})
+
 testthat::test_that(".bad_activity_data_param_error returns helpful message", {
   msg <- .bad_activity_data_param_error()
 


### PR DESCRIPTION
## Summary

Closes #186.

`get_faostat_data()` wrapped its example in `\dontrun{}`, which the project's `CLAUDE.md` forbids and which means the example never runs in CI — the wrapped call hits the live FAOSTAT bulk API.

This PR applies the package's established `example = FALSE` pattern:

- Add an `example` argument to `get_faostat_data()` that short-circuits to a small hardcoded tibble fixture `.example_get_faostat_data()` in `R/toy_examples.R` (Portugal 2010 livestock stocks, 10 rows), matching the real output schema `area, item, element, year, value, unit, ISO3_CODE`.
- Change the `@examples` block to `get_faostat_data(example = TRUE)` (no `\dontrun`); the example now runs offline during `R CMD check`.
- Fix the `@return` doc: the function returns a `tibble` (`tibble::as_tibble()` on the last line), not a `data.frame`.
- Make the title imperative per the documentation rules.
- Add a test covering the offline fixture schema and types.

The real function could not be run to sample rows (no network in this environment), so the fixture was constructed faithfully from the real column schema, derived by reading the function body and `FAOSTAT::fillCountryCode` (which `merge`s the `ISO3_CODE` column onto the subset `c("area","item","element","year","value","unit")`).

## Verification

- `air format .`, `devtools::document()` run.
- `.Rd` regenerated without `\dontrun`.
- `get_faostat_data(example = TRUE)` returns a 10x7 tibble offline.
- `test_scrape_faostat.R`: all 25 assertions pass.
- `lintr` (CI config): no lints on changed files.
- pkgdown `reference:` entry for `get_faostat_data` already present.

🤖 Generated with [Claude Code](https://claude.com/claude-code)