### PR TITLE
fix(spatialize): conserve irrigation and area-weight PFT N rates

### DIFF
--- a/inst/scripts/prepare_spatialize_all.R
+++ b/inst/scripts/prepare_spatialize_all.R
@@ -1102,6 +1102,7 @@ prepare_country_areas <- function(
       crop_areas$irrigated_area_ha[needs_fallback] <-
         fallback$irrigated_area_ha
     }
+    crop_areas <- .cap_national_irrigation(crop_areas)
   } else {
     cli::cli_alert_info(
       "MIRCA not found -- using LUH2-proportional irrigation allocation"
@@ -1138,6 +1139,27 @@ prepare_country_areas <- function(
       "harvested_area_ha",
       "irrigated_area_ha"
     )
+}
+
+# Cap summed irrigated area per country-year at the LUH2 national total. MIRCA
+# rescaling makes covered crops absorb the whole national total, so the per-CFT
+# fallback for MIRCA-absent crops would otherwise add irrigation on top of an
+# already-complete allocation (double-counting). Scaling proportionally when the
+# country sum exceeds `total_irrig_ha` conserves the national irrigation total.
+.cap_national_irrigation <- function(crop_areas) {
+  crop_areas |>
+    dplyr::mutate(
+      national_irrig_ha = sum(.data$irrigated_area_ha, na.rm = TRUE),
+      cap_scale = dplyr::if_else(
+        .data$national_irrig_ha > .data$total_irrig_ha &
+          .data$national_irrig_ha > 0,
+        .data$total_irrig_ha / .data$national_irrig_ha,
+        1
+      ),
+      irrigated_area_ha = .data$irrigated_area_ha * .data$cap_scale,
+      .by = c("year", "area_code")
+    ) |>
+    dplyr::select(-"national_irrig_ha", -"cap_scale")
 }
 
 
@@ -4690,6 +4712,23 @@ write_lpjml_static_inputs <- function(
   .pft_nc_write_chunk(nc_lu, out, chunk_years, all_years, grid, 32L)
 }
 
+# Collapse per-crop N rates to LPJmL PFT bands with an area-weighted mean
+# (weight = rainfed_ha + irrigated_ha), mirroring the yields writer. Many crops
+# share one band; a plain mean would bias the band rate toward minor-area crops
+# and break the implied applied-N mass (LPJmL multiplies rate x band area).
+.aggregate_nitrogen_pft <- function(ng) {
+  ng <- data.table::as.data.table(ng)
+  ng[, w := rainfed_ha + irrigated_ha]
+  agg <- ng[
+    w > 0,
+    .(num = sum(kg_n_ha * w, na.rm = TRUE), w_sum = sum(w, na.rm = TRUE)),
+    by = .(year, pft, fert_type, row, col)
+  ]
+  agg[, value := num / w_sum]
+  agg[is.nan(value), value := 0]
+  agg[, .(year, pft, fert_type, row, col, value)]
+}
+
 .write_nitrogen_nc_chunks <- function(
   nc_syn,
   nc_man,
@@ -4701,10 +4740,7 @@ write_lpjml_static_inputs <- function(
 ) {
   ng <- data.table::as.data.table(n_dt)
   ng <- coord_to_rowcol(ng, grid)
-  agg <- ng[,
-    .(value = mean(kg_n_ha, na.rm = TRUE)),
-    by = .(year, pft, fert_type, row, col)
-  ]
+  agg <- .aggregate_nitrogen_pft(ng)
   # Duplicate PFTs 1-16 into 17-32 for irrigated bands (LPJmL expects 32 bands)
   # Convert kgN/ha -> g/m2 (LPJmL expects g/m2)
   rf <- agg[, .(year, pft, row, col, value = value * 0.1, fert_type)]

--- a/tests/testthat/test_prepare_nitrogen.R
+++ b/tests/testthat/test_prepare_nitrogen.R
@@ -144,3 +144,45 @@ test_that(".fill_n_inputs_to_target_year leaves pre-first-obs as NA", {
   # 1920 is the first observed year; backward fill is disabled.
   expect_false(any(out$year < 1920L))
 })
+
+
+test_that(".aggregate_nitrogen_pft area-weights N rates by crop area", {
+  skip_if_not(exists(".aggregate_nitrogen_pft", mode = "function"))
+  # Two crops share PFT band 1 in the same cell: a 100-ha crop at 200 kgN/ha and
+  # a 1-ha crop at 10 kgN/ha. An unweighted mean gives 105; the area-weighted
+  # mean must stay close to the dominant crop's rate.
+  ng <- tibble::tribble(
+    ~year, ~pft, ~fert_type, ~row, ~col, ~kg_n_ha, ~rainfed_ha, ~irrigated_ha,
+    2000L, 1L, "Synthetic", 5L, 7L, 200, 100, 0,
+    2000L, 1L, "Synthetic", 5L, 7L, 10, 1, 0
+  )
+  out <- tibble::as_tibble(.aggregate_nitrogen_pft(ng))
+  expect_equal(nrow(out), 1L)
+  # (200 * 100 + 10 * 1) / (100 + 1) = 20010 / 101
+  expect_equal(out$value, 20010 / 101, tolerance = 1e-9)
+  expect_false(isTRUE(all.equal(out$value, 105)))
+})
+
+test_that(".aggregate_nitrogen_pft conserves total applied N mass", {
+  skip_if_not(exists(".aggregate_nitrogen_pft", mode = "function"))
+  ng <- tibble::tribble(
+    ~year, ~pft, ~fert_type, ~row, ~col, ~kg_n_ha, ~rainfed_ha, ~irrigated_ha,
+    2000L, 1L, "Synthetic", 5L, 7L, 200, 80, 20,
+    2000L, 1L, "Synthetic", 5L, 7L, 10, 1, 0
+  )
+  out <- tibble::as_tibble(.aggregate_nitrogen_pft(ng))
+  total_area <- sum(ng$rainfed_ha + ng$irrigated_ha)
+  mass_in <- sum(ng$kg_n_ha * (ng$rainfed_ha + ng$irrigated_ha))
+  # band rate x band area must reproduce the input applied-N mass
+  expect_equal(out$value * total_area, mass_in, tolerance = 1e-6)
+})
+
+test_that(".aggregate_nitrogen_pft drops zero-area bands and NaN", {
+  skip_if_not(exists(".aggregate_nitrogen_pft", mode = "function"))
+  ng <- tibble::tribble(
+    ~year, ~pft, ~fert_type, ~row, ~col, ~kg_n_ha, ~rainfed_ha, ~irrigated_ha,
+    2000L, 1L, "Synthetic", 5L, 7L, 200, 0, 0
+  )
+  out <- .aggregate_nitrogen_pft(ng)
+  expect_equal(nrow(out), 0L)
+})

--- a/tests/testthat/test_prepare_nitrogen.R
+++ b/tests/testthat/test_prepare_nitrogen.R
@@ -158,7 +158,7 @@ test_that(".aggregate_nitrogen_pft area-weights N rates by crop area", {
   )
   out <- tibble::as_tibble(.aggregate_nitrogen_pft(ng))
   expect_equal(nrow(out), 1L)
-  # (200 * 100 + 10 * 1) / (100 + 1) = 20010 / 101
+  # Area-weighted: 200 over 100 ha and 10 over 1 ha gives 20010 over 101.
   expect_equal(out$value, 20010 / 101, tolerance = 1e-9)
   expect_false(isTRUE(all.equal(out$value, 105)))
 })

--- a/tests/testthat/test_prepare_spatialize_irrigation.R
+++ b/tests/testthat/test_prepare_spatialize_irrigation.R
@@ -1,0 +1,61 @@
+# Smoke tests for the MIRCA irrigation national-cap helper added in
+# inst/scripts/prepare_spatialize_all.R. The helper lives at script scope
+# (not package R/) so we source the script once and exercise it offline.
+
+local({
+  pkg_root <- testthat::test_path("..", "..")
+  script_path <- file.path(
+    pkg_root,
+    "inst",
+    "scripts",
+    "prepare_spatialize_all.R"
+  )
+  if (file.exists(script_path)) {
+    sys.source(script_path, envir = topenv())
+  }
+})
+
+
+test_that(".cap_national_irrigation caps summed irrigation at the total", {
+  skip_if_not(exists(".cap_national_irrigation", mode = "function"))
+  # MIRCA crops already absorb the whole 1000-ha national total; a MIRCA-absent
+  # crop then received an extra 400 ha from the per-CFT fallback -> 1400 total.
+  crop_areas <- tibble::tribble(
+    ~year, ~area_code, ~irrigated_area_ha, ~total_irrig_ha,
+    2000L, 1L, 1000, 1000,
+    2000L, 1L, 400, 1000
+  )
+  out <- .cap_national_irrigation(crop_areas)
+  expect_equal(sum(out$irrigated_area_ha), 1000, tolerance = 1e-9)
+  # scaling is proportional: 1000/1400 and 400/1400 of the total
+  expect_equal(
+    out$irrigated_area_ha,
+    c(1000, 400) * 1000 / 1400,
+    tolerance = 1e-9
+  )
+})
+
+test_that(".cap_national_irrigation leaves within-budget countries untouched", {
+  skip_if_not(exists(".cap_national_irrigation", mode = "function"))
+  crop_areas <- tibble::tribble(
+    ~year, ~area_code, ~irrigated_area_ha, ~total_irrig_ha,
+    2000L, 2L, 300, 1000,
+    2000L, 2L, 200, 1000
+  )
+  out <- .cap_national_irrigation(crop_areas)
+  expect_equal(out$irrigated_area_ha, c(300, 200))
+})
+
+test_that(".cap_national_irrigation caps each country-year independently", {
+  skip_if_not(exists(".cap_national_irrigation", mode = "function"))
+  crop_areas <- tibble::tribble(
+    ~year, ~area_code, ~irrigated_area_ha, ~total_irrig_ha,
+    2000L, 1L, 1000, 1000, # over budget -> scaled
+    2000L, 1L, 1000, 1000,
+    2000L, 2L, 100, 1000 # under budget -> untouched
+  )
+  out <- .cap_national_irrigation(crop_areas)
+  by_country <- tapply(out$irrigated_area_ha, out$area_code, sum)
+  expect_equal(unname(by_country[["1"]]), 1000, tolerance = 1e-9)
+  expect_equal(unname(by_country[["2"]]), 100, tolerance = 1e-9)
+})


### PR DESCRIPTION
Fixes two conservation bugs in the canonical spatial pipeline `inst/scripts/prepare_spatialize_all.R`. Both fixed computations are extracted into pure private helpers with unit tests.

## #258 — MIRCA irrigation double-count (no national cap)

In `prepare_country_areas`, `mirca_scale = total_irrig_ha / mirca_total` rescales the MIRCA-covered crops so they alone absorb the **entire** LUH2 national irrigation total. Crops with no MIRCA fraction in that country then go through the per-CFT fallback and receive an *additional* `crop_share * irrig_ha` slice — additive on top of the MIRCA crops that already hold 100% of the total. The only prior cap was the per-crop `pmin(irrigated, harvested)`, so summed `irrigated_area_ha` could exceed the national total (irrigation not conserved).

Fix: new `.cap_national_irrigation()` helper scales each country-year's summed irrigation down to `total_irrig_ha` when it exceeds it (proportionally, so relative crop shares are preserved). Within-budget countries are untouched; each country-year is capped independently.

## #257 — unweighted mean collapsing N rates to PFT bands

`.write_nitrogen_nc_chunks` collapsed per-crop N rates into LPJmL PFT bands with a plain `mean(kg_n_ha)`. Many `item_prod_code`s share one band (wheat+barley+rye+oats → temperate_cereals, etc.), so a 1-ha crop counted as much as a 100,000-ha crop, biasing band rates toward minor-area crops and breaking the implied applied-N mass (LPJmL applies rate × band-area). The sibling yields writer already area-weights — the asymmetry was the tell.

Fix: new `.aggregate_nitrogen_pft()` helper uses an area-weighted mean `sum(kg_n_ha * w) / sum(w)` with `w = rainfed_ha + irrigated_ha`, identical to the yields writer.

## Tests

- `test_prepare_spatialize_irrigation.R` (new): cap conserves total, leaves within-budget untouched, caps per country-year independently.
- `test_prepare_nitrogen.R`: area-weighting, applied-N mass conservation, zero-area/NaN band drop.

All new tests pass offline (sourced via the existing `sys.source` script-scope pattern). Note: full `rcmdcheck`/suite not run per task scope; the pin/network-backed helpers in the same script remain uncovered as before.

Closes #258
Closes #257

🤖 Generated with [Claude Code](https://claude.com/claude-code)