### PR TITLE
fix(cbs): clamp final-balance exports and bound FBS scaling ratio

### DIFF
--- a/R/build_cbs.R
+++ b/R/build_cbs.R
@@ -1890,13 +1890,19 @@ build_processing_coefs <- function(
   ]
   overlap_ratio <- overlap[,
     .(
-      scale_new_old = stats::median(
+      n_overlap = .N,
+      scale_raw = stats::median(
         FAOSTAT_FBS_New / FAOSTAT_FBS_Old,
         na.rm = TRUE
       )
     ),
     by = group_cols
-  ][is.finite(scale_new_old)]
+  ][is.finite(scale_raw)]
+
+  # Guard against extreme ratios (unit changes, near-zero overlap values) and
+  # against extrapolating a single overlap year to five decades: clamp to a
+  # plausible band and require a minimum number of overlap observations.
+  overlap_ratio <- .clamp_fbs_scale_ratio(overlap_ratio)
 
   wide[
     overlap_ratio,
@@ -3560,16 +3566,7 @@ build_processing_coefs <- function(
     all.x = TRUE,
     sort = FALSE
   )
-  cbs_raw8[,
-    `:=`(
-      domestic_supply = pmax(domestic_supply, 0),
-      export = data.table::fifelse(
-        balance < 0,
-        production + import - stock_variation - domestic_supply,
-        export
-      )
-    )
-  ]
+  cbs_raw8 <- .cbs_fix_final_balance(cbs_raw8)
   cbs_raw8[, default_destiny := NULL]
   cbs_raw8 <- .untest_cbs(cbs_raw8)
 
@@ -3616,4 +3613,41 @@ build_processing_coefs <- function(
     all.x = TRUE,
     sort = FALSE
   )
+}
+
+# -- Helpers -------------------------------------------------------------------
+
+# Bounds for the FBS_Old -> FBS_New scaling ratio. The [lower, upper] band
+# mirrors the clamp used for processing scalings; min_overlap avoids
+# extrapolating a single overlap year to the whole FBS_Old series.
+.fbs_scale_ratio_bounds <- function() {
+  list(lower = 0.2, upper = 5, min_overlap = 2L)
+}
+
+# Clamp the FBS scaling ratio to a plausible band and drop groups whose
+# overlap window is too thin to trust. Groups that fail the overlap threshold
+# are dropped so they stay unscaled (source remains FAOSTAT_FBS_Old).
+.clamp_fbs_scale_ratio <- function(overlap_ratio) {
+  bounds <- .fbs_scale_ratio_bounds()
+  overlap_ratio <- overlap_ratio[n_overlap >= bounds$min_overlap]
+  overlap_ratio[,
+    scale_new_old := pmin(pmax(scale_raw, bounds$lower), bounds$upper)
+  ]
+  overlap_ratio[, c("n_overlap", "scale_raw") := NULL]
+  overlap_ratio[]
+}
+
+# Reconcile the final CBS balance. Clamp domestic supply at 0 first, then
+# recompute export from the clamped supply so the export fix cannot read a
+# negative supply, and clamp export at 0 so no negative exports survive.
+.cbs_fix_final_balance <- function(cbs_dt) {
+  cbs_dt[, domestic_supply := pmax(domestic_supply, 0)]
+  cbs_dt[,
+    export := data.table::fifelse(
+      balance < 0,
+      pmax(production + import - stock_variation - domestic_supply, 0),
+      export
+    )
+  ]
+  cbs_dt[]
 }

--- a/R/utils.R
+++ b/R/utils.R
@@ -956,6 +956,7 @@ utils::globalVariables(
     "is_tradeable",
     "other_mean",
     "scale_new_old",
+    "scale_raw",
     # spatialize.R — data.table i.* and computed cols
     ".cell_group",
     ".cross",

--- a/tests/testthat/test_build_cbs.R
+++ b/tests/testthat/test_build_cbs.R
@@ -1081,3 +1081,88 @@ test_that("build_commodity_balances needs primary_all for the wide format", {
     "primary_all"
   )
 })
