### PR TITLE
fix(cbs): wire historical trade into pre-1961 CBS extension

### DIFF
--- a/R/build_cbs.R
+++ b/R/build_cbs.R
@@ -739,25 +739,32 @@ build_processing_coefs <- function(
     .(item_cbs, item_cbs_code)
   ]
   cbs_trade <- data.table::as.data.table(whep::cbs_trade_codes)
+  # Map the ISO3 reporter to the polity area code only. The human-readable
+  # area name is derived from the code afterwards (see below) so it matches
+  # the primary-production naming convention exactly, rather than trusting a
+  # potentially multi-valued name carried alongside the code.
   area_bridge <- .current_area_lookup(include_unmapped = FALSE)[
     !is.na(area_iso3c),
-    .(iso3c = area_iso3c, area = area_name, area_code = polity_area_code)
+    .(iso3c = area_iso3c, area_code = polity_area_code)
   ]
   area_bridge <- unique(area_bridge, by = "iso3c")
 
+  # The exports pin holds reporter exports and the imports pin holds reporter
+  # imports (verified against FAOSTAT 1961 overlap values), so label them
+  # directly. An earlier version mirrored the flows, which reversed direction.
   exports <- .read_input(
     "historical-trade-exports",
     years = years,
     year_col = "year"
   )
-  exports[, element := "import"]
+  exports[, element := "export"]
 
   imports <- .read_input(
     "historical-trade-imports",
     years = years,
     year_col = "year"
   )
