### PR TITLE
fix(manure): exempt in-situ grazing stream from storage C:N cap

### DIFF
--- a/R/manure_management.R
+++ b/R/manure_management.R
@@ -126,6 +126,8 @@ split_manure_management <- function(excretion, options = list()) {
 #' `applied_n` times the post-storage manure C:N (the solid/liquid/excreta value
 #' for the stream's management system), so the applied C:N reflects storage, not
 #' fresh excreta; the carbon and volatile-solids storage losses follow from that.
+#' The grazing stream undergoes no storage and keeps its full carbon and volatile
+#' solids (no storage C:N cap is applied to it).
 #'
 #' @param split A tibble from [split_manure_management()].
 #' @param options A named list. `method` selects the loss method
@@ -213,7 +215,11 @@ apply_management_losses <- function(split, options = list()) {
 
   out |>
     dplyr::mutate(
-      applied_c = pmin(.data$c_stream, .data$applied_n * .data$cn_post),
+      applied_c = dplyr::if_else(
+        .data$stream == "grazing",
+        .data$c_stream,
+        pmin(.data$c_stream, .data$applied_n * .data$cn_post)
+      ),
       c_lost = .data$c_stream - .data$applied_c,
       applied_vs = dplyr::if_else(
         .data$c_stream > 0,

--- a/man/apply_management_losses.Rd
+++ b/man/apply_management_losses.Rd
@@ -29,6 +29,8 @@ nitrogen (the same N is not removed twice). Carbon applied to the field is
 \code{applied_n} times the post-storage manure C:N (the solid/liquid/excreta value
 for the stream's management system), so the applied C:N reflects storage, not
 fresh excreta; the carbon and volatile-solids storage losses follow from that.
+The grazing stream undergoes no storage and keeps its full carbon and volatile
+solids (no storage C:N cap is applied to it).
 }
 \examples{
 excretion <- tibble::tribble(

--- a/tests/testthat/test_manure_management.R
+++ b/tests/testthat/test_manure_management.R
@@ -140,6 +140,37 @@ test_that("apply_management_losses conserves C and VS, applied C:N post-storage"
   expect_false(isTRUE(all.equal(coll_cn, rep(excreta_cn[1], length(coll_cn)))))
 })
 
+test_that("grazing retains full C and VS even above storage C:N cap", {
+  # Sheep Excreta C:N is 12.4; feed a high-C:N excretion (C:N = 25) so the
+  # storage cap would bite the grazing stream if it were applied. It must not:
+  # the in-situ stream undergoes no storage and keeps its full C and VS.
+  high_cn <- tibble::tribble(
+    ~year,
+    ~territory,
+    ~sub_territory,
+    ~livestock_category,
+    ~n_excretion,
+    ~c_excretion,
+    ~vs_excretion,
+    2020L,
+    "ES",
+    NA,
+    "Sheep",
+    100,
+    2500,
+    200
+  )
+  res <- whep::apply_management_losses(
+    whep::split_manure_management(high_cn)
+  )
+  graz <- res[res$stream == "grazing", ]
+  frac <- graz$applied_n / 100
+  expect_true(all(abs(graz$applied_c - 2500 * frac) < 1e-8))
+  expect_true(all(abs(graz$applied_vs - 200 * frac) < 1e-8))
+  expect_true(all(abs(graz$c_lost) < 1e-8))
+  expect_true(all(abs(graz$vs_destroyed) < 1e-8))
+})
+
 test_that("apply_management_losses guards bad input", {
   ok <- whep::split_manure_management(.toy_excretion())
   expect_error(


### PR DESCRIPTION
## What

`apply_management_losses()` (`R/manure_management.R`) applied the post-storage C:N cap `applied_c = pmin(c_stream, applied_n * cn_post)` and the coupled VS scaling to **every** row, including the grazing (`stream == "grazing"`, Pasture/Range/Paddock) stream.

## Why it matters

Grazing manure is deposited in situ and undergoes no storage, yet its carbon and volatile solids were being capped. When upstream fresh-excreta C:N exceeded the tabulated Excreta C:N, the excess C (and proportional VS) was booked as `c_lost` / `vs_destroyed` and never reached the soil. Verified: Sheep with `n=100, c=2500, vs=200` (C:N 25) at 100% grazing, Excreta C:N 12.4 → the old code destroyed ~1260 kg C and ~100 kg VS for a stream that has no storage stage. Nitrogen was already correctly protected.

## Fix

Skip the storage C:N cap for `stream == "grazing"` so it carries full `c_stream` / `vs_stream`. The existing VS coupling (`vs_stream * applied_c / c_stream`) then yields full VS automatically, keeping the diff minimal. Docstring updated to state the grazing stream keeps its full carbon and volatile solids.

## Verification

- Ran the real pipeline on the high-C:N Sheep case: grazing now retains full C (2500) and VS (200), `c_lost = 0`, `vs_destroyed = 0`, mass conserved.
- Added a regression test in `tests/testthat/test_manure_management.R`.
- `testthat::test_file` on the file: 33 passing, 0 failures. Lint clean on the changed file.

Closes #197

🤖 Generated with [Claude Code](https://claude.com/claude-code)