### PR TITLE
fix(n_prov_destiny): take seed only from the Product row (#147)

### DIFF
--- a/R/n_prov_destiny.R
+++ b/R/n_prov_destiny.R
@@ -625,7 +625,12 @@ create_n_nat_destiny <- function(example = FALSE) {
       Seeds_used_MgFM = Area_ha * dplyr::coalesce(Seed_rate_per_ha, 0)
     )
 
-  # Substracting the Seed data from Production in grafs_prod_combined.
+  # Subtract seed from production. Seed is grain, so it comes out of the
+  # `Product` stream only: `grafs_prod_combined` also carries `Residue` and
+  # `Grass` rows for the same (Year, Province_name, Item), and the join attaches
+  # the same per-item seed mass to every one of them. Subtracting from all three
+  # removed up to ~2x the real seed use and understated residue biomass, and the
+  # 50% cap was likewise applied per row against the wrong denominator (#147).
   grafs_prod_combined_no_seeds <- grafs_prod_combined |>
     dplyr::left_join(
       seed_rates |>
@@ -635,9 +640,13 @@ create_n_nat_destiny <- function(example = FALSE) {
     dplyr::mutate(
       Seeds_used_MgFM = dplyr::coalesce(Seeds_used_MgFM, 0),
       Seeds_used_capped = dplyr::if_else(
-        Seeds_used_MgFM > 0.5 * production_fm,
-        0.5 * production_fm,
-        Seeds_used_MgFM
+        prod_type == "Product",
+        dplyr::if_else(
+          Seeds_used_MgFM > 0.5 * production_fm,
+          0.5 * production_fm,
+          Seeds_used_MgFM
+        ),
+        0
       ),
       production_fm = production_fm - Seeds_used_capped
     ) |>

--- a/tests/testthat/test_n_prov_destiny.R
+++ b/tests/testthat/test_n_prov_destiny.R
@@ -919,9 +919,9 @@ test_that(".remove_seeds_from_system subtracts seed and applies 50% cap", {
   )
 
   prod <- tibble::tribble(
-    ~Year, ~Province_name, ~Item, ~production_fm,
-    2000, "A", "Wheat", 300,
-    2000, "B", "Wheat", 30
+    ~Year, ~Province_name, ~Item, ~prod_type, ~production_fm,
+    2000, "A", "Wheat", "Product", 300,
+    2000, "B", "Wheat", "Product", 30
   )
 
   res <- .remove_seeds_from_system(npp, pie_seed, prod)
@@ -955,8 +955,8 @@ test_that(".remove_seeds_from_system caps at 50% when seeds exceed prod", {
   )
 
   prod <- tibble::tribble(
-    ~Year, ~Province_name, ~Item, ~production_fm,
-    2000, "A", "Wheat", 10
+    ~Year, ~Province_name, ~Item, ~prod_type, ~production_fm,
+    2000, "A", "Wheat", "Product", 10
   )
 
   out <- .remove_seeds_from_system(npp, pie_seed, prod)
@@ -976,13 +976,73 @@ test_that(".remove_seeds_from_system leaves non-seed items unchanged", {
   )
 
   prod <- tibble::tribble(
-    ~Year, ~Province_name, ~Item, ~production_fm,
-    2000, "A", "Barley", 200
+    ~Year, ~Province_name, ~Item, ~prod_type, ~production_fm,
+    2000, "A", "Barley", "Product", 200
   )
 
   out <- .remove_seeds_from_system(npp, pie_seed, prod)
 
   expect_equal(out$production_fm, 200)
+})
+
+
+test_that(".remove_seeds_from_system takes seed only from the Product row", {
+  # Seed is grain. `grafs_prod_combined` carries Residue and Grass rows for the
+  # same (Year, Province_name, Item), and the join attaches the same per-item
+  # seed mass to each, so subtracting from all three removed ~3x the real seed
+  # use here and understated residue and grass biomass (#147).
+  npp <- tibble::tribble(
+    ~Year, ~Province_name, ~Item, ~Area_ygpit_ha, ~LandUse,
+    2000, "A", "Wheat", 100, "Cropland"
+  )
+
+  pie_seed <- tibble::tribble(
+    ~Year, ~Item, ~Element, ~Destiny, ~Value_destiny,
+    2000, "Wheat", "Domestic_supply", "Seed", 10
+  )
+
+  prod <- tibble::tribble(
+    ~Year, ~Province_name, ~Item, ~prod_type, ~production_fm,
+    2000, "A", "Wheat", "Product", 100,
+    2000, "A", "Wheat", "Residue", 80,
+    2000, "A", "Wheat", "Grass", 60
+  )
+
+  out <- .remove_seeds_from_system(npp, pie_seed, prod)
+  got <- function(type) out$production_fm[out$prod_type == type]
+
+  # Only the Product row loses the 10 Mg of seed.
+  expect_equal(got("Product"), 90)
+  expect_equal(got("Residue"), 80)
+  expect_equal(got("Grass"), 60)
+
+  # Total removed is the seed used exactly once, not once per prod_type.
+  expect_equal(sum(prod$production_fm) - sum(out$production_fm), 10)
+})
+
+test_that(".remove_seeds_from_system caps against the Product row alone", {
+  # The 50% cap must bind on the Product row's own production, not be applied
+  # separately to each prod_type against its own denominator.
+  npp <- tibble::tribble(
+    ~Year, ~Province_name, ~Item, ~Area_ygpit_ha, ~LandUse,
+    2000, "A", "Wheat", 1, "Cropland"
+  )
+
+  pie_seed <- tibble::tribble(
+    ~Year, ~Item, ~Element, ~Destiny, ~Value_destiny,
+    2000, "Wheat", "Domestic_supply", "Seed", 1000
+  )
+
+  prod <- tibble::tribble(
+    ~Year, ~Province_name, ~Item, ~prod_type, ~production_fm,
+    2000, "A", "Wheat", "Product", 10,
+    2000, "A", "Wheat", "Residue", 40
+  )
+
+  out <- .remove_seeds_from_system(npp, pie_seed, prod)
+
+  expect_equal(out$production_fm[out$prod_type == "Product"], 5)
+  expect_equal(out$production_fm[out$prod_type == "Residue"], 40)
 })
 
 


### PR DESCRIPTION
Rebased onto current `main` and **rescoped** — see the scope note below.

**Classification: mechanical.** Mass conservation; no defensible alternative.

## The bug (#147)

Seed is grain, so it comes out of the product stream. But `grafs_prod_combined`
carries `Residue` and `Grass` rows for the same
`(Year, Province_name, Item)`, and the per-item seed mass is joined onto **every
one of them**. Both the subtraction and the 50% cap then ran once per
`prod_type`:

- up to ~3x the real seed use removed (once per row, not once per item), and
- residue and grass biomass understated, with the cap binding against the wrong
  denominator.

## The fix

Restrict the subtraction and the cap to `prod_type == "Product"`.

## Evidence

Two new tests, both failing on `main` and passing with the fix:

| | `n_prov_destiny` |
| --- | --- |
| without the fix | **4 failed**, 117 pass |
| with the fix | **0 failed, 121 pass** |

- *takes seed only from the Product row* — Product 100 → 90, Residue 80 and
  Grass 60 untouched, and total removed equals the seed used exactly once (10),
  not once per `prod_type`.
- *caps against the Product row alone* — the 50% cap binds on the Product row's
  own production and leaves Residue alone.

Full suite **6377 pass, 0 failed, 0 errors**.

The three existing fixtures gained a `prod_type` column. They were incomplete
rather than wrong — the real input always carries it, since `.add_grass_wood()`
consumes it immediately downstream — and all three were already exercising the
Product path, so their expectations are unchanged.

## Scope note: the #239 half is dropped, not deferred

This PR originally also fixed **#239** (the inter-provincial N leak in
`create_n_nat_destiny()`), with a 246-line rewrite into five helpers. **That
defect is no longer present on `main`**, so the rewrite has been dropped rather
than replayed into code that has moved underneath it.

Both mechanisms #239 describes are gone:

| #239 said | on `main` today |
| --- | --- |
| national consumption kept only locally-produced rows (`nat_core`, `origin != "Outside"`), so inter-provincial N vanished | `nat_consumption` applies **no `Origin` filter** — the only `Origin` filter is `Origin == Box`, on the *production* path |
| imports/exports re-derived per `(year, item, box, irrig_cat)`, so `irrig_cat = NA` rows never cancelled | netting is `pmax(production - consumption, 0)` on `nat_balance`, keyed on **`(Year, Item)` only** — no `Irrig_cat` |

Main also keeps the domestic share (`local = pmin(production, demand)`) and
turns only the genuine shortfall into an `Outside` import, which is what the
original PR argued for.

**Caveat:** this was verified by reading `main`'s implementation, not by running
the A→B provincial trace the original PR described — that needs provincial data
that is not wired up here. The two mechanisms are unambiguously absent from the
code, but that is inspection, not execution. #239 should be closed against
`main`'s current implementation rather than against this branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)