### PR TITLE
fix(consolidate): real value beats higher-rank NA in winner selection

### DIFF
--- a/R/consolidate_sources.R
+++ b/R/consolidate_sources.R
@@ -28,21 +28,26 @@
 #'   matching `measure$exempt` keep their base rank (for example world-level
 #'   cells, where production equals consumption).
 #'
-#'   3. **Winner selection.** Within each (`.by`, `time_col`) cell the winner is
-#'   the row of lowest effective rank; ties are broken by broader within-series
-#'   coverage (the count of cells the source reports across the `.by` group)
-#'   when `tie_break$coverage`, then by `tie_break$quality_col` ordered per
-#'   `tie_break$quality_levels`, then by ascending source name (reported when
-#'   `verbose`).
+#'   3. **Winner selection.** Within each (`.by`, `time_col`) cell any row with
+#'   a real (non-missing) value outranks every `value_col`-missing row, so a
+#'   higher-priority source's `NA` never discards a lower-priority source's real
+#'   observation; a cell wins `NA` only when no source reports a real value. Among
+#'   rows with a real value the winner is the row of lowest effective rank; ties
+#'   are broken by broader within-series coverage (the count of cells the source
+#'   reports across the `.by` group) when `tie_break$coverage`, then by
+#'   `tie_break$quality_col` ordered per `tie_break$quality_levels`, then by
+#'   ascending source name (reported when `verbose`).
 #'
 #'   4. **Continuity override.** When enabled, an isolated single-period winner
 #'   flip is reverted: if the immediately preceding and following periods share
 #'   a different winner that also reports the middle period, that continuous
 #'   source reclaims the middle cell, removing single-period teeth from
-#'   otherwise smooth series. The reversion is skipped when it would hand a
-#'   cell won by a measure-consistent source back to a measure-demoted one:
-#'   continuity never undoes the measure penalty, because a single-period
-#'   source switch is cosmetic while a measure switch corrupts the series.
+#'   otherwise smooth series. The reversion is skipped when the flanking source's
+#'   middle-period value is itself missing (continuity never reinstates an `NA`)
+#'   and when it would hand a cell won by a measure-consistent source back to a
+#'   measure-demoted one: continuity never undoes the measure penalty, because a
+#'   single-period source switch is cosmetic while a measure switch corrupts the
+#'   series.
 #'
 #'   This operationalises the AFE decision *Consolidate multi-source panels
 #'   measure-consistently* (`wiki/decisions/measure-consistent-panel-consolidation`):
