### PR TITLE
fix(livestock): land transported manure within documented land_use domain

### DIFF
--- a/R/build_livestock_nutrient_flows.R
+++ b/R/build_livestock_nutrient_flows.R
@@ -226,13 +226,17 @@ build_livestock_nutrient_flows <- function(
 
 # Replace each source cell's retained surplus with the transport outcome:
 # manure delivered to neighbours, plus the un-transportable remainder disposed
-# locally per the caller's disposal method.
+# locally per the caller's disposal method. Transported manure fills the sink
+# cells' remaining cropland-plus-grassland room; only collected manure is ever
+# transported (in-situ grazing is not), so it lands as "Cropland" to stay within
+# the documented land_use domain, matching the "over_apply_local" disposal fate.
+# Its transported origin is still recorded in source_stream.
 .fold_transport <- function(local, flows, alloc_methods) {
   opt <- .allocate_options(alloc_methods)
   kept <- dplyr::filter(local, .data$land_use != "Unallocated")
   transported <- flows |>
     dplyr::filter(.data$kind == "transported") |>
-    .transport_landing("transported", FALSE)
+    .transport_landing("Cropland", FALSE)
   residual <- flows |>
     dplyr::filter(.data$kind == "residual") |>
     .transport_landing(

--- a/tests/testthat/test_build_livestock_nutrient_flows.R
+++ b/tests/testthat/test_build_livestock_nutrient_flows.R
@@ -193,6 +193,10 @@ test_that("subnational run transports surplus between cells and conserves N", {
   # Some collected manure originating in "1.5_40" is transported to "1_40".
   expect_true("transported" %in% res$applied$source_stream)
   expect_true(all(res$applied$method_transport == "room_weighted"))
+  # No row escapes the documented land_use domain: transported manure lands as
+  # "Cropland", never the internal "transported" label (issue #202).
+  land_use_domain <- c("Cropland", "Grassland", "Disposal", "Unallocated")
+  expect_true(all(res$applied$land_use %in% land_use_domain))
   # Provenance is scalar-correct on every row, including transported/disposed
   # rows: the caller's disposal choice, not the internal retain_unallocated pass.
   expect_true(all(res$applied$disposal_method == "over_apply_local"))


### PR DESCRIPTION
## What

`build_livestock_nutrient_flows()` (subnational resolution) emitted transported manure with `land_use = "transported"`, a value outside the documented output domain of `allocate_manure_to_land` (`Cropland` / `Grassland` / `Disposal` / `Unallocated`).

## Why it matters

Every transported tonne of N landed with `land_use = "transported"` and `crop = NA`, never attributed to cropland or grassland. Downstream soil steps that filter or join on `land_use %in% c("Cropland", "Grassland")` silently dropped all transported manure — the mass was present but mis-categorised, an output-contract violation on the `"subnational"` path.

## Fix

In `.fold_transport`, transported manure now lands as `"Cropland"` instead of the literal `"transported"`. Rationale:

- Transported manure fills sink cells' remaining **cropland-plus-grassland room**.
- Only **collected** manure is ever transported (in-situ grazing deposition is not), and collected manure's primary application target is cropland.
- This matches the `over_apply_local` disposal fate, which also lands on `"Cropland"`.
- The transported origin remains recorded in `source_stream = "transported"`, so no provenance is lost.

Added a test asserting no output row carries an out-of-domain `land_use` value.

## Test status

`test_build_livestock_nutrient_flows.R` passes (17 assertions, 0 failures), including the new domain check.

Closes #202

🤖 Generated with [Claude Code](https://claude.com/claude-code)