### PR TITLE
fix(lmdi): correct decomposition on unbalanced panels, integer selectors, zeros and smoothing

### DIFF
--- a/R/calculate_lmdi.R
+++ b/R/calculate_lmdi.R
@@ -379,7 +379,12 @@ calculate_lmdi <- function(
   # Parse factors from identity
   factors <- .parse_identity(identity)$factors
 
-  # Always treat zeros (required for LMDI log calculations)
+  # Balance the panel first, independent of rolling mean, so groups that
+  # appear or disappear between periods do not break additive closure (#155).
+  data <- data |>
+    .lmdi_balance_panel({{ time_var }}, group_cols, numeric_vars, verbose)
+
+  # Treat zeros after balancing so filled-in gaps are handled too (#155).
   data <- .lmdi_treat_zeros(data, numeric_vars, target_var, factors, verbose)
 
   # Only apply rolling mean smoothing if requested (rolling_mean > 1)
@@ -393,7 +398,6 @@ calculate_lmdi <- function(
     )
 
     data <- data |>
-      .lmdi_balance_panel({{ time_var }}, group_cols, numeric_vars, verbose) |>
       .lmdi_apply_rolling_mean(
         target_var,
         {{ time_var }},
@@ -401,7 +405,10 @@ calculate_lmdi <- function(
         numeric_vars,
         k_eff,
         verbose
-      )
+      ) |>
+      # Smoothing each series independently breaks the identity; re-derive the
+      # target from its (now smoothed) factors so closure holds (#246).
+      .lmdi_recompute_target(target_var, factors, verbose)
   }
 
   data
@@ -712,6 +719,9 @@ calculate_lmdi <- function(
   ))
   numeric_vars <- all_vars[all_vars %in% names(data)]
   numeric_vars <- numeric_vars[purrr::map_lgl(data[numeric_vars], is.numeric)]
+  # Bracket selectors (e.g. `sector` in `activity[sector]`) are grouping keys,
+  # never numeric decomposition variables, even when integer-coded (#247).
+  numeric_vars <- setdiff(numeric_vars, .extract_selectors(identity))
   group_cols <- setdiff(names(data), c(time_var_str, numeric_vars))
   list(numeric_vars = numeric_vars, group_cols = group_cols)
 }
@@ -758,12 +768,13 @@ calculate_lmdi <- function(
   }
   epsilon <- 1e-12
 
-  # Check if any zeros/NAs exist before replacement
-  has_zeros <- any(
-    purrr::map_lgl(
-      numeric_vars,
-      ~ any(is.na(data[[.x]]) | data[[.x]] == 0)
-    )
+  # Rows where at least one numeric column will be epsilon-replaced. Only these
+  # rows get their target re-derived, so adding a single zero elsewhere never
+  # rewrites the target of unaffected rows (behaviour stays continuous, #180).
+  affected <- purrr::reduce(
+    numeric_vars,
+    ~ .x | is.na(data[[.y]]) | data[[.y]] == 0,
+    .init = rep(FALSE, nrow(data))
   )
 
   # Replace zeros/NAs with epsilon in all numeric columns
@@ -775,23 +786,27 @@ calculate_lmdi <- function(
       )
     )
 
-  # Recalculate target to maintain identity after epsilon replacement
-  # Only when: (1) zeros were replaced, and (2) factors are simple column names
+  # Re-derive the target from its factors on affected rows to maintain the
+  # identity after epsilon replacement, but only for simple-factor identities.
   simple_factors <- factors[!stringr::str_detect(factors, "[/\\[\\]]")]
-  if (
-    has_zeros &&
-      length(simple_factors) == length(factors) &&
-      all(simple_factors %in% names(data))
-  ) {
+  is_simple <- length(simple_factors) == length(factors) &&
+    all(simple_factors %in% names(data))
+  if (is_simple && any(affected)) {
+    prod_factors <- data |>
+      dplyr::select(dplyr::all_of(simple_factors)) |>
+      purrr::reduce(`*`)
     data <- data |>
       dplyr::mutate(
-        !!rlang::sym(target_var) := purrr::reduce(
-          dplyr::across(dplyr::all_of(simple_factors)),
-          `*`
+        !!rlang::sym(target_var) := dplyr::if_else(
+          affected,
+          prod_factors,
+          .data[[target_var]]
         )
       )
     if (verbose) {
-      cli::cli_inform("  - Target '{target_var}' recalculated from factors")
+      cli::cli_inform(
+        "  - Target '{target_var}' re-derived on {sum(affected)} affected row(s)"
+      )
     }
   }
 
@@ -801,6 +816,26 @@ calculate_lmdi <- function(
     )
     cli::cli_inform("-----------------------------")
     cli::cli_inform("")
+  }
+  data
+}
+
+.lmdi_recompute_target <- function(data, target_var, factors, verbose) {
+  simple_factors <- factors[!stringr::str_detect(factors, "[/\\[\\]]")]
+  is_simple <- length(simple_factors) == length(factors) &&
+    all(simple_factors %in% names(data))
+  if (!is_simple) {
+    return(data)
+  }
+  prod_factors <- data |>
+    dplyr::select(dplyr::all_of(simple_factors)) |>
+    purrr::reduce(`*`)
+  data <- data |>
+    dplyr::mutate(!!rlang::sym(target_var) := prod_factors)
+  if (verbose) {
+    cli::cli_inform(
+      "  - Target '{target_var}' re-derived from smoothed factors"
+    )
   }
   data
 }
