### PR TITLE
fix(gapfilling): make documented "var:group" proxy syntax reachable

### DIFF
--- a/R/gapfilling.R
+++ b/R/gapfilling.R
@@ -1915,6 +1915,11 @@ fill_proxy_growth <- function(
 }
 
 .parse_proxy_spec <- function(spec, data, value_col, group_by, verbose) {
+  # Advanced grouped syntax "variable:group1+group2" (optional "[weight]").
+  if (grepl(":", spec)) {
+    return(.parse_grouped_proxy_spec(spec, data))
+  }
+
   weight_col <- NULL
   col_name <- spec
   if (grepl("\\[", spec)) {
@@ -1970,30 +1975,15 @@ fill_proxy_growth <- function(
           if (!is.null(weight_col)) "_w" else ""
         )
       ))
-    } else {
-      if (verbose) {
-        message(
-          "Auto-detected '",
-          col_name,
-          "' as categorical -> ",
-          "using as grouping variable"
-        )
-      }
-      return(list(
-        source_var = value_col,
-        group_vars = col_name,
-        present_group_vars = present(col_name),
-        weight_col = weight_col,
-        spec_name = paste0(
-          value_col,
-          "_",
-          col_name,
-          if (!is.null(weight_col)) "_w" else ""
-        )
-      ))
     }
-  } else {
-    warning("Column '", col_name, "' not found in data")
+    if (verbose) {
+      message(
+        "Auto-detected '",
+        col_name,
+        "' as categorical -> ",
+        "using as grouping variable"
+      )
+    }
     return(list(
       source_var = value_col,
       group_vars = col_name,
@@ -2008,10 +1998,28 @@ fill_proxy_growth <- function(
     ))
   }
 
-  parts <- strsplit(spec, ":")[[1]]
-  source_var <- parts[1]
-  rhs <- if (length(parts) > 1) parts[2] else ""
+  cli::cli_warn("Column {.val {col_name}} not found in data.")
+  list(
+    source_var = value_col,
+    group_vars = col_name,
+    present_group_vars = present(col_name),
+    weight_col = weight_col,
+    spec_name = paste0(
+      value_col,
+      "_",
+      col_name,
+      if (!is.null(weight_col)) "_w" else ""
+    )
+  )
+}
 