-  imports[, element := "export"]
+  imports[, element := "import"]
 
   dt <- data.table::rbindlist(
     list(exports, imports),
@@ -781,11 +788,18 @@ build_processing_coefs <- function(
   dt <- merge(dt, cbs_trade, by = "item_code_trade", all.x = TRUE, sort = FALSE)
   dt <- merge(dt, items, by = "item_cbs", all.x = TRUE, sort = FALSE)
 
+  dt <- dt[!is.na(area_code)]
   dt <- dt[,
     .(value = sum(value, na.rm = TRUE)),
-    by = c("year", "area", "area_code", "item_cbs", "item_cbs_code", "element")
+    by = c("year", "area_code", "item_cbs", "item_cbs_code", "element")
   ]
   dt[, unit := "tonnes"]
+
+  # Derive the area name from the code so it matches the convention used by
+  # primary production, which is what the pre-1961 extension joins against.
+  dt <- add_area_name(dt) |>
+    data.table::as.data.table()
+  data.table::setnames(dt, "area_name", "area")
   dt[!is.na(area)]
 }
 
@@ -1545,8 +1559,12 @@ build_processing_coefs <- function(
   trade <- traded_res
   trade[, source := "FAOSTAT_trade"]
 
+  # Historical (pre-1961) trade evidence. FAOSTAT trade begins in 1961, so
+  # this is the only import/export source feeding the pre-1961 extension.
+  trade_hist <- .prepare_trade_hist_source(inputs$trade_hist)
+
   dt <- data.table::rbindlist(
-    list(fbs_new, fbs_old, cbs, primary, trade),
+    list(fbs_new, fbs_old, cbs, primary, trade, trade_hist),
     use.names = TRUE,
     fill = TRUE
   )
@@ -1565,6 +1583,19 @@ build_processing_coefs <- function(
   dt_pp[, element := "processing_primary"]
 
   data.table::rbindlist(list(dt, dt_pp), use.names = TRUE, fill = TRUE)
+}
+
+# Label historical trade with its source and restrict it to the pre-1961
+# extension window. Keeping it out of the FAOSTAT era (>= 1961) avoids mixing
+# it with the polity-name convention those sources use.
+.prepare_trade_hist_source <- function(trade_hist) {
+  if (is.null(trade_hist) || nrow(trade_hist) == 0L) {
+    return(data.table::data.table())
+  }
+  dt <- data.table::as.data.table(trade_hist)
+  dt <- dt[year < 1961L]
+  data.table::set(dt, j = "source", value = "trade_hist")
+  dt
 }
 
 .select_best_source <- function(cbs_raw_all) {

--- a/tests/testthat/test_build_cbs.R
+++ b/tests/testthat/test_build_cbs.R
@@ -474,6 +474,129 @@ test_that(".cbs_extend_historical preserves observed historical sources", {
 })
 
 
+# -- historical trade wiring (issue #141) -------------------------------------
+
+.empty_cbs_component <- function() {
+  # Internal CBS helpers receive data.tables in production; mirror that here.
+  data.table::data.table(
+    year = integer(),
+    area = character(),
+    area_code = integer(),
+    item_cbs = character(),
+    item_cbs_code = integer(),
+    element = character(),
+    value = numeric(),
+    unit = character()
+  )
+}
+
+.make_trade_hist_inputs <- function(with_trade_hist = TRUE) {
+  primary_cbs <- data.table::data.table(
+    year = 1950L,
+    area = "Spain",
+    area_code = 203L,
+    item_cbs = "Wheat and products",
+    item_cbs_code = 2511L,
+    element = "production",
+    value = 5000,
+    unit = "tonnes"
+  )
+  trade_hist <- tibble::tribble(
+    ~year, ~area, ~area_code, ~item_cbs, ~item_cbs_code, ~element, ~value,
+    ~unit,
+    1950L, "Spain", 203L, "Wheat and products", 2511L, "import", 700,
+    "tonnes",
+    1950L, "Spain", 203L, "Wheat and products", 2511L, "export", 200,
+    "tonnes"
+  ) |>
+    data.table::as.data.table()
+  list(
+    fbs_new = .empty_cbs_component(),
+    fbs_old = .empty_cbs_component(),
+    cbs_animals = .empty_cbs_component(),
+    cbs_crops = .empty_cbs_component(),
+    primary_cbs = primary_cbs,
+    crop_residues = .empty_cbs_component(),
+    trade_hist = if (with_trade_hist) trade_hist else NULL
+  )
+}
+
+test_that(".assemble_cbs_sources binds historical trade under its source", {
+  inputs <- .make_trade_hist_inputs()
+  empty <- .empty_cbs_component()
+
+  result <- whep:::.assemble_cbs_sources(
+    inputs,
+    empty,
+    empty,
+    empty,
+    whep::items_full
+  )
+
+  hist_rows <- result |>
+    dplyr::filter(.data$source == "trade_hist")
+  expect_equal(nrow(hist_rows), 2L)
+  expect_setequal(hist_rows$element, c("import", "export"))
+  expect_equal(
+    hist_rows |> dplyr::filter(element == "import") |> dplyr::pull(value),
+    700
+  )
+})
+
+test_that("historical trade reaches pre-1961 CBS import/domestic supply", {
+  ext_inputs <- list(
+    primary_cbs_area = tibble::tibble(
+      year = 1950L,
+      area = "Spain",
+      area_code = 203L,
+      item_cbs = "Wheat and products",
+      item_cbs_code = 2511L,
+      area_ha = 1
+    ),
+    gdp_pop = tibble::tibble(year = 1950L, area = "Spain", pop = 10),
+    land_areas_wide = tibble::tibble(
+      year = 1950L,
+      area = "Spain",
+      Cropland = 1,
+      Pasture = 0,
+      agriland = 1
+    )
+  )
+  empty <- .empty_cbs_component()
+
+  run_extension <- function(with_trade_hist) {
+    inputs <- .make_trade_hist_inputs(with_trade_hist)
+    whep:::.assemble_cbs_sources(
+      inputs,
+      empty,
+      empty,
+      empty,
+      whep::items_full
+    ) |>
+      whep:::.select_best_source() |>
+      tibble::as_tibble() |>
+      whep:::.cbs_extend_historical(ext_inputs, 1950L)
+  }
+
+  value_1950 <- function(ext, el) {
+    ext |>
+      dplyr::filter(.data$year == 1950L, .data$element == el) |>
+      dplyr::pull(value)
+  }
+
+  with_hist <- run_extension(TRUE)
+  expect_equal(value_1950(with_hist, "import"), 700)
+  expect_equal(value_1950(with_hist, "export"), 200)
+  # Domestic supply is production plus imports minus exports: 5000 + 700 - 200.
+  expect_equal(value_1950(with_hist, "domestic_supply"), 5500)
+
+  # Without historical trade, pre-1961 has no import/export evidence at all.
+  without_hist <- run_extension(FALSE)
+  expect_length(value_1950(without_hist, "import"), 0L)
+  expect_length(value_1950(without_hist, "domestic_supply"), 0L)
+})
+
+
 # -- .format_cbs_output -------------------------------------------------------
 
 test_that(".format_cbs_output returns long format with source column", {


### PR DESCRIPTION
Closes #141.

## Problem

`.read_historical_trade()` was read into `inputs$trade_hist` but `.assemble_cbs_sources()` only bound `fbs_new, fbs_old, cbs, primary, trade`. No row ever carried `source == "trade_hist"`, so the exclusion guard at `.assemble_cbs_sources()` never matched and the pre-1961 import/export extension was **silently dead**: for `start_year < 1962`, historical import/export evidence was downloaded (two pins) and discarded.

## What this does

- **Wires it in.** `trade_hist` is now bound into the assembled sources under the `trade_hist` source label (via a small `.prepare_trade_hist_source()` helper), restricted to years `< 1961` so the FAOSTAT era (>= 1961) is untouched. This is the only import/export source feeding the pre-1961 extension, and it now flows through `.select_best_source()` into the historical destiny/domestic-supply fill.
- **Resolves the flow-direction question flagged in the issue.** The read function previously labelled the exports pin `element := "import"` and the imports pin `element := "export"`. Checked against the 1961 FAOSTAT overlap: the exports pin gives USA wheat ≈ 19.2 Mt (a known ~17-19 Mt exporter) vs ≈ 0.2 Mt on the imports pin, and Egypt (importer) ≈ 0.4 vs ≈ 661. So it is a genuine direction swap, not a mirror-flow convention — the flows are now labelled directly.
- **Avoids the naming-convention trap.** `trade_hist` carried an `area_name` alongside its polity `area_code`, and one polity code could receive several ISO3-derived names. Historical trade is now aggregated by integer `area_code` only, and the area name is derived from the code via `add_area_name()` — the same convention primary production uses, which is what the extension joins production against.

## Verification

Exercised against the real cached pins and with a fixture through `assemble -> select -> extend`: with historical trade a 1950 wheat row gains `import`, `export`, and `domestic_supply = production + import - export`; without it those elements are absent (pre-1961 previously had no import/export evidence). New tests in `test_build_cbs.R` assert both.

`devtools::test()` on `test_build_cbs.R`: all pass, no warnings. `lintr` clean on both changed files. `air format .` applied.

## Scope / remaining

Kept scoped to wiring the input in (open PRs #292 and #284 touch other `build_cbs.R` functions). For edge polities where the legacy production `area_code` differs from the polity `area_code`, historical trade may not align with production and simply won't contribute — no double-count, no regression vs. the previous behaviour (where it never contributed at all).

🤖 Generated with [Claude Code](https://claude.com/claude-code)