### PR TITLE
fix(diagnostics): revive dead CBS diagnostic scripts on long schema

### DIFF
--- a/inst/scripts/diagnose_stock_variation.R
+++ b/inst/scripts/diagnose_stock_variation.R
@@ -12,10 +12,22 @@ cat("Building pipeline...\n")
 primary <- whep::build_primary_production()
 cbs <- whep::build_commodity_balances(primary)
 
-# Wide format with all elements
+# CBS is long (element column). Pivot the elements we need to wide so
+# each row is one year-area-item with its stock_variation, domestic_supply
+# and production side by side.
 cbs_wide <- cbs |>
-  dplyr::mutate(stock_variation = -stock_retrieval) |>
-  dplyr::select(-stock_retrieval)
+  dplyr::filter(
+    element %in% c("stock_variation", "domestic_supply", "production")
+  ) |>
+  tidyr::pivot_wider(
+    id_cols = c(year, area_code, item_cbs_code),
+    names_from = element,
+    values_from = value
+  )
+
+# Guarantee the three columns exist even if an element is absent.
+needed <- c("stock_variation", "domestic_supply", "production")
+cbs_wide[setdiff(needed, names(cbs_wide))] <- NA_real_
 
 # Compute SV as share of domestic supply
 cbs_wide <- cbs_wide |>

--- a/inst/scripts/diagnose_trade_imputation.R
+++ b/inst/scripts/diagnose_trade_imputation.R
@@ -22,7 +22,7 @@ cli::cli_h1("Building CBS pipeline")
 primary <- whep::build_primary_production()
 cbs <- whep::build_commodity_balances(primary)
 
-# The CBS output is wide: year, area_code, item_cbs_code, + element columns
+# The CBS output is long: year, area_code, item_cbs_code, element, value.
 # We need to identify which export/import values were imputed.
 # Since .cbs_impute_trade() fills NA trade with DS-production residual,
 # imputed values are those where the original FAOSTAT had no trade data.
@@ -36,14 +36,9 @@ original_trade <- cbs_raw |>
   dplyr::filter(element %in% c("import", "export")) |>
   dplyr::select(year, area_code, item_cbs_code, element, value_original = value)
 
-# Final CBS in long format
+# Final CBS is already long (year, area_code, item_cbs_code, element, value).
 cbs_long <- cbs |>
-  dplyr::mutate(stock_variation = -stock_retrieval, .keep = "unused") |>
-  tidyr::pivot_longer(
-    cols = -c(year, area_code, item_cbs_code),
-    names_to = "element",
-    values_to = "value"
-  )
+  dplyr::select(year, area_code, item_cbs_code, element, value)
 
 # Merge to identify imputed trade
 trade_comparison <- cbs_long |>


### PR DESCRIPTION
## Summary

`inst/scripts/diagnose_stock_variation.R` and `inst/scripts/diagnose_trade_imputation.R` were dead: both assumed a **wide** CBS with a `stock_retrieval` column. `build_commodity_balances()` now returns **long** format (an `element` column plus `value`), so both scripts crashed on `stock_retrieval` not found and produced no validation at all (#262).

## Choice: update, not remove

I chose to **update** rather than delete, because both diagnostics are still genuinely useful QC:

- **Stock-variation coherence** — flags rows where |stock variation| dwarfs domestic supply/production, a real data-quality smell.
- **Trade-imputation validation** — checks imputed exports/imports (from `.cbs_impute_trade()`) against series context and flags implausible values.

Nothing else supersedes them, and `compare_global_whep.R` already treats long format as canonical (it branches on `"element" %in% names(df)`), so aligning these two scripts to the same schema is the consistent fix.

## Changes

- `diagnose_stock_variation.R`: replace the wide-format `-stock_retrieval` construction with a `filter(element %in% ...) |> pivot_wider()` over the three needed elements, plus a vectorised guard that ensures the columns exist. Downstream ratio logic unchanged.
- `diagnose_trade_imputation.R`: the final CBS is already long, so drop the `-stock_retrieval` mutate + `pivot_longer` and select the long columns directly. Pre-imputation read and all downstream joins/plots unchanged.

The stored `stock_variation` element already carries the correct sign, so the old `-stock_retrieval` negation is intentionally dropped.

Formatted with `air`. Scripts parse cleanly. No package `R/` code touched (these are `inst/scripts/` diagnostics), so no docs/NAMESPACE changes.

Closes #262

🤖 Generated with [Claude Code](https://claude.com/claude-code)