### PR TITLE
feat(landuse): net temporary grassland out of arable footprint default (#342)

### DIFF
--- a/R/arable_permanent_land.R
+++ b/R/arable_permanent_land.R
@@ -433,19 +433,23 @@ get_arable_permanent_land <- function(
 #' perennial base area is reported as an error because it cannot be reconciled
 #' without inventing a crop allocation.
 #'
-#' The default of [build_cropgrids_land_extension()] and the footprint balance
-#' are unchanged; this is an additive method.
+#' This is the crop-side default of the land-balance footprint
+#' ([build_land_balance_footprint()]).
 #'
-#' @section Temporary grassland (do not double-count):
+#' @section Temporary grassland (no double-count):
 #' FAO's **Arable land** total includes *temporary meadows and pastures* —
-#' temporary grassland is part of cropland, not grassland. This method therefore
-#' already absorbs the temporary-grassland slice into its arable-crop total. Do
-#' **not** combine it with CBS 3002 (`Temporary grassland`) from
-#' [build_grassland_land_extension()] on top, or that land is counted twice. The
-#' intended invariant is
-#' `ordinary crop occupation (incl. fallow) + CBS 3002 = FAO Arable land`.
-#' Netting modelled CBS 3002 out of the arable target and promoting this method
-#' to the footprint-balance default is tracked in issue #342.
+#' temporary grassland is part of cropland, not grassland. That land is also
+#' reported separately as CBS 3002 (`Temporary grassland`) by
+#' [build_grassland_land_extension()], so summing both extensions naively would
+#' count it twice. Pass that grassland occupation as `temporary_grassland` and
+#' its CBS 3002 is netted out of the arable target before reconciling ordinary
+#' crops, enforcing the invariant per `(area_code, year)`
+#' `ordinary crop occupation (incl. fallow) + CBS 3002 = FAO Arable land`. The
+#' land-balance footprint ([build_land_balance_footprint()]) does exactly this. Where
+#' modelled CBS 3002 exceeds FAO Arable land (survey vs. fodder-reconstruction
+#' mismatch) the arable target is clamped at 0 and a warning is emitted. Called
+#' standalone (`temporary_grassland = NULL`) no netting is applied and the arable
+#' crops reconcile to the full FAO Arable land.
 #'
 #' @param harvested Tibble of harvested area with columns `year`, `area_code`,
 #'   `item_cbs_code`, `harvested_ha`. If `NULL`, built from
@@ -466,6 +470,13 @@ get_arable_permanent_land <- function(
 #'   crop's cropped physical area (perennials always excluded). The cropped-area
 #'   fallback is used independently for an area when it has no usable supplied
 #'   weights, a non-finite or negative supplied weight, or a non-positive total.
+#' @param temporary_grassland Tibble of grassland occupation in the
+#'   [build_grassland_land_extension()] schema (`area_code`, `year`,
+#'   `item_cbs_code`, `impact_u`); its CBS 3002 rows are the temporary grassland
+#'   netted out of the arable target so ordinary crops plus CBS 3002 reconcile to
+#'   FAO Arable land (see the temporary-grassland section). If `NULL` (default)
+#'   no netting is applied and arable crops reconcile to the full FAO Arable
+#'   land; the land-balance footprint supplies the grassland occupation here.
 #' @param items_prod_full Crosswalk used to classify `item_cbs_code` as arable or
 #'   perennial via `Herb_Woody`. Defaults to [items_prod_full].
 #'
@@ -495,8 +506,13 @@ get_arable_permanent_land <- function(
 #'   2511L, "Herbaceous",
 #'   2560L, "Woody"
 #' )
+#' temporary_grassland <- tibble::tribble(
+#'   ~area_code, ~year, ~item_cbs_code, ~impact_u,
+#'   1L, 2020L, 3002L, 100 # temporary grassland netted out of arable
+#' )
 #' build_fao_arable_fallow_extension(
 #'   harvested, arable_permanent, base_extension,
+#'   temporary_grassland = temporary_grassland,
 #'   items_prod_full = items
 #' )
 # nolint start: object_length_linter.
@@ -505,6 +521,7 @@ build_fao_arable_fallow_extension <- function(
   arable_permanent = NULL,
   base_extension = NULL,
   fallow_weights = NULL,
+  temporary_grassland = NULL, # nolint: object_length_linter.
   items_prod_full = whep::items_prod_full
 ) {
   if (is.null(base_extension)) {
@@ -541,6 +558,12 @@ build_fao_arable_fallow_extension <- function(
     arable_ha = as.numeric(arable_ha),
     permanent_ha = as.numeric(permanent_ha)
   )]
+
+  # FAO Arable land already contains temporary meadows and pastures (CBS 3002),
+  # which the grassland extension reports separately. Net that land out of the
+  # arable target so ordinary crops reconcile to the arable land they alone
+  # occupy and the invariant ordinary + CBS 3002 = FAO arable holds.
+  ap <- .net_temporary_grassland(ap, temporary_grassland)
 
   perennial_codes <- .item_cbs_perennial(items_prod_full)
   base[,
@@ -595,6 +618,57 @@ build_fao_arable_fallow_extension <- function(
   data.table::setorder(tally, item_cbs_code, -N)
   majority <- tally[, .SD[1L], by = item_cbs_code]
   majority[Herb_Woody == "Woody", item_cbs_code]
+}
+
+# Subtract temporary grassland (CBS 3002) from each (area_code, year) arable
+# target so ordinary arable crops reconcile to the arable land they alone
+# occupy. Modelled CBS 3002 can exceed FAO arable land for a few country-years
+# (survey vs. fodder-reconstruction mismatch); those are clamped at 0 and warned.
+.net_temporary_grassland <- function(ap, temporary_grassland) {
+  temp <- .temporary_grassland_ha(temporary_grassland)
+  if (nrow(temp) == 0L) {
+    return(ap)
+  }
+  ap <- merge(ap, temp, by = c("area_code", "year"), all.x = TRUE)
+  ap[is.na(temp_grassland_ha), temp_grassland_ha := 0]
+  overshoot <- ap[temp_grassland_ha > arable_ha]
+  if (nrow(overshoot) > 0L) {
+    keys <- paste(
+      paste(overshoot$area_code, overshoot$year, sep = "/"),
+      collapse = ", "
+    )
+    cli::cli_warn(c(
+      "Modelled temporary grassland (CBS 3002) exceeds FAO arable land for {.val {keys}}.",
+      i = "Arable target clamped at 0; combined crop plus CBS 3002 occupation will exceed FAO arable land there."
+    ))
+  }
+  ap[, arable_ha := pmax(0, arable_ha - temp_grassland_ha)]
+  ap[, temp_grassland_ha := NULL]
+  ap[]
+}
+
+# Temporary grassland (CBS 3002) hectares per (area_code, year). NULL means no
+# netting (standalone use); a supplied table must carry the grassland extension
+# schema (area_code, year, item_cbs_code, impact_u), from which CBS 3002 is kept.
+.temporary_grassland_ha <- function(temporary_grassland) {
+  if (is.null(temporary_grassland)) {
+    return(data.table::data.table(
+      area_code = integer(),
+      year = integer(),
+      temp_grassland_ha = numeric()
+    ))
+  }
+  .check_required_cols(
+    temporary_grassland,
+    c("area_code", "year", "item_cbs_code", "impact_u"),
+    "temporary_grassland"
+  )
+  dt <- data.table::as.data.table(temporary_grassland)
+  dt <- dt[as.integer(item_cbs_code) == 3002L] # CBS 3002 temporary grassland.
+  dt[,
+    .(temp_grassland_ha = sum(as.numeric(impact_u))),
+    by = .(area_code = as.integer(area_code), year = as.integer(year))
+  ]
 }
 
 # Per (area_code, year): add rotational fallow to arable crops up to FAO Arable

--- a/R/footprint_balance.R
+++ b/R/footprint_balance.R
@@ -326,10 +326,14 @@ build_land_balance_footprint <- function(
 }
 
 .land_balance_extension <- function(year) {
-  crop <- build_cropgrids_land_extension(source = "cropgrids_fallow") |>
+  # Build grassland once and pass it in: the FAO-arable crop extension nets the
+  # same CBS 3002 out of its arable target as the grass side adds back, so
+  # crop + grass occupation reconciles to FAO Arable land (no double-count).
+  grass_full <- build_grassland_land_extension(grassland_metric = "occupation")
+  crop <- build_fao_arable_fallow_extension(temporary_grassland = grass_full) |>
     dplyr::filter(year == .env$year) |>
     dplyr::select(area_code, item_cbs_code, value = impact_u)
-  grass <- build_grassland_land_extension(grassland_metric = "occupation") |>
+  grass <- grass_full |>
     dplyr::filter(year == .env$year) |>
     dplyr::select(area_code, item_cbs_code, value = impact_u)
   dplyr::bind_rows(crop, grass)

--- a/R/utils.R
+++ b/R/utils.R
@@ -51,6 +51,7 @@ utils::globalVariables(
     "source_prod",
     # crop_npp.R (potential NPP + residues/roots/components)
     "temp_c",
+    "temp_grassland_ha",
     "water_input_mm",
     "aet_mm",
     "npp_potential_dm_t_ha",

--- a/man/build_fao_arable_fallow_extension.Rd
+++ b/man/build_fao_arable_fallow_extension.Rd
@@ -9,6 +9,7 @@ build_fao_arable_fallow_extension(
   arable_permanent = NULL,
   base_extension = NULL,
   fallow_weights = NULL,
+  temporary_grassland = NULL,
   items_prod_full = whep::items_prod_full
 )
 }
@@ -35,6 +36,14 @@ weight). If \code{NULL}, fallow is distributed in proportion to each arable
 crop's cropped physical area (perennials always excluded). The cropped-area
 fallback is used independently for an area when it has no usable supplied
 weights, a non-finite or negative supplied weight, or a non-positive total.}
+
+\item{temporary_grassland}{Tibble of grassland occupation in the
+\code{\link[=build_grassland_land_extension]{build_grassland_land_extension()}} schema (\code{area_code}, \code{year},
+\code{item_cbs_code}, \code{impact_u}); its CBS 3002 rows are the temporary grassland
+netted out of the arable target so ordinary crops plus CBS 3002 reconcile to
+FAO Arable land (see the temporary-grassland section). If \code{NULL} (default)
+no netting is applied and arable crops reconcile to the full FAO Arable
+land; the land-balance footprint supplies the grassland occupation here.}
 
 \item{items_prod_full}{Crosswalk used to classify \code{item_cbs_code} as arable or
 perennial via \code{Herb_Woody}. Defaults to \link{items_prod_full}.}
@@ -77,20 +86,24 @@ perennial base area is reported as an error because it cannot be reconciled
 without inventing a crop allocation.
 }
 
-The default of \code{\link[=build_cropgrids_land_extension]{build_cropgrids_land_extension()}} and the footprint balance
-are unchanged; this is an additive method.
+This is the crop-side default of the land-balance footprint
+(\code{\link[=build_land_balance_footprint]{build_land_balance_footprint()}}).
 }
-\section{Temporary grassland (do not double-count)}{
+\section{Temporary grassland (no double-count)}{
 
 FAO's \strong{Arable land} total includes \emph{temporary meadows and pastures} —
-temporary grassland is part of cropland, not grassland. This method therefore
-already absorbs the temporary-grassland slice into its arable-crop total. Do
-\strong{not} combine it with CBS 3002 (\verb{Temporary grassland}) from
-\code{\link[=build_grassland_land_extension]{build_grassland_land_extension()}} on top, or that land is counted twice. The
-intended invariant is
-\verb{ordinary crop occupation (incl. fallow) + CBS 3002 = FAO Arable land}.
-Netting modelled CBS 3002 out of the arable target and promoting this method
-to the footprint-balance default is tracked in issue #342.
+temporary grassland is part of cropland, not grassland. That land is also
+reported separately as CBS 3002 (\verb{Temporary grassland}) by
+\code{\link[=build_grassland_land_extension]{build_grassland_land_extension()}}, so summing both extensions naively would
+count it twice. Pass that grassland occupation as \code{temporary_grassland} and
+its CBS 3002 is netted out of the arable target before reconciling ordinary
+crops, enforcing the invariant per \verb{(area_code, year)}
+\verb{ordinary crop occupation (incl. fallow) + CBS 3002 = FAO Arable land}. The
+land-balance footprint (\code{\link[=build_land_balance_footprint]{build_land_balance_footprint()}}) does exactly this. Where
+modelled CBS 3002 exceeds FAO Arable land (survey vs. fodder-reconstruction
+mismatch) the arable target is clamped at 0 and a warning is emitted. Called
+standalone (\code{temporary_grassland = NULL}) no netting is applied and the arable
+crops reconcile to the full FAO Arable land.
 }
 
 \examples{
@@ -113,8 +126,13 @@ items <- tibble::tribble(
   2511L, "Herbaceous",
   2560L, "Woody"
 )
+temporary_grassland <- tibble::tribble(
+  ~area_code, ~year, ~item_cbs_code, ~impact_u,
+  1L, 2020L, 3002L, 100 # temporary grassland netted out of arable
+)
 build_fao_arable_fallow_extension(
   harvested, arable_permanent, base_extension,
+  temporary_grassland = temporary_grassland,
   items_prod_full = items
 )
 }

--- a/tests/testthat/test_crop_land_extension.R
+++ b/tests/testthat/test_crop_land_extension.R
@@ -821,3 +821,81 @@ test_that("positive land targets require crop support", {
     "without positive perennial base area"
   )
 })
+
+test_that("build_fao_arable_fallow_extension nets temporary grassland (CBS 3002) so crop + CBS 3002 = FAO arable", {
+  base <- tibble::tribble(
+    ~year, ~area_code, ~item_cbs_code, ~impact_u,
+    2020L, 1L, 2511L, 300,
+    2020L, 1L, 2513L, 200
+  )
+  ap <- tibble::tribble(
+    ~area_code, ~year, ~arable_ha, ~permanent_ha,
+    1L, 2020L, 600, 0
+  )
+  # FAO arable 600 already contains 100 ha of temporary grassland (CBS 3002).
+  temp <- tibble::tribble(
+    ~area_code, ~year, ~item_cbs_code, ~impact_u,
+    1L, 2020L, 3002L, 100
+  )
+  res <- whep::build_fao_arable_fallow_extension(
+    base_extension = base,
+    arable_permanent = ap,
+    temporary_grassland = temp,
+    items_prod_full = .fao_fallow_items()
+  )
+  # ordinary crops reconcile to the netted arable target 600 - 100 = 500
+  expect_equal(sum(res$impact_u), 500)
+  # the enforced invariant: ordinary crops + CBS 3002 == FAO arable land
+  expect_equal(sum(res$impact_u) + sum(temp$impact_u), 600)
+})
+
+test_that("build_fao_arable_fallow_extension ignores non-3002 grassland rows (no netting)", {
+  base <- tibble::tribble(
+    ~year, ~area_code, ~item_cbs_code, ~impact_u,
+    2020L, 1L, 2511L, 300,
+    2020L, 1L, 2513L, 200
+  )
+  ap <- tibble::tribble(
+    ~area_code, ~year, ~arable_ha, ~permanent_ha,
+    1L, 2020L, 600, 0
+  )
+  # only permanent pasture (CBS 3000); no temporary grassland to net out
+  temp <- tibble::tribble(
+    ~area_code, ~year, ~item_cbs_code, ~impact_u,
+    1L, 2020L, 3000L, 999
+  )
+  res <- whep::build_fao_arable_fallow_extension(
+    base_extension = base,
+    arable_permanent = ap,
+    temporary_grassland = temp,
+    items_prod_full = .fao_fallow_items()
+  )
+  expect_equal(sum(res$impact_u), 600) # full FAO arable target, unchanged
+})
+
+test_that("build_fao_arable_fallow_extension warns and clamps when CBS 3002 exceeds FAO arable", {
+  base <- tibble::tribble(
+    ~year, ~area_code, ~item_cbs_code, ~impact_u,
+    2020L, 1L, 2511L, 300
+  )
+  ap <- tibble::tribble(
+    ~area_code, ~year, ~arable_ha, ~permanent_ha,
+    1L, 2020L, 400, 0
+  )
+  # modelled temporary grassland (500) exceeds FAO arable land (400)
+  temp <- tibble::tribble(
+    ~area_code, ~year, ~item_cbs_code, ~impact_u,
+    1L, 2020L, 3002L, 500
+  )
+  expect_warning(
+    res <- whep::build_fao_arable_fallow_extension(
+      base_extension = base,
+      arable_permanent = ap,
+      temporary_grassland = temp,
+      items_prod_full = .fao_fallow_items()
+    ),
+    "exceeds FAO arable"
+  )
+  # arable target clamped at 0, so no ordinary crop area survives
+  expect_equal(nrow(res), 0L)
+})


### PR DESCRIPTION
## What

Realises the point of #125: promotes `build_fao_arable_fallow_extension()` to the **crop-side default of the land-balance footprint** (`.land_balance_extension()`), replacing `cropgrids_fallow`, and closes the temporary-grassland double-count that switch would otherwise open.

Adds a `temporary_grassland` argument to `build_fao_arable_fallow_extension()`. When supplied (grassland-extension schema), its **CBS 3002** rows are netted out of the FAO arable target before ordinary crops are reconciled, enforcing per `(area_code, year)`:

```
ordinary crop occupation (incl. fallow) + CBS 3002 = FAO Arable land
```

`.land_balance_extension()` builds the grassland occupation once and passes it in, so the exact CBS 3002 it adds back on the grass side is the CBS 3002 netted out on the crop side — the two reconcile to FAO Arable land with no overlap.

## Why

FAO **Arable land** includes *temporary meadows and pastures* — temporary grassland is part of cropland, not grassland (confirmed with the domain author). Since the FAO-arable method reconciles all crops to that total, it already contains temporary grassland; the grassland extension reports the same land again as CBS 3002. Before this PR the crop side used `cropgrids_fallow` so there was no overlap; switching to the FAO-arable method (the whole point) made the double-count live. Netting fixes it.

## Provenance

whep's CBS 3002 is **modelled** (item 996 → fodder reconstruction), not the patchy direct FAO temporary-meadows series, so modelled CBS 3002 is treated as authoritative. Where modelled CBS 3002 exceeds FAO Arable land for a country-year (survey vs. reconstruction mismatch) the arable target is clamped at 0 and a warning is emitted.

## Design note for review

The `@AskUserQuestion` decision was to add a plain 6th argument. On `NULL` I made it a **no-op (no netting)** rather than auto-building the grassland extension from pins, because:
- it keeps `build_fao_arable_fallow_extension()` correct standalone (full arable target when CBS 3002 is not being added), and
- it keeps every pre-existing reconciliation unit test pin-free and unchanged.

The invariant is enforced where it matters — the footprint balance passes the grassland occupation explicitly. Happy to flip `NULL` to auto-build-and-net if you'd rather the extension be self-protecting by default.

## Validation

- 3 new reconciliation tests: netting reconciles crop + CBS 3002 to FAO arable; non-3002 grassland rows ignored; overshoot clamps at 0 and warns.
- `test_crop_land_extension.R`, `test_footprint_balance.R`, `test_footprint.R`, `test_footprint_paths.R`, `test_footprint_grazing.R` all green (FAIL 0 / SKIP 0).
- `air format`, `lintr`, `roxygen2`, pkgdown reference coverage all clean.

Closes #342.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