+
+# -- .cbs_fix_final_balance (issue #162) --------------------------------------
+
+test_that(".cbs_fix_final_balance clamps DS then export, no negatives", {
+  dt <- data.table::data.table(
+    production = c(0, 100, 50),
+    import = c(10, 5, 5),
+    stock_variation = c(20, 0, 0),
+    domestic_supply = c(-5, -30, 40),
+    export = c(0, 10, 15),
+    balance = c(-3, -2, 1)
+  )
+
+  result <- whep:::.cbs_fix_final_balance(dt)
+
+  # Domestic supply is clamped at 0 before the export fix reads it.
+  expect_true(all(result$domestic_supply >= 0))
+  # No negative exports survive.
+  expect_true(all(result$export >= 0))
+  # Row 1: 0 + 10 - 20 - 0 = -10 -> clamped to 0.
+  expect_equal(result$export[1], 0)
+  # Row 2: reads clamped DS (0), 100 + 5 - 0 - 0 = 105 (not 135 pre-clamp).
+  expect_equal(result$export[2], 105)
+  # Row 3: balance >= 0, export left untouched.
+  expect_equal(result$export[3], 15)
+})
+
+
+# -- FBS scaling ratio bounds (issue #161) ------------------------------------
+
+test_that(".select_best_source clamps extreme FBS scaling ratio", {
+  input <- tibble::tribble(
+    ~area, ~area_code, ~item_cbs, ~item_cbs_code, ~element, ~year,
+    ~value, ~source, ~unit,
+    "Spain", 203L, "Wheat", 2511L, "food", 2010L,
+    10, "FAOSTAT_FBS_Old", "tonnes",
+    "Spain", 203L, "Wheat", 2511L, "food", 2010L,
+    1000, "FAOSTAT_FBS_New", "tonnes",
+    "Spain", 203L, "Wheat", 2511L, "food", 2011L,
+    10, "FAOSTAT_FBS_Old", "tonnes",
+    "Spain", 203L, "Wheat", 2511L, "food", 2011L,
+    1000, "FAOSTAT_FBS_New", "tonnes",
+    "Spain", 203L, "Wheat", 2511L, "food", 2005L,
+    100, "FAOSTAT_FBS_Old", "tonnes"
+  )
+
+  result <- whep:::.select_best_source(input)
+
+  val_2005 <- result |>
+    dplyr::filter(year == 2005) |>
+    dplyr::pull(value)
+  # Raw ratio is 100x; clamp caps it at 5x -> 100 * 5 = 500, not 10000.
+  expect_equal(val_2005, 500)
+
+  src_2005 <- result |>
+    dplyr::filter(year == 2005) |>
+    dplyr::pull(source)
+  expect_equal(src_2005, "FAOSTAT_FBS_Old_scaled")
+})
+
+test_that(".select_best_source leaves FBS unscaled when overlap is thin", {
+  input <- tibble::tribble(
+    ~area, ~area_code, ~item_cbs, ~item_cbs_code, ~element, ~year,
+    ~value, ~source, ~unit,
+    "Spain", 203L, "Wheat", 2511L, "food", 2010L,
+    10, "FAOSTAT_FBS_Old", "tonnes",
+    "Spain", 203L, "Wheat", 2511L, "food", 2010L,
+    1000, "FAOSTAT_FBS_New", "tonnes",
+    "Spain", 203L, "Wheat", 2511L, "food", 2005L,
+    100, "FAOSTAT_FBS_Old", "tonnes"
+  )
+
+  result <- whep:::.select_best_source(input)
+
+  val_2005 <- result |>
+    dplyr::filter(year == 2005) |>
+    dplyr::pull(value)
+  # A single overlap year is not extrapolated: value stays unscaled.
+  expect_equal(val_2005, 100)
+
+  src_2005 <- result |>
+    dplyr::filter(year == 2005) |>
+    dplyr::pull(source)
+  expect_equal(src_2005, "FAOSTAT_FBS_Old")
+})


### PR DESCRIPTION
## Summary

Fixes two bugs in `R/build_cbs.R`, both scoped to the specific blocks flagged in the audit.

### #162 — final-balance export fix
`.cbs_final_balance()` clamped `domestic_supply` and recomputed `export` in a single `:=`, so `export` read the *pre-clamp* (possibly negative) domestic supply, and there was no lower bound — negative exports could survive. Extracted `.cbs_fix_final_balance()`:
- clamp `domestic_supply` at 0 **first**;
- recompute `export = pmax(production + import - stock_variation - domestic_supply, 0)` from the **clamped** supply, so exports can never go negative and are consistent with the clamped supply.

### #161 — FBS_Old→FBS_New scaling ratio
The 2010–2013 median ratio was unbounded and applied to the entire 1961–2009 FBS_Old series (a unit change or near-zero overlap value could rescale five decades by e.g. 50×). Extracted `.clamp_fbs_scale_ratio()`:
- clamp the ratio to `[0.2, 5]` (matching the existing processing-scaling band);
- require `>= 2` overlap years, so a single overlap year is not extrapolated to the whole series — thin-overlap groups stay unscaled (`source` remains `FAOSTAT_FBS_Old`).

## Tests
Added to `tests/testthat/test_build_cbs.R`:
- `.cbs_fix_final_balance`: no negative exports; export reads the clamped supply; `balance >= 0` rows untouched.
- `.select_best_source`: extreme overlap ratio (100×) is clamped to 5×; thin (single-year) overlap leaves FBS unscaled.

`test_build_cbs.R`: 25 tests, 0 failures, 0 warnings. Lint clean on changed files. `air format .` applied.

Closes #162
Closes #161

🤖 Generated with [Claude Code](https://claude.com/claude-code)