### PR TITLE
fix(validation): flag conservation leaks instead of scoring them as perfect

### DIFF
--- a/R/validation_helpers.R
+++ b/R/validation_helpers.R
@@ -1,0 +1,34 @@
+# Internal helpers backing the inst/scripts validation figures. Kept as
+# pure, stateless functions so the conservation-scoring and join logic can
+# be unit-tested independently of the plotting scripts (which need large
+# gridded parquet inputs to run).
+
+# Relative error (%) of a gridded total against a reference total, with
+# correct handling of the zero-reference case. A country the reference
+# says has no animals/area but that carries spurious gridded mass is a
+# genuine conservation failure, not a perfect match, so it scores `Inf`.
+# Only a true zero-against-zero pair scores `0`.
+.conservation_rel_error <- function(gridded, reference) {
+  dplyr::case_when(
+    reference > 0 ~ abs(gridded - reference) / reference * 100,
+    gridded > 0 ~ Inf,
+    .default = 0
+  )
+}
+
+# Join gridded totals to their country reference keeping *every* country
+# from both sides (`full_join`), so a reference country with no gridded
+# output -- a total mass leak, the most severe conservation failure -- is
+# retained and flagged instead of silently dropped by an inner join.
+# Numeric columns named in `fill` have their post-join `NA`s (the absent
+# side) set to `0` so downstream error scoring treats them as leaks.
+.join_conservation <- function(gridded, reference, by, fill = NULL) {
+  joined <- dplyr::full_join(gridded, reference, by = by)
+  if (!is.null(fill)) {
+    joined <- joined |>
+      dplyr::mutate(
+        dplyr::across(dplyr::all_of(fill), \(x) tidyr::replace_na(x, 0))
+      )
+  }
+  joined
+}

--- a/inst/scripts/figure_validate_livestock.R
+++ b/inst/scripts/figure_validate_livestock.R
@@ -96,20 +96,31 @@ faostat_totals <- faostat |>
     fao_manure_n = manure_n_mg
   )
 
-comparison <- gridded_by_country |>
-  inner_join(
-    faostat_totals,
-    by = c("year", "area_code", "species_group")
-  ) |>
+# Full join so countries present on only one side are kept: a reference
+# country with no gridded output (a total mass leak) and a gridded
+# country the reference says has no animals both survive and get flagged.
+comparison <- .join_conservation(
+  gridded_by_country,
+  faostat_totals,
+  by = c("year", "area_code", "species_group"),
+  fill = c(
+    "grid_heads",
+    "grid_enteric_ch4",
+    "grid_manure_ch4",
+    "grid_manure_n2o",
+    "grid_manure_n",
+    "fao_heads",
+    "fao_enteric_ch4",
+    "fao_manure_ch4",
+    "fao_manure_n2o",
+    "fao_manure_n"
+  )
+) |>
   mutate(
     heads_diff = grid_heads - fao_heads,
-    heads_rel_error = if_else(
-      fao_heads > 0,
-      abs(grid_heads - fao_heads) / fao_heads * 100,
-      0
-    )
+    heads_rel_error = .conservation_rel_error(grid_heads, fao_heads)
   ) |>
-  inner_join(polities, by = "area_code")
+  left_join(polities, by = "area_code")
 
 cli::cli_alert_success(
   "Matched {nrow(comparison)} country-species-year observations"

--- a/inst/scripts/figure_validate_spatialized.R
+++ b/inst/scripts/figure_validate_spatialized.R
@@ -253,9 +253,17 @@ grid_country <- grid_country_cft |>
     .by = c(year, area_code)
   )
 
-comp_country <- ref_country |>
-  dplyr::inner_join(grid_country, by = c("year", "area_code")) |>
-  dplyr::inner_join(polities, by = "area_code")
+# Full join so a reference country with no gridded cells -- a total mass
+# leak, the most severe conservation failure -- is kept (with zero gridded
+# area) and surfaces as a worst-case deviation instead of being silently
+# dropped by an inner join. Names come from a left join to keep all rows.
+comp_country <- .join_conservation(
+  ref_country,
+  grid_country,
+  by = c("year", "area_code"),
+  fill = c("ref_mha", "ref_irr_mha", "grid_mha", "grid_irr_mha")
+) |>
+  dplyr::left_join(polities, by = "area_code")
 
 scatter_years <- c(1960L, 1980L, 2000L, 2020L)
 