@@ -343,6 +348,7 @@ consolidate_sources <- function(
 
 .cs_add_tiebreaks <- function(work, cols, tie_break) {
   cell_keys <- c(cols$by, cols$time)
+  work$.value_na <- is.na(work[[cols$value]])
   work <- .cs_add_coverage(work, cols$by, cols$source, cols$value, cols$time)
   work$.coverage_ord <- if (tie_break$coverage) work$.coverage else 0L
   work$.quality_rank <- if (is.null(tie_break$quality_col)) {
@@ -394,6 +400,7 @@ consolidate_sources <- function(
 .cs_select_winners <- function(work, cell_keys, source_name, verbose) {
   ordered <- dplyr::arrange(
     work,
+    .value_na,
     .effective_rank,
     dplyr::desc(.coverage_ord),
     .quality_rank,
@@ -409,7 +416,12 @@ consolidate_sources <- function(
 }
 
 .cs_log_name_ties <- function(ordered, cell_keys, source_name) {
-  key_cols <- c(".effective_rank", ".coverage_ord", ".quality_rank")
+  key_cols <- c(
+    ".value_na",
+    ".effective_rank",
+    ".coverage_ord",
+    ".quality_rank"
+  )
   tie <- ordered |>
     dplyr::group_by(dplyr::across(dplyr::all_of(cell_keys))) |>
     dplyr::filter(
@@ -441,6 +453,7 @@ consolidate_sources <- function(
   repl_keys <- iso[cell_keys]
   repl_keys[[cols$source]] <- iso$.neighbor
   repl <- dplyr::inner_join(work, repl_keys, by = c(cell_keys, cols$source))
+  repl <- repl[!repl$.value_na, , drop = FALSE]
   repl <- .cs_block_demoting_reversion(repl, iso, cell_keys)
   if (nrow(repl) == 0L) {
     return(clean)

--- a/R/utils.R
+++ b/R/utils.R
@@ -1263,6 +1263,7 @@ utils::globalVariables(
     "allowlisted",
     "..allow_keys",
     # consolidate_sources.R — winner-selection NSE columns
+    ".value_na",
     ".effective_rank",
     ".coverage_ord",
     ".quality_rank",

--- a/man/consolidate_sources.Rd
+++ b/man/consolidate_sources.Rd
@@ -108,20 +108,25 @@ source loses any cell a measure-consistent source also reports, yet still
 wins a cell it alone reports (a lone reporter is never demoted away). Rows
 matching \code{measure$exempt} keep their base rank (for example world-level
 cells, where production equals consumption).
-\item \strong{Winner selection.} Within each (\code{.by}, \code{time_col}) cell the winner is
-the row of lowest effective rank; ties are broken by broader within-series
-coverage (the count of cells the source reports across the \code{.by} group)
-when \code{tie_break$coverage}, then by \code{tie_break$quality_col} ordered per
-\code{tie_break$quality_levels}, then by ascending source name (reported when
-\code{verbose}).
+\item \strong{Winner selection.} Within each (\code{.by}, \code{time_col}) cell any row with
+a real (non-missing) value outranks every \code{value_col}-missing row, so a
+higher-priority source's \code{NA} never discards a lower-priority source's real
+observation; a cell wins \code{NA} only when no source reports a real value. Among
+rows with a real value the winner is the row of lowest effective rank; ties
+are broken by broader within-series coverage (the count of cells the source
+reports across the \code{.by} group) when \code{tie_break$coverage}, then by
+\code{tie_break$quality_col} ordered per \code{tie_break$quality_levels}, then by
+ascending source name (reported when \code{verbose}).
 \item \strong{Continuity override.} When enabled, an isolated single-period winner
 flip is reverted: if the immediately preceding and following periods share
 a different winner that also reports the middle period, that continuous
 source reclaims the middle cell, removing single-period teeth from
-otherwise smooth series. The reversion is skipped when it would hand a
-cell won by a measure-consistent source back to a measure-demoted one:
-continuity never undoes the measure penalty, because a single-period
-source switch is cosmetic while a measure switch corrupts the series.
+otherwise smooth series. The reversion is skipped when the flanking source's
+middle-period value is itself missing (continuity never reinstates an \code{NA})
+and when it would hand a cell won by a measure-consistent source back to a
+measure-demoted one: continuity never undoes the measure penalty, because a
+single-period source switch is cosmetic while a measure switch corrupts the
+series.
 }
 
 This operationalises the AFE decision \emph{Consolidate multi-source panels

--- a/tests/testthat/test_consolidate_sources.R
+++ b/tests/testthat/test_consolidate_sources.R
@@ -36,6 +36,74 @@ testthat::test_that("consolidate_sources keeps the highest-priority source", {
   testthat::expect_equal(won$source_rank, 1L)
 })
 
+# NA-valued high-rank row never beats a real lower-rank value ------------------
+
+testthat::test_that("a rank-1 NA does not beat a rank-4 real observation", {
+  # OWID (rank 1) reports year 2000 as NA; Malanima (rank 4) reports 20. The
+  # consolidated cell must hold Malanima's real 20, not OWID's NA.
+  panel <- tibble::tribble(
+    ~year, ~region, ~category, ~source, ~value,
+    2000, "WLD", "Coal", "OWID", NA_real_,
+    2000, "WLD", "Coal", "Malanima", 20
+  )
+
+  won <- whep::consolidate_sources(
+    panel,
+    value_col = value,
+    source_col = source,
+    priority = c(OWID = 1L, Malanima = 4L),
+    .by = c("region", "category"),
+    verbose = FALSE
+  )
+
+  testthat::expect_equal(nrow(won), 1L)
+  testthat::expect_equal(won$source, "Malanima")
+  testthat::expect_equal(won$value, 20)
+  testthat::expect_equal(won$source_rank, 4L)
+
+  # A cell wins NA only when every source is missing there.
+  all_na <- tibble::tribble(
+    ~year, ~region, ~category, ~source, ~value,
+    2001, "WLD", "Coal", "OWID", NA_real_,
+    2001, "WLD", "Coal", "Malanima", NA_real_
+  )
+  won_na <- whep::consolidate_sources(
+    all_na,
+    value_col = value,
+    source_col = source,
+    priority = c(OWID = 1L, Malanima = 4L),
+    .by = c("region", "category"),
+    verbose = FALSE
+  )
+  testthat::expect_equal(nrow(won_na), 1L)
+  testthat::expect_true(is.na(won_na$value))
+})
+
+testthat::test_that("continuity override does not reinstate an NA neighbour", {
+  # B (rank 1) wins 1901; A (rank 4) flanks 1900 and 1902 but reports 1901 as
+  # NA. Continuity must not smooth 1901 back to A's NA, so B keeps the cell.
+  panel <- tibble::tribble(
+    ~year, ~region, ~category, ~source, ~value,
+    1900, "WLD", "Coal", "A", 10,
+    1901, "WLD", "Coal", "A", NA_real_,
+    1901, "WLD", "Coal", "B", 99,
+    1902, "WLD", "Coal", "A", 12
+  )
+
+  won <- whep::consolidate_sources(
+    panel,
+    value_col = value,
+    source_col = source,
+    priority = c(B = 1L, A = 4L),
+    .by = c("region", "category"),
+    verbose = FALSE
+  )
+
+  win_1901 <- won[won$year == 1901, ]
+  testthat::expect_equal(win_1901$source, "B")
+  testthat::expect_equal(win_1901$value, 99)
+})
+
 # Coverage tie-break beats alphabetical ----------------------------------------
 
 testthat::test_that("broader coverage breaks an equal-rank tie and beats name order", {


### PR DESCRIPTION
## Summary

`consolidate_sources()` ranked cells by effective rank alone, so a top-priority source's `NA`-valued row won a cell over a lower-priority source's real observation — discarding real data. The continuity override (`R/consolidate_sources.R`) could likewise reinstate an `NA`-valued neighbour row.

Per issue #165: e.g. OWID (rank 1) reports year 2000 as `NA` while Malanima (rank 4) reports 20 → the consolidated panel held `NA` instead of 20.

## Fix

Winner selection is now `NA`-aware:

- A new `.value_na` marker sorts any row with a real (non-missing) value ahead of every value-missing row, before effective rank. A higher-rank `NA` therefore never displaces a lower-rank real value; a cell wins `NA` only when no source reports a real value there.
- The name-tie warning key mirrors this so it no longer flags a real-vs-`NA` pair as a genuine tie.
- The continuity override drops `NA`-valued replacement rows, so it never reinstates a missing flanking value.

Among rows that all carry real values, ranking/coverage/quality/name behaviour is unchanged.

## Tests

Added to `test_consolidate_sources.R`:

- a rank-1 `NA` does not beat a rank-4 real value;
- an all-`NA` cell still yields `NA`;
- continuity keeps the real winner when the flanking neighbour is `NA`.

All `test_consolidate_sources.R` assertions pass (49 PASS, 0 FAIL). `air format` and `lintr` clean; `devtools::document()` regenerated `man/consolidate_sources.Rd`.

Closes #165

🤖 Generated with [Claude Code](https://claude.com/claude-code)