### PR TITLE
fix(footprint): reconcile sparse/dense paths and validate fd_labels

### DIFF
--- a/R/footprint.R
+++ b/R/footprint.R
@@ -21,6 +21,16 @@
 #' entirely and reducing memory from \eqn{O(n^2)} to
 #' \eqn{O(nnz)}.
 #'
+#' The `z_mat` and `l_inv` paths give identical results while the
+#' largest column sum of A stays below 1 (the Leontief inverse is
+#' then non-negative). At or above 1 the paths can diverge: the dense
+#' inverse zeroes negative entries whereas the sparse solve drops the
+#' resulting negative embodied flows, and a precomputed `l_inv` may
+#' have been capped differently (`compute_leontief_inverse()` defaults
+#' to a conservative cap below 1). The `z_mat` path emits a warning
+#' when this happens; `max_column_sum` is ignored when `l_inv` is
+#' supplied directly.
+#'
 #' @param l_inv Leontief inverse matrix from
 #'   [compute_leontief_inverse()]. Ignored when `z_mat` is
 #'   provided.
@@ -125,6 +135,7 @@ compute_footprint <- function(
     max_column_sum,
     conserve_extensions
   )
+  .validate_fd_labels(fd_labels, y_mat)
   if (!rlang::is_bool(report_conservation)) {
     cli::cli_abort("{.arg report_conservation} must be `TRUE` or `FALSE`.")
   }
@@ -158,6 +169,7 @@ compute_footprint <- function(
       value_added_floor = value_added_floor,
       max_column_sum = max_column_sum
     )
+    .warn_sparse_dense_divergence(a_mat)
     ia <- Matrix::Diagonal(n) - a_mat
     lu_fact <- .factor_ia(ia)
     multiply_fn <- function(rhs) f_diag %*% Matrix::solve(lu_fact, rhs)
@@ -505,6 +517,34 @@ compute_footprint <- function(
   )
 }
 
+# --- Sparse-vs-dense reconciliation ---
+
+# Warn when the sparse solve cannot be reconciled with the dense
+# `l_inv` path. For a non-negative A the spectral radius is bounded
+# above by the largest column sum, so a largest column sum below 1
+# guarantees a non-negative Leontief inverse and both paths agree
+# exactly (given the same A). A column sum >= 1 admits a spectral
+# radius >= 1, where the implied inverse can hold negative entries:
+# the dense path (`compute_leontief_inverse()`) zeroes them, while the
+# sparse solve instead drops the resulting negative embodied flows.
+# The two paths then diverge, so this must not be silent (issue #193).
+.warn_sparse_dense_divergence <- function(a_mat) {
+  max_col_sum <- max(Matrix::colSums(a_mat))
+  if (is.finite(max_col_sum) && max_col_sum >= 1) {
+    cli::cli_warn(c(
+      "!" = "Sparse {.arg z_mat} solve may diverge from the dense
+        {.arg l_inv} path.",
+      "i" = "Largest A column sum is {signif(max_col_sum, 4)} (>= 1),
+        so the implied Leontief inverse can contain negative entries.",
+      "i" = "The dense path zeroes them; the sparse path drops the
+        resulting negative embodied flows, giving different footprints.",
+      "i" = "Below 1 the paths agree exactly. Build {.arg l_inv} with the
+        same {.arg max_column_sum} to compare like for like."
+    ))
+  }
+  invisible(a_mat)
+}
+
 # --- Sparse LU factorisation with regularisation ---
 
 # Factor (I - A) with a very small diagonal regularisation as a
@@ -579,6 +619,23 @@ compute_footprint <- function(
   ) {
     cli::cli_abort("{.arg conserve_extensions} must be `TRUE` or `FALSE`.")
   }