--- a/tests/testthat/test_validation_helpers.R
+++ b/tests/testthat/test_validation_helpers.R
@@ -1,0 +1,88 @@
+# Unit tests for the pure conservation-scoring helpers behind the
+# inst/scripts validation figures (issues #260, #261).
+
+test_that(".conservation_rel_error scores agreement and leaks correctly", {
+  # Exact agreement scores 0.
+  testthat::expect_equal(whep:::.conservation_rel_error(100, 100), 0)
+  # A true zero-against-zero pair is legitimate agreement, not a failure.
+  testthat::expect_equal(whep:::.conservation_rel_error(0, 0), 0)
+  # Ordinary relative error.
+  testthat::expect_equal(whep:::.conservation_rel_error(110, 100), 10)
+})
+
+test_that(".conservation_rel_error flags spurious gridded mass (#261)", {
+  # Zero reference but nonzero gridded mass is a real disagreement and
+  # must NOT score as a perfect match.
+  err <- whep:::.conservation_rel_error(50, 0)
+  testthat::expect_true(is.infinite(err))
+  testthat::expect_false(err < 0.01)
+})
+
+test_that(".conservation_rel_error is vectorised", {
+  testthat::expect_equal(
+    whep:::.conservation_rel_error(c(50, 100, 0, 110), c(0, 100, 0, 100)),
+    c(Inf, 0, 0, 10)
+  )
+})
+
+test_that(".join_conservation keeps fully-leaked countries (#260)", {
+  gridded <- tibble::tribble(
+    ~area_code,
+    ~grid_heads,
+    1L,
+    500,
+    2L,
+    300 # spurious gridded country absent from the reference
+  )
+  reference <- tibble::tribble(
+    ~area_code,
+    ~fao_heads,
+    1L,
+    500,
+    3L,
+    900 # reference country with zero gridded output (total leak)
+  )
+
+  out <- whep:::.join_conservation(
+    gridded,
+    reference,
+    by = "area_code",
+    fill = c("grid_heads", "fao_heads")
+  )
+
+  # An inner join would have dropped countries 2 and 3.
+  testthat::expect_setequal(out$area_code, c(1L, 2L, 3L))
+
+  leaked <- dplyr::filter(out, area_code == 3L)
+  testthat::expect_equal(leaked$grid_heads, 0)
+  testthat::expect_equal(leaked$fao_heads, 900)
+
+  spurious <- dplyr::filter(out, area_code == 2L)
+  testthat::expect_equal(spurious$fao_heads, 0)
+})
+
+test_that("join + scoring flags a total leak as a failure, not perfect", {
+  gridded <- tibble::tribble(~area_code, ~grid_heads, 1L, 100)
+  reference <- tibble::tribble(
+    ~area_code,
+    ~fao_heads,
+    1L,
+    100,
+    3L,
+    900
+  )
+
+  scored <- whep:::.join_conservation(
+    gridded,
+    reference,
+    by = "area_code",
+    fill = c("grid_heads", "fao_heads")
+  ) |>
+    dplyr::mutate(
+      err = whep:::.conservation_rel_error(grid_heads, fao_heads)
+    )
+
+  leaked_err <- dplyr::filter(scored, area_code == 3L)$err
+  testthat::expect_equal(leaked_err, 100)
+  testthat::expect_false(leaked_err < 0.01)
+})


### PR DESCRIPTION
## What

Fixes two conservation-check bugs in the `inst/scripts` validation
figures that let severe mass leaks pass as perfect agreement.

### #261 — zero-FAO / nonzero-gridded scored as perfect match
`figure_validate_livestock.R` computed `heads_rel_error = 0` whenever
`fao_heads == 0`, so a country the reference says has no animals but
that carries spurious gridded mass counted toward `n_perfect`. It now
scores `Inf` (a genuine failure); only a true zero-vs-zero pair scores
`0`.

### #260 — inner_join silently dropped fully-leaked countries
Both `figure_validate_livestock.R` and `figure_validate_spatialized.R`
joined gridded totals to the country reference with an `inner_join`, so
a reference country producing **zero gridded cells** — a total mass
leak, the most severe conservation failure — had no gridded row and was
silently dropped from every metric (`n_perfect/n_total`, error
histograms, worst-case panels, `validation_detail.csv`). The join is now
a `full_join` that retains countries present on either side and
coalesces the absent side to zero, so leaks surface as worst-case
failures. The `polities` name join is now a `left_join` so no row is
dropped for lack of a name.

## How

The scoring and join logic is extracted into pure, stateless internal
helpers in `R/validation_helpers.R`:

- `.conservation_rel_error(gridded, reference)` — relative error (%) with
  correct zero-reference handling.
- `.join_conservation(gridded, reference, by, fill)` — full join keeping
  both sides, filling the absent side's numeric columns with zero.

Both are unit-tested in `tests/testthat/test_validation_helpers.R`
(12 assertions, all passing), including the leak and spurious-mass cases.

Closes #261
Closes #260

🤖 Generated with [Claude Code](https://claude.com/claude-code)