### PR TITLE
fix(footprint_balance): surface extension-only land and abort on NA extension

### DIFF
--- a/R/footprint_balance.R
+++ b/R/footprint_balance.R
@@ -63,8 +63,16 @@ compute_footprint_balance <- function(production, trade, extension) {
     c("area_code", "item_cbs_code", "value"),
     "extension"
   )
+  .require_finite_value(production, "production")
+  .require_finite_value(trade, "trade")
+  .require_finite_value(extension, "extension")
+  .warn_orphan_land(production, trade, extension)
 
-  items <- sort(unique(c(production$item_cbs_code, trade$item_cbs_code)))
+  items <- sort(unique(c(
+    production$item_cbs_code,
+    trade$item_cbs_code,
+    extension$item_cbs_code
+  )))
   purrr::map(items, \(it) {
     .balance_one_item(
       production[production$item_cbs_code == it, ],
@@ -221,7 +229,12 @@ build_land_balance_footprint <- function(
 # --- Helpers ---
 
 .balance_one_item <- function(prod_i, trade_i, ext_i, item) {
-  areas <- sort(unique(c(prod_i$area_code, trade_i$from_code, trade_i$to_code)))
+  areas <- sort(unique(c(
+    prod_i$area_code,
+    trade_i$from_code,
+    trade_i$to_code,
+    ext_i$area_code
+  )))
   if (length(areas) == 0) {
     return(.empty_balance())
   }
@@ -367,4 +380,39 @@ build_land_balance_footprint <- function(
   if (!is.numeric(year) || length(year) != 1 || is.na(year)) {
     cli::cli_abort("{.arg year} must be a single number.")
   }
+}
+
+# A non-finite land value silently propagates through solve() and
+# wipes the whole item's solution, so reject NA/NaN/Inf loudly.
+.require_finite_value <- function(data, name) {
+  if (nrow(data) > 0 && any(!is.finite(data$value))) {
+    cli::cli_abort(
+      "{.arg {name}} column {.field value} must be finite (no NA/NaN/Inf)."
+    )
+  }
+}
+
+# Direct land whose (item_cbs_code, area_code) has no production and
+# no trade cannot carry a balance footprint and would vanish; surface
+# it instead of dropping it silently.
+.warn_orphan_land <- function(production, trade, extension) {
+  support <- dplyr::bind_rows(
+    dplyr::distinct(production, item_cbs_code, area_code),
+    dplyr::distinct(trade, item_cbs_code, area_code = from_code),
+    dplyr::distinct(trade, item_cbs_code, area_code = to_code)
+  ) |>
+    dplyr::distinct()
+  orphan <- extension |>
+    dplyr::filter(value > 0) |>
+    dplyr::anti_join(support, by = c("item_cbs_code", "area_code"))
+  if (nrow(orphan) == 0) {
+    return(invisible())
+  }
+  items <- sort(unique(orphan$item_cbs_code))
+  cli::cli_warn(c(
+    "!" = "Dropped {nrow(orphan)} extension land record{?s} \\
+           ({round(sum(orphan$value))} units total) with no production \\
+           or trade support from the balance footprint.",
+    "i" = "Affected item_cbs_code: {items}."
+  ))
 }

--- a/tests/testthat/test_footprint_balance.R
+++ b/tests/testthat/test_footprint_balance.R
@@ -79,6 +79,37 @@ testthat::test_that("land balance validates inputs", {
   )
 })
 
+testthat::test_that("balance surfaces extension land without prod/trade", {
+  inp <- .balance_inputs()
+  # Country 5 has 100 ha of land for item 99 but no production and no
+  # trade of it: the balance cannot route it and used to drop it silently.
+  ext <- dplyr::bind_rows(
+    inp$extension,
+    tibble::tibble(area_code = 5L, item_cbs_code = 99L, value = 100)
+  )
+  testthat::expect_warning(
+    fp <- whep::compute_footprint_balance(inp$production, inp$trade, ext),
+    "no production or trade support"
+  )
+  # The supported item keeps all its direct land (30 + 20 = 50 ha) and
+  # the unsupported land is not silently folded into another item.
+  testthat::expect_false(99L %in% fp$item_cbs_code)
+  testthat::expect_equal(sort(fp$value), c(20, 30))
+  testthat::expect_equal(sum(dplyr::filter(fp, item_cbs_code == 10L)$value), 50)
+})
+
+testthat::test_that("balance aborts on NA extension rather than wiping item", {
+  inp <- .balance_inputs()
+  # A single NA land value used to make solve() return an all-NA vector,
+  # silently erasing item 10 for every country. It must abort loudly.
+  ext <- inp$extension
+  ext$value[1] <- NA_real_
+  testthat::expect_error(
+    whep::compute_footprint_balance(inp$production, inp$trade, ext),
+    "finite"
+  )
+})
+
 testthat::test_that("compare_footprint_methods reports differences", {
   a <- tibble::tibble(
     area_code = c(1L, 2L),


### PR DESCRIPTION
## Summary

Fixes two silent data-loss bugs in the land-balance footprint (`R/footprint_balance.R`), the independent conservation cross-check for the Leontief footprint. Both are silent, so both erode exactly the trust the method is meant to provide.

## #194 — extension-only items/areas silently drop direct land

**Root cause.** The item universe was `unique(c(production$item_cbs_code, trade$item_cbs_code))` and the per-item area universe `unique(c(prod_i$area_code, trade_i$from_code, trade_i$to_code))`. The `extension` table fed neither. So any country with direct land (e.g. CROPGRIDS harvested area) but zero/missing FAOSTAT production and no trade of that item had its land vanish with no signal. Grass is safeguarded (production is derived from the extension); crops are not.

**Fix.** Include the extension's `item_cbs_code` / `area_code` in both universes, and add `.warn_orphan_land()`, which emits a `cli::cli_warn()` listing any extension land whose `(item_cbs_code, area_code)` has no production or trade support. Such land cannot carry a balance intensity (zero supply throughput) and is still dropped from the estimate, but now loudly and with the offending items named, instead of silently.

## #204 — one NA in the extension deletes an item's footprint worldwide

**Root cause.** `.vec_by_area()` used `tapply(..., sum)` with no `na.rm`, so a single NA extension value produced an NA-laden `L`. `solve(a_sys, l_act)` then returned an all-NA vector (LAPACK propagates NA) *without erroring*, so the `tryCatch` never fired, and `filter(value > 0)` dropped that item's footprint for **every** country with no warning.

**Fix.** Validate up front (`.require_finite_value()`) that the `value` columns of `production`, `trade` and `extension` are finite, aborting with a clear `cli::cli_abort()`. This converts the silent worldwide wipe into a loud, actionable error.

## Tests

Extended `tests/testthat/test_footprint_balance.R`:
- extension-only land (item present only in the extension, no production/trade) triggers the warning while the supported item keeps all its direct land — fails on old code, which was silent;
- an NA extension value aborts with a finiteness error instead of silently erasing the item worldwide.

Full `test_footprint_balance.R` passes (27 tests); `air format .` and `lintr` (project linter set) are clean. No exported signatures or roxygen changed, so no `man/` or `_pkgdown.yml` updates; all NSE columns were already in `globalVariables`.

Closes #194
Closes #204

🤖 Generated with [Claude Code](https://claude.com/claude-code)