### PR TITLE
fix(footprint): retain grazing land of grazers with no eligible output

### DIFF
--- a/R/footprint_grazing.R
+++ b/R/footprint_grazing.R
@@ -19,7 +19,8 @@
 #' [compute_footprint_balance()]. Because each step redistributes a
 #' total without creating or destroying it, the country-level land
 #' total is conserved whenever an animal fed and produced an output
-#' there.
+#' there. Land fed to animals that produced no eligible output item is
+#' set aside and reported via a warning rather than silently dropped.
 #'
 #' @param grass_land Tibble with `year`, `area_code` and `value`
 #'   (grazing land, e.g. hectares). Multiple rows per country (for
@@ -224,13 +225,19 @@ build_grazing_feed_footprint <- function(
     dplyr::select(year, area_code, live_anim_code, item_cbs_code, output_share)
 }
 
-# Combine the per-animal land with the per-animal output weights.
+# Combine the per-animal land with the per-animal output weights. A left
+# join keeps the land of animals that fed but produced no eligible output
+# item, which an inner join would silently drop; that land is surfaced by
+# .warn_unattributed_output_land() before being set aside.
 .grazing_land_to_products <- function(land_by_animal, weights) {
-  land_by_animal |>
-    dplyr::inner_join(
+  joined <- land_by_animal |>
+    dplyr::left_join(
       weights,
       by = c("year", "area_code", "live_anim_code")
-    ) |>
+    )
+  .warn_unattributed_output_land(land_by_animal, joined)
+  joined |>
+    dplyr::filter(!is.na(item_cbs_code)) |>
     dplyr::summarise(
       value = sum(land_animal * output_share),
       .by = c(year, area_code, item_cbs_code)
@@ -363,6 +370,33 @@ build_grazing_feed_footprint <- function(
       attributed to meat or dairy.",
     "i" = "These areas have grassland but no grazing-animal feed intake to
       hand the land forward to."
+  ))
+  invisible(dropped)
+}
+
+# Surface grazing land handed to animals that fed but produced no eligible
+# output item (e.g. no meat or milk under `products = "meat_milk"`): the
+# product-output join cannot place it on any traded item, so it is set
+# aside rather than silently conserved. Reported, never hidden.
+.warn_unattributed_output_land <- function(land_by_animal, joined) {
+  total <- sum(land_by_animal$land_animal, na.rm = TRUE)
+  if (total <= 0) {
+    return(invisible(NULL))
+  }
+  dropped <- joined |>
+    dplyr::filter(is.na(item_cbs_code)) |>
+    dplyr::distinct(year, area_code, live_anim_code, land_animal)
+  lost <- sum(dropped$land_animal, na.rm = TRUE)
+  if (lost <= 0) {
+    return(invisible(NULL))
+  }
+  areas <- length(unique(dropped$area_code))
+  cli::cli_warn(c(
+    "!" = "{round(100 * lost / total, 1)}% of grazing land is fed to
+      animals in {areas} countr{?y/ies} that produced no eligible output
+      item and cannot be attributed to a product.",
+    "i" = "These grazing animals had forage intake but no matching
+      production of the selected products to hand the land forward to."
   ))
   invisible(dropped)
 }

--- a/man/allocate_grazing_to_products.Rd
+++ b/man/allocate_grazing_to_products.Rd
@@ -58,7 +58,8 @@ item, ready to route to consumers with
 \code{\link[=compute_footprint_balance]{compute_footprint_balance()}}. Because each step redistributes a
 total without creating or destroying it, the country-level land
 total is conserved whenever an animal fed and produced an output
-there.
+there. Land fed to animals that produced no eligible output item is
+set aside and reported via a warning rather than silently dropped.
 }
 \examples{
 grass_land <- tibble::tibble(

--- a/tests/testthat/test_footprint_grazing.R
+++ b/tests/testthat/test_footprint_grazing.R
@@ -98,6 +98,49 @@ testthat::test_that("animals that did not graze receive no land", {
   testthat::expect_equal(sum(out$value), 100)
 })
 
+testthat::test_that("intake without eligible output is surfaced not dropped", {
+  grass_land <- tibble::tibble(year = 2010L, area_code = 1L, value = 100)
+  # Cattle graze 75% of the land and produce milk; sheep graze the other
+  # 25% but produce no eligible output at all. The second-stage join must
+  # not silently drop the sheep's grazing land.
+  grazer_intake <- tibble::tibble(
+    year = 2010L,
+    area_code = 1L,
+    live_anim_code = c(960L, 976L),
+    value = c(75, 25)
+  )
+  production <- tibble::tibble(
+    year = 2010L,
+    area_code = 1L,
+    live_anim_code = 960L,
+    item_cbs_code = 2848L,
+    value = 90
+  )
+  testthat::expect_warning(
+    out <- whep::allocate_grazing_to_products(
+      grass_land,
+      grazer_intake,
+      production
+    ),
+    "25% of grazing land"
+  )
+  # The 25 ha is surfaced by the warning, never attributed to cattle milk
+  # and never left as an NA output item.
+  testthat::expect_false(anyNA(out$item_cbs_code))
+  testthat::expect_equal(sum(out$value), 75)
+})
+
+testthat::test_that("full output coverage stays silent", {
+  inp <- .grazing_inputs()
+  testthat::expect_no_warning(
+    whep::allocate_grazing_to_products(
+      inp$grass_land,
+      inp$grazer_intake,
+      inp$livestock_production
+    )
+  )
+})
+
 testthat::test_that("forward footprint routes grazing land to meat consumers", {
   grass_land <- tibble::tibble(year = 2010L, area_code = 10L, value = 200)
   grazer_intake <- tibble::tibble(


### PR DESCRIPTION
## Problem

Closes #200

`.grazing_land_to_products()` (`R/footprint_grazing.R`) joined per-animal grazing land to per-animal output weights with an **inner_join**. An animal that grazed (has forage intake) but produced no eligible product output lost its land share entirely. With `products = "meat_milk"` the weights are pre-filtered to the meat/milk item codes, so a country whose grazers have intake but no recorded meat/milk production silently lost **all** its grazing land — directly contradicting the function's documented "mass-conserving steps / Reported, never hidden" contract. The only leak reporting (`.warn_unattributed_land()`) covered the *first* join and only ran inside `build_grazing_feed_footprint()`, never the exported `allocate_grazing_to_products()`.

## Fix

- Replace the second-stage `inner_join` with a `left_join`, so land handed to animals with no eligible output is retained rather than dropped.
- Add `.warn_unattributed_output_land()`, which computes the dropped share (against the total per-animal land, de-duplicated so multi-output animals are not double-counted) and warns via `cli::cli_warn()` with the leaked percentage and number of affected countries before the unattributable land is set aside.
- Update the `allocate_grazing_to_products()` documentation to state the new behaviour.

## Tests

- New test: an animal with forage intake but no eligible product output no longer silently loses its land — the leak is surfaced by a warning (`"25% of grazing land"`), the output carries no `NA` item, and only the attributable land is placed on products.
- New test: full output coverage stays silent (`expect_no_warning`).
- Full `test_footprint_grazing.R` suite passes locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)