+}
+
+.validate_fd_labels <- function(fd_labels, y_mat) {
+  if (is.null(fd_labels)) {
+    return(invisible())
+  }
+  n_fd <- ncol(y_mat)
+  if (nrow(fd_labels) != n_fd) {
+    cli::cli_abort(c(
+      "{.arg fd_labels} must have one row per {.arg y_mat} column.",
+      "x" = "{.arg fd_labels} has {nrow(fd_labels)} row{?s} but
+        {.arg y_mat} has {n_fd} column{?s}.",
+      "i" = "A stale or wrong-year {.arg fd_labels} would otherwise
+        silently yield rows with missing target labels."
+    ))
+  }
+  invisible()
 }
 
 .validate_square_mat <- function(mat, n, name) {

--- a/man/compute_footprint.Rd
+++ b/man/compute_footprint.Rd
@@ -109,6 +109,16 @@ For large systems, pass \code{z_mat} and \code{x_vec} instead of
 sparse LU factorisation, avoiding the dense Leontief inverse
 entirely and reducing memory from \eqn{O(n^2)} to
 \eqn{O(nnz)}.
+
+The \code{z_mat} and \code{l_inv} paths give identical results while the
+largest column sum of A stays below 1 (the Leontief inverse is
+then non-negative). At or above 1 the paths can diverge: the dense
+inverse zeroes negative entries whereas the sparse solve drops the
+resulting negative embodied flows, and a precomputed \code{l_inv} may
+have been capped differently (\code{compute_leontief_inverse()} defaults
+to a conservative cap below 1). The \code{z_mat} path emits a warning
+when this happens; \code{max_column_sum} is ignored when \code{l_inv} is
+supplied directly.
 }
 \examples{
 z_mat <- matrix(c(0, 5, 10, 0), nrow = 2)

--- a/tests/testthat/test_footprint.R
+++ b/tests/testthat/test_footprint.R
@@ -248,6 +248,96 @@ testthat::test_that("sparse path (z_mat) matches dense path (l_inv)", {
   testthat::expect_equal(nrow(sparse), nrow(dense))
 })
 
+testthat::test_that("sparse and dense paths agree when A stays productive", {
+  # Column sums of A are 0.13 and 0.14 (< 1), so L is non-negative and
+  # the two paths must produce identical footprints, not just equal sums.
+  f <- footprint_2sector_fixture()
+
+  dense <- compute_footprint(
+    f$l_inv,
+    f$x,
+    f$y,
+    f$extensions,
+    f$labels
+  )
+  sparse <- testthat::expect_no_warning(
+    compute_footprint(
+      x_vec = f$x,
+      y_mat = f$y,
+      extensions = f$extensions,
+      labels = f$labels,
+      z_mat = f$z
+    )
+  )
+
+  key <- c("origin_area", "origin_item", "target_area", "target_item")
+  dense <- dplyr::arrange(dense, dplyr::across(dplyr::all_of(key)))
+  sparse <- dplyr::arrange(sparse, dplyr::across(dplyr::all_of(key)))
+
+  testthat::expect_equal(sparse, dense, tolerance = 1e-8)
+})
+
+testthat::test_that("sparse path warns when A column sum reaches 1", {
+  # A column 2 sums to 1.3 (>= 1): the sparse solve can diverge from a
+  # dense l_inv, so the divergence must be signalled, not silent.
+  z <- matrix(c(0, 0, 70, 60), nrow = 2)
+  x <- c(100, 100)
+  y <- matrix(c(40, 50), ncol = 1)
+  extensions <- c(20, 10)
+  labels <- tibble::tibble(
+    area_code = c(1L, 1L),
+    item_cbs_code = c(10L, 20L)
+  )
+
+  testthat::expect_warning(
+    compute_footprint(
+      x_vec = x,
+      y_mat = y,
+      extensions = extensions,
+      labels = labels,
+      z_mat = z
+    ),
+    "may diverge"
+  )
+})
+
+testthat::test_that("fd_labels length must match ncol(y_mat)", {
+  z <- matrix(
+    c(5, 2, 1, 0, 3, 1, 0, 2, 0, 1, 4, 0, 1, 0, 1, 3),
+    nrow = 4,
+    byrow = TRUE
+  )
+  y <- matrix(
+    c(30, 20, 10, 5, 25, 15, 8, 3),
+    nrow = 4,
+    ncol = 4
+  )
+  x <- rowSums(z) + rowSums(y)
+  l_inv <- compute_leontief_inverse(z, x)
+  extensions <- c(10, 5, 8, 3)
+  labels <- tibble::tibble(
+    area_code = c(1L, 1L, 2L, 2L),
+    item_cbs_code = c(10L, 20L, 10L, 20L)
+  )
+  # Only 2 rows for 4 Y columns: stale/wrong-year fd_labels.
+  fd_labels <- tibble::tibble(
+    area_code = c(1L, 2L),
+    fd_col = c("food", "food")
+  )
+
+  testthat::expect_error(
+    compute_footprint(
+      l_inv,
+      x,
+      y,
+      extensions,
+      labels,
+      fd_labels = fd_labels
+    ),
+    "one row per"
+  )
+})
+
 testthat::test_that("sparse path caps closed sectors with value_added_floor", {
   z <- Matrix::sparseMatrix(
     i = 1,


### PR DESCRIPTION
## Summary

Fixes two bugs in `R/footprint.R` (`compute_footprint()`).

### #193 — sparse (`z_mat`) vs dense (`l_inv`) paths diverge silently

The two paths cap A differently by default (100 for the physical-biomass sparse path vs ~0.999 for `compute_leontief_inverse()`) and handle negatives differently (dense zeroes negative Leontief-inverse entries; the sparse LU solve instead drops negative embodied flows). Those numeric defaults are deliberate — the `100` cap was introduced on purpose for physical biomass systems (commit "Allow higher physical input coefficients") and the conservative leontief cap is pinned by `test_leontief.R` and assumed by `balance.R` — so forcing one cap or aborting would break the pipeline.

Instead this makes the divergence **non-silent** and provable:

- For a non-negative A, the spectral radius is bounded above by the largest column sum. **Below 1**, the Leontief inverse is non-negative and both paths produce **identical** results (new test asserts full tibble equality, not just matching sums).
- **At or above 1**, the inverse can contain negatives the two paths treat differently, so the `z_mat` path now emits a `cli::cli_warn()` explaining the divergence and how to compare like-for-like.
- The `@description` documents the discrepancy, including that `max_column_sum` is ignored when `l_inv` is supplied directly.

### #205 — `fd_labels` length never validated against `ncol(y_mat)`

Added `.validate_fd_labels()`: aborts with a clear `cli::cli_abort()` when `nrow(fd_labels) != ncol(y_mat)`, instead of indexing out of bounds and silently emitting rows with `NA` target labels.

## Tests

Added to `tests/testthat/test_footprint.R` (repo convention is one test file per R script; the script is `footprint.R`):
- sparse and dense paths agree exactly (full tibble) when A stays productive, with no warning;
- the `z_mat` path warns when an A column sum reaches 1;
- mismatched `fd_labels` length aborts.

`test_footprint.R`: 42 pass / 0 fail / 0 warn. `test_leontief.R` unchanged and green. `air format` and `lintr` (project config) clean; `devtools::document()` refreshed `man/compute_footprint.Rd`.

Closes #193
Closes #205

🤖 Generated with [Claude Code](https://claude.com/claude-code)