@@ -867,7 +902,7 @@ calculate_lmdi <- function(
         ~ zoo::rollapply(
           .x,
           width = k_eff,
-          FUN = mean,
+          FUN = function(x) mean(x, na.rm = TRUE),
           align = "center",
           partial = TRUE
         )
@@ -881,7 +916,7 @@ calculate_lmdi <- function(
         ~ zoo::rollapply(
           .x,
           width = k_eff,
-          FUN = mean,
+          FUN = function(x) mean(x, na.rm = TRUE),
           align = "center",
           partial = TRUE
         )

--- a/tests/testthat/test_calculate_lmdi.R
+++ b/tests/testthat/test_calculate_lmdi.R
@@ -640,6 +640,163 @@ test_that("calculate_lmdi recalculates target after epsilon replacement", {
 })
 
 
+# Regression: decomposition correctness -----------------------------------
+
+# Data where activity and intensity covary, so smoothing each series
+# independently would break the identity emissions = activity * intensity.
+lmdi_covarying_fixture <- function() {
+  activity <- c(100, 130, 90, 160, 120, 200, 150)
+  intensity <- c(0.10, 0.20, 0.05, 0.30, 0.08, 0.40, 0.12)
+  tibble::tibble(
+    year = 2010:2016,
+    activity = activity,
+    intensity = intensity,
+    emissions = activity * intensity
+  )
+}
+
+# Structural panel where one sector appears and another disappears between
+# the two periods (unbalanced panel).
+lmdi_unbalanced_sector_fixture <- function() {
+  tibble::tribble(
+    ~year, ~sector, ~activity, ~emissions,
+    2010, "a", 600, 60,
+    2010, "c", 400, 40,
+    2011, "a", 700, 63,
+    2011, "b", 500, 55
+  ) |>
+    dplyr::group_by(year) |>
+    dplyr::mutate(total_activity = sum(activity)) |>
+    dplyr::ungroup()
+}
+
+test_that("calculate_lmdi closes with rolling_mean on covarying factors", {
+  # Regression for #246: smoothing target and factors independently must not
+  # break additive closure, even on a balanced single-group panel.
+  data <- lmdi_covarying_fixture()
+
+  result <- calculate_lmdi(
+    data,
+    identity = "emissions:activity*intensity",
+    time_var = year,
+    rolling_mean = 3,
+    verbose = FALSE
+  )
+
+  closure <- result |>
+    dplyr::group_by(period) |>
+    dplyr::summarise(
+      target_add = sum(additive[component_type == "target"]),
+      factor_add = sum(additive[component_type == "factor"]),
+      .groups = "drop"
+    ) |>
+    dplyr::mutate(gap = abs(target_add - factor_add))
+
+  expect_true(all(closure$gap < 1e-6))
+})
+
+test_that("calculate_lmdi closes on unbalanced structural panels", {
+  # Regression for #155: sectors that appear/disappear between periods must
+  # still be attributed so contributions sum to the total change.
+  data <- lmdi_unbalanced_sector_fixture()
+
+  result <- calculate_lmdi(
+    data,
+    identity = paste0(
+      "emissions:total_activity*",
+      "(activity[sector]/total_activity)*",
+      "(emissions[sector]/activity[sector])"
+    ),
+    time_var = year,
+    verbose = FALSE
+  )
+
+  period_result <- result |> dplyr::filter(period == "2010-2011")
+  target_change <- period_result |>
+    dplyr::filter(component_type == "target") |>
+    dplyr::pull(additive)
+  factor_sum <- period_result |>
+    dplyr::filter(component_type == "factor") |>
+    dplyr::pull(additive) |>
+    sum()
+
+  # True total change is (63 + 55) - (60 + 40) = 18.
+  expect_equal(target_change, 18, tolerance = 1e-6)
+  expect_equal(factor_sum, target_change, tolerance = 1e-6)
+})
+
+test_that("calculate_lmdi treats integer selector as a grouping key", {
+  # Regression for #247: an integer-coded selector column must be a grouping
+  # key, never a numeric decomposition variable that gets smoothed/blended.
+  # One column named `sector`, populated either as integers or as characters,
+  # with no redundant grouping column that could mask the misclassification.
+  build <- function(codes) {
+    tibble::tibble(
+      year = rep(2010:2012, each = 2),
+      sector = rep(codes, times = 3),
+      activity = c(600, 400, 700, 500, 750, 550),
+      emissions = c(60, 40, 63, 55, 71, 60)
+    ) |>
+      dplyr::group_by(year) |>
+      dplyr::mutate(total_activity = sum(activity)) |>
+      dplyr::ungroup()
+  }
+
+  run <- function(codes) {
+    calculate_lmdi(
+      build(codes),
+      identity = paste0(
+        "emissions:total_activity*",
+        "(activity[sector]/total_activity)*",
+        "(emissions[sector]/activity[sector])"
+      ),
+      time_var = year,
+      rolling_mean = 3,
+      verbose = FALSE
+    ) |>
+      dplyr::arrange(period, factor_label, component_type) |>
+      dplyr::pull(additive)
+  }
+
+  # An integer-coded selector must yield the same decomposition as a
+  # character-coded one; if it were smoothed as a numeric variable the
+  # grouping (and thus the contributions) would be corrupted.
+  expect_equal(run(c(1L, 2L)), run(c("a", "b")), tolerance = 1e-6)
+})
+
+test_that("calculate_lmdi target rewrite is not gated on a single zero", {
+  # Regression for #180: adding one zero row must not change the decomposition
+  # of the zero-free rows (behaviour must be continuous). Use slightly
+  # inconsistent emissions so a whole-column rewrite would be detectable.
+  base <- tibble::tribble(
+    ~year, ~activity, ~intensity, ~emissions,
+    2010, 1000, 0.10, 100,
+    2011, 1100, 0.10, 115,
+    2012, 1200, 0.10, 120
+  )
+  with_zero <- dplyr::bind_rows(
+    base,
+    tibble::tibble(year = 2013, activity = 1300, intensity = 0, emissions = 0)
+  )
+
+  period_add <- function(data) {
+    suppressWarnings(
+      calculate_lmdi(
+        data,
+        identity = "emissions:activity*intensity",
+        time_var = year,
+        verbose = FALSE
+      )
+    ) |>
+      dplyr::filter(period == "2010-2011") |>
+      dplyr::arrange(factor_label, component_type) |>
+      dplyr::pull(additive)
+  }
+
+  expect_equal(period_add(base), period_add(with_zero), tolerance = 1e-9)
+})
+
+
 # Closure warning tests --------------------------------------------------------
 
 test_that("calculate_lmdi warns on inconsistent data", {


### PR DESCRIPTION
## Summary

Fixes four related correctness bugs in `R/calculate_lmdi.R` that broke the LMDI additive identity (sum of factor contributions == total change) or silently misattributed contributions. The identity now holds on balanced **and** unbalanced panels, with or without rolling-mean smoothing.

## Fixes

- **Closes #247** — Bracket selectors (e.g. `sector` in `activity[sector]`) are now removed from `numeric_vars` in `.lmdi_extract_vars`, so an integer-coded group key is treated as a grouping column, not a measured variable. It is no longer epsilon-treated, smoothed, or blended across sectors.
- **Closes #246** — After a rolling mean, the target is re-derived from its (now smoothed) factors via a new `.lmdi_recompute_target()` helper, restoring the identity. Previously every numeric series was smoothed independently, so `target != prod(factors)` whenever the factors covaried and closure was violated even on a perfectly balanced panel.
- **Closes #180** — The target rewrite is no longer gated on the presence of a single zero. Epsilon-driven re-derivation is now applied **per affected row only**, so adding one zero can never rewrite the target of the zero-free rows. Behaviour is continuous in the input.
- **Closes #155** — The panel is now balanced on the default path (independent of `rolling_mean`), zero treatment runs **after** balancing, and the rolling mean uses `na.rm`. Groups that appear/disappear between the two periods are now attributed, so contributions sum to the total change instead of silently dropping the missing group.

## Tests

Added four regression tests to `tests/testthat/test_calculate_lmdi.R`, each verified to **fail on `main`** and **pass with this change**:

- additive closure with `rolling_mean = 3` on covarying factors (#246);
- additive closure on an unbalanced structural panel where sectors appear/disappear (#155);
- an integer-coded selector yields the same decomposition as a character-coded one (#247);
- adding a single zero row does not change the decomposition of zero-free rows (#180).

Full `test_calculate_lmdi.R` suite: 86 passing. `air format .` applied; `lintr` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)