### PR TITLE
fix(production): compute QC flags after deduplication

### DIFF
--- a/R/build_production.R
+++ b/R/build_production.R
@@ -2,11 +2,13 @@
 #'
 #' @description
 #' Construct the full primary production dataset from raw FAOSTAT inputs.
-#' This is a convenience wrapper that chains the three pipeline steps:
+#' This is a convenience wrapper that chains the pipeline steps:
 #'
 #' 1. `.read_production()` — read & reformat FAOSTAT data.
 #' 2. `.fix_production()` — apply Global-ported corrections.
-#' 3. `.qc_production()` — flag data-quality anomalies.
+#' 3. `.dedup_production()` — keep one value per key across sources.
+#' 4. `.qc_production()` — flag data-quality anomalies on the
+#'   surviving (deduplicated) values.
 #'
 #' @param start_year Integer. First year to include. Default `1850`.
 #' @param end_year Integer. Last year to include. Default `2023`.
@@ -74,15 +76,20 @@ build_primary_production <- function(
   clean <- raw |>
     .fix_production() |>
     dplyr::mutate(value = .round_reproducible(.data$value)) |>
-    .qc_production(smooth = smooth_carry_forward) |>
     tibble::as_tibble()
 
   if (show_duplicates) {
     return(.show_prod_duplicates(clean))
   }
 
+  # QC flags are computed after deduplication so anomaly detection compares
+  # surviving values within a single source. Running it before dedup compared
+  # values across competing sources (later discarded), yielding spurious
+  # spike and carry-forward flags when sources disagreed.
   result <- clean |>
     .dedup_production() |>
+    .qc_production(smooth = smooth_carry_forward) |>
+    tibble::as_tibble() |>
     dplyr::mutate(
       item_prod_code = as.numeric(item_prod_code),
       live_anim_code = as.numeric(live_anim_code)

--- a/man/build_primary_production.Rd
+++ b/man/build_primary_production.Rd
@@ -58,11 +58,13 @@ column per source showing the competing values.
 }
 \description{
 Construct the full primary production dataset from raw FAOSTAT inputs.
-This is a convenience wrapper that chains the three pipeline steps:
+This is a convenience wrapper that chains the pipeline steps:
 \enumerate{
 \item \code{.read_production()} — read & reformat FAOSTAT data.
 \item \code{.fix_production()} — apply Global-ported corrections.
-\item \code{.qc_production()} — flag data-quality anomalies.
+\item \code{.dedup_production()} — keep one value per key across sources.
+\item \code{.qc_production()} — flag data-quality anomalies on the
+surviving (deduplicated) values.
 }
 }
 \examples{

--- a/tests/testthat/test_build_production.R
+++ b/tests/testthat/test_build_production.R
@@ -532,6 +532,33 @@ test_that(".show_prod_duplicates returns wide format of competing sources", {
   expect_equal(src_cols[1], "FAOSTAT_prod")
 })
 
+test_that("QC flags reflect post-dedup values, not competing sources", {
+  # Two sources disagree by >10x on 2001; FAOSTAT_prod is a smooth series.
+  competing <- tibble::tribble(
+    ~year, ~area, ~area_code, ~item_prod, ~item_prod_code, ~unit, ~value, ~source,
+    2000L, "Spain", 203L, "Wheat", 15L, "tonnes", 5000, "FAOSTAT_prod",
+    2001L, "Spain", 203L, "Wheat", 15L, "tonnes", 5500, "FAOSTAT_prod",
+    2002L, "Spain", 203L, "Wheat", 15L, "tonnes", 6000, "FAOSTAT_prod",
+    2001L, "Spain", 203L, "Wheat", 15L, "tonnes", 100000, "imputed_yield"
+  )
+
+  # QC after dedup: the competing imputed_yield value for 2001 is discarded,
+  # leaving a smooth single-source series with no spike.
+  qc_after <- competing |>
+    whep:::.dedup_production() |>
+    whep:::.qc_production()
+  expect_false(
+    any(stringr::str_detect(qc_after$qc_flag, "spike"), na.rm = TRUE)
+  )
+
+  # Regression guard: QC before dedup compares the two 2001 sources and
+  # raises a spurious spike flag.
+  qc_before <- whep:::.qc_production(competing)
+  expect_true(
+    any(stringr::str_detect(qc_before$qc_flag, "spike"), na.rm = TRUE)
+  )
+})
+
 test_that("build_primary_production output has no duplicate keys", {
   result <- whep::build_primary_production(example = TRUE)
   keys <- dplyr::select(


### PR DESCRIPTION
## What

`.qc_production()` ran *before* `.dedup_production()` in `build_primary_production()` and grouped by key columns **without `source`**. Competing-source rows sharing a `year` sat adjacent in the sorted series, so:

- `.flag_cf_and_spikes()` compared a value against the *other source's* value for the same year, producing spurious `spike` flags when sources disagreed >10x.
- Carry-forward tail detection used whichever source sorted last as `last_val`, corrupting `run_len`.

## Fix

Move `.qc_production()` to run **after** `.dedup_production()`, so anomaly detection operates on the surviving single-source values. The `show_duplicates` diagnostic path (which needs the pre-dedup competing rows) is unaffected — it never used the QC flags.

## Test

Added a regression test in `test_build_production.R` with two sources disagreeing by >10x on one year:
- After dedup + QC: no `spike` flag (the discarded competing value never enters detection).
- Before dedup (guard): the spurious `spike` flag is raised.

Full `test_build_production.R` suite passes (0 failures). Scoped narrowly to the QC-flag ordering; untouched by the other open `build_production.R` PRs.

Closes #146

🤖 Generated with [Claude Code](https://claude.com/claude-code)