+# Parse the advanced "variable:group1+group2[weight]" proxy syntax, where the
+# growth reference is `variable` aggregated over the `+`-separated grouping
+# columns (optionally weighted by `weight`).
+.parse_grouped_proxy_spec <- function(spec, data) {
+  parts <- strsplit(spec, ":")[[1]]
+  source_var <- trimws(parts[1])
+  rhs <- if (length(parts) > 1) parts[2] else ""
   if (is.na(rhs)) {
     rhs <- ""
   }
@@ -2043,7 +2051,7 @@ fill_proxy_growth <- function(
   list(
     source_var = source_var,
     group_vars = group_vars,
-    present_group_vars = present(group_vars),
+    present_group_vars = intersect(group_vars, names(data)),
     weight_col = weight_col,
     spec_name = spec_name
   )

--- a/tests/testthat/test_gapfilling.R
+++ b/tests/testthat/test_gapfilling.R
@@ -748,6 +748,48 @@ test_that("fill_proxy_growth works with grouping", {
   expect_false(is.na(fra_filled))
 })
 
+test_that("fill_proxy_growth groups proxy growth by region (var:group)", {
+  # Advanced "variable:group" syntax: growth is taken from `gdp` aggregated
+  # over `region`, not from the value column's own series. ESP and FRA share
+  # region "EU", so ESP's gaps are backfilled with the region-mean gdp growth
+  # (mean of the two countries' growths), not ESP's own gdp growth.
+  data <- tibble::tribble(
+    ~region, ~country, ~year, ~value, ~gdp,
+    "EU", "ESP", 2000, NA, 100,
+    "EU", "ESP", 2001, NA, 120,
+    "EU", "ESP", 2002, 500, 150,
+    "EU", "FRA", 2000, 1000, 200,
+    "EU", "FRA", 2001, 1200, 260,
+    "EU", "FRA", 2002, 1400, 299
+  )
+
+  result <- fill_proxy_growth(
+    data,
+    value_col = value,
+    proxy_col = "gdp:region",
+    .by = "country",
+    verbose = FALSE
+  )
+
+  # Region-mean gdp growth: 2001 = mean(0.20, 0.30) = 0.25;
+  # 2002 = mean(0.25, 0.15) = 0.20. Backfill from the 2002 anchor (500):
+  #   value_2001 = 500 / 1.20; value_2000 = value_2001 / 1.25.
+  esp <- result |>
+    dplyr::filter(country == "ESP") |>
+    dplyr::arrange(year)
+
+  expect_equal(esp$value[esp$year == 2001], 500 / 1.20, tolerance = 1e-6)
+  expect_equal(
+    esp$value[esp$year == 2000],
+    500 / (1.20 * 1.25),
+    tolerance = 1e-6
+  )
+
+  # The region-grouped result must differ from ESP's own-gdp backfill, which
+  # would give 500 / 1.25 for 2001. This confirms growth is grouped by region.
+  expect_false(isTRUE(all.equal(esp$value[esp$year == 2001], 500 / 1.25)))
+})
+
 test_that("fill_proxy_growth extrapolates per group, not across groups", {
   # Regression: .parse_proxy_spec used to return `group_vars` while
   # downstream code read `present_group_vars` (unset), collapsing all


### PR DESCRIPTION
## What

Closes #150.

`.parse_proxy_spec()` in `R/gapfilling.R` documented an advanced `"variable:group"` (and `"variable:group[weight]"`) proxy syntax for `fill_proxy_growth()`, but the `col_name %in% names(data)` if/else block returned in **every** branch, so the `strsplit(spec, ":")` parser below it was unreachable dead code.

As a result, `fill_proxy_growth(..., proxy_col = "gdp:region")` fell into the not-found `else` branch: it emitted a base `warning()`, silently set `source_var` to the value column itself, and used `group_vars = "gdp:region"` (a column that does not exist). Growth was therefore computed from the target series aggregated **globally** instead of from regional GDP — silently wrong.

## Fix

- Dispatch to a dedicated `.parse_grouped_proxy_spec()` helper whenever the spec contains `:`, **before** the column-name check. The previously-dead advanced parser now runs and returns the correct `source_var`, `group_vars`, `present_group_vars`, `weight_col`, and `spec_name`.
- Replace the base `warning()` in the not-found branch with `cli::cli_warn()` per project style.

The documented `"var:group"` behaviour now works end-to-end.

## Test

Added `fill_proxy_growth groups proxy growth by region (var:group)` in `tests/testthat/test_gapfilling.R`: with `proxy_col = "gdp:region"` and two countries sharing a region, each country's gaps are backfilled from the region-mean GDP growth (0.25 / 0.20), yielding `500 / 1.20` and `500 / (1.20 * 1.25)` — and asserted to differ from the country's own-GDP backfill, confirming growth is grouped by region.

All 48 `test_gapfilling.R` tests pass (141 assertions, 0 failures). `lintr` clean, `air`-formatted.

## Out of scope

The weighted grouped form `"var:group[weight]"` is now reachable too, but surfaces two independent, pre-existing bugs in the weighted branch of `.fg_growth_aggregate()` (a `setnames(c("V1","V2"))` mismatch, since data.table auto-names the returned columns `g_val`/`o_val`; and a weight `shift()` grouped by the coarse group that crosses the finer boundary and drops the first row's weight). These also affect the already-documented simple `"gdp[weight]"` form and are unrelated to the reachability defect in #150 (noted there as "Related to #131"); they should be fixed and tested separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)