### PR TITLE
fix(scripts): point MIRCA country-areas regen at prepare_spatialize_all.R

### DIFF
--- a/inst/scripts/update_country_areas_mirca.R
+++ b/inst/scripts/update_country_areas_mirca.R
@@ -3,12 +3,12 @@
 #
 # Re-generates country_areas.parquet with MIRCA2000 irrigation fractions.
 # This is a lightweight alternative to re-running the full
-# prepare_spatialize_inputs.R — it only regenerates the country_areas
+# prepare_spatialize_all.R — it only regenerates the country_areas
 # output, using the existing MIRCA, LUH2, and FAOSTAT data.
 #
 # Prerequisites:
 #   - mirca_irrigation_country.parquet (from prepare_mirca_inputs.R)
-#   - country_grid.parquet (from prepare_spatialize_inputs.R)
+#   - country_grid.parquet (from prepare_spatialize_all.R)
 # -----------------------------------------------------------------------
 
 library(dplyr, warn.conflicts = FALSE)
@@ -23,7 +23,13 @@ target_res <- 0.5
 # We extract just what we need: prepare_country_areas and its helpers
 local({
   # Read the whole script source
-  lines <- readLines("inst/scripts/prepare_spatialize_inputs.R")
+  prepare_script <- "inst/scripts/prepare_spatialize_all.R"
+  if (!file.exists(prepare_script)) {
+    cli::cli_abort(
+      "{.file {prepare_script}} not found. Run this script from the package root."
+    )
+  }
+  lines <- readLines(prepare_script)
 
   # Find the Main execution line and cut before it
   main_line <- grep("^# ==== Main execution", lines)


### PR DESCRIPTION
## What

`inst/scripts/update_country_areas_mirca.R` did `readLines("inst/scripts/prepare_spatialize_inputs.R")`, but that file does not exist. The prepare pipeline is `inst/scripts/prepare_spatialize_all.R`, which contains `prepare_country_areas()` and the `# ==== Main execution` marker the script greps for.

## Fix

- Point the `readLines()` at `inst/scripts/prepare_spatialize_all.R` (verified: `prepare_country_areas()` at line 983, `# ==== Main execution` marker at line 5393).
- Update the two stale doc comments that also named the nonexistent script.
- Add a `file.exists()` guard that aborts via `cli::cli_abort()` with a clear message if the script is run outside the package root, instead of a bare `readLines()` error.

Closes #254

🤖 Generated with [Claude Code](https://claude.com/claude-code)