### PR TITLE
fix(landuse): net temporary grassland by default when arg omitted

### DIFF
--- a/R/arable_permanent_land.R
+++ b/R/arable_permanent_land.R
@@ -445,11 +445,14 @@ get_arable_permanent_land <- function(
 #' its CBS 3002 is netted out of the arable target before reconciling ordinary
 #' crops, enforcing the invariant per `(area_code, year)`
 #' `ordinary crop occupation (incl. fallow) + CBS 3002 = FAO Arable land`. The
-#' land-balance footprint ([build_land_balance_footprint()]) does exactly this. Where
-#' modelled CBS 3002 exceeds FAO Arable land (survey vs. fodder-reconstruction
-#' mismatch) the arable target is clamped at 0 and a warning is emitted. Called
-#' standalone (`temporary_grassland = NULL`) no netting is applied and the arable
-#' crops reconcile to the full FAO Arable land.
+#' land-balance footprint ([build_land_balance_footprint()]) does exactly this,
+#' passing the grassland occupation it has already built. When
+#' `temporary_grassland` is `NULL` (default) the grassland occupation extension
+#' is built internally so netting still happens — correct but slow, since that
+#' build reruns much of the pipeline; supply the table to avoid the rebuild.
+#' Where modelled CBS 3002 exceeds FAO Arable land (survey vs.
+#' fodder-reconstruction mismatch) the arable target is clamped at 0 and a
+#' warning is emitted.
 #'
 #' @param harvested Tibble of harvested area with columns `year`, `area_code`,
 #'   `item_cbs_code`, `harvested_ha`. If `NULL`, built from
@@ -475,8 +478,9 @@ get_arable_permanent_land <- function(
 #'   `item_cbs_code`, `impact_u`); its CBS 3002 rows are the temporary grassland
 #'   netted out of the arable target so ordinary crops plus CBS 3002 reconcile to
 #'   FAO Arable land (see the temporary-grassland section). If `NULL` (default)
-#'   no netting is applied and arable crops reconcile to the full FAO Arable
-#'   land; the land-balance footprint supplies the grassland occupation here.
+#'   it is built with [build_grassland_land_extension()]`(grassland_metric =
+#'   "occupation")` so netting still applies (correct but slow); supply the table
+#'   to skip that rebuild, or pass one with no CBS 3002 rows to opt out.
 #' @param items_prod_full Crosswalk used to classify `item_cbs_code` as arable or
 #'   perennial via `Herb_Woody`. Defaults to [items_prod_full].
 #'
@@ -647,16 +651,16 @@ build_fao_arable_fallow_extension <- function(
   ap[]
 }
 
-# Temporary grassland (CBS 3002) hectares per (area_code, year). NULL means no
-# netting (standalone use); a supplied table must carry the grassland extension
-# schema (area_code, year, item_cbs_code, impact_u), from which CBS 3002 is kept.
+# Temporary grassland (CBS 3002) hectares per (area_code, year). NULL builds the
+# grassland occupation extension so netting is applied by default (correct but
+# slow); a supplied table (grassland extension schema: area_code, year,
+# item_cbs_code, impact_u) is reused as-is, from which CBS 3002 is kept. Pass a
+# table with no CBS 3002 rows to opt out of netting.
 .temporary_grassland_ha <- function(temporary_grassland) {
   if (is.null(temporary_grassland)) {
-    return(data.table::data.table(
-      area_code = integer(),
-      year = integer(),
-      temp_grassland_ha = numeric()
-    ))
+    temporary_grassland <- build_grassland_land_extension(
+      grassland_metric = "occupation"
+    )
   }
   .check_required_cols(
     temporary_grassland,

--- a/man/build_fao_arable_fallow_extension.Rd
+++ b/man/build_fao_arable_fallow_extension.Rd
@@ -42,8 +42,8 @@ weights, a non-finite or negative supplied weight, or a non-positive total.}
 \code{item_cbs_code}, \code{impact_u}); its CBS 3002 rows are the temporary grassland
 netted out of the arable target so ordinary crops plus CBS 3002 reconcile to
 FAO Arable land (see the temporary-grassland section). If \code{NULL} (default)
-no netting is applied and arable crops reconcile to the full FAO Arable
-land; the land-balance footprint supplies the grassland occupation here.}
+it is built with \code{\link[=build_grassland_land_extension]{build_grassland_land_extension()}}\code{(grassland_metric = "occupation")} so netting still applies (correct but slow); supply the table
+to skip that rebuild, or pass one with no CBS 3002 rows to opt out.}
 
 \item{items_prod_full}{Crosswalk used to classify \code{item_cbs_code} as arable or
 perennial via \code{Herb_Woody}. Defaults to \link{items_prod_full}.}
@@ -99,11 +99,14 @@ count it twice. Pass that grassland occupation as \code{temporary_grassland} and
 its CBS 3002 is netted out of the arable target before reconciling ordinary
 crops, enforcing the invariant per \verb{(area_code, year)}
 \verb{ordinary crop occupation (incl. fallow) + CBS 3002 = FAO Arable land}. The
-land-balance footprint (\code{\link[=build_land_balance_footprint]{build_land_balance_footprint()}}) does exactly this. Where
-modelled CBS 3002 exceeds FAO Arable land (survey vs. fodder-reconstruction
-mismatch) the arable target is clamped at 0 and a warning is emitted. Called
-standalone (\code{temporary_grassland = NULL}) no netting is applied and the arable
-crops reconcile to the full FAO Arable land.
+land-balance footprint (\code{\link[=build_land_balance_footprint]{build_land_balance_footprint()}}) does exactly this,
+passing the grassland occupation it has already built. When
+\code{temporary_grassland} is \code{NULL} (default) the grassland occupation extension
+is built internally so netting still happens — correct but slow, since that
+build reruns much of the pipeline; supply the table to avoid the rebuild.
+Where modelled CBS 3002 exceeds FAO Arable land (survey vs.
+fodder-reconstruction mismatch) the arable target is clamped at 0 and a
+warning is emitted.
 }
 
 \examples{

--- a/tests/testthat/test_crop_land_extension.R
+++ b/tests/testthat/test_crop_land_extension.R
@@ -603,6 +603,15 @@ test_that("land-base readers accept snake case without mutating supplied data ta
   )
 }
 
+# No temporary grassland in the scenario: passed to opt out of CBS 3002 netting
+# so reconciliation-mechanics tests stay pin-free (a NULL default would build
+# the real grassland occupation extension).
+.no_temp_grassland <- function() {
+  tibble::tribble(
+    ~area_code, ~year, ~item_cbs_code, ~impact_u
+  )
+}
+
 test_that("build_fao_arable_fallow_extension distributes fallow summing to fallow_total", {
   base <- tibble::tribble(
     ~year, ~area_code, ~item_cbs_code, ~impact_u,
@@ -616,6 +625,7 @@ test_that("build_fao_arable_fallow_extension distributes fallow summing to fallo
   res <- whep::build_fao_arable_fallow_extension(
     base_extension = base,
     arable_permanent = ap,
+    temporary_grassland = .no_temp_grassland(),
     items_prod_full = .fao_fallow_items()
   )
   # fallow_total = 600 - (300 + 200) = 100, distributed by cropped area share
@@ -639,6 +649,7 @@ test_that("build_fao_arable_fallow_extension gives perennials zero fallow and sc
   res <- whep::build_fao_arable_fallow_extension(
     base_extension = base,
     arable_permanent = ap,
+    temporary_grassland = .no_temp_grassland(),
     items_prod_full = .fao_fallow_items()
   )
   wheat <- res$impact_u[res$item_cbs_code == 2511L]
@@ -665,6 +676,7 @@ test_that("build_fao_arable_fallow_extension leaves intensity-1 arable (FRA/USA-
   res <- whep::build_fao_arable_fallow_extension(
     base_extension = base,
     arable_permanent = ap,
+    temporary_grassland = .no_temp_grassland(),
     items_prod_full = .fao_fallow_items()
   )
   expect_equal(res$impact_u[res$item_cbs_code == 2511L], 480) # unchanged
@@ -688,6 +700,7 @@ test_that("build_fao_arable_fallow_extension scales arable down when cropped phy
   res <- whep::build_fao_arable_fallow_extension(
     base_extension = base,
     arable_permanent = ap,
+    temporary_grassland = .no_temp_grassland(),
     items_prod_full = .fao_fallow_items()
   )
   expect_equal(sum(res$impact_u), 600) # matches the FAO arable total
@@ -723,6 +736,7 @@ test_that("fallow weights fall back independently for unsupported areas", {
     base_extension = base,
     arable_permanent = ap,
     fallow_weights = weights,
+    temporary_grassland = .no_temp_grassland(),
     items_prod_full = .fao_fallow_items()
   )
 
@@ -753,6 +767,7 @@ test_that("impossible arable reconciliation fails explicitly", {
       base_extension = base,
       arable_permanent = ap,
       fallow_weights = weights,
+      temporary_grassland = .no_temp_grassland(),
       items_prod_full = .fao_fallow_items()
     ),
     "Arable totals do not reconcile"
@@ -779,6 +794,7 @@ test_that("invalid custom weights cannot create negative crop areas", {
     base_extension = base,
     arable_permanent = ap,
     fallow_weights = weights,
+    temporary_grassland = .no_temp_grassland(),
     items_prod_full = .fao_fallow_items()
   )
 
@@ -799,6 +815,7 @@ test_that("positive land targets require crop support", {
     whep::build_fao_arable_fallow_extension(
       base_extension = perennial_only,
       arable_permanent = arable_target,
+      temporary_grassland = .no_temp_grassland(),
       items_prod_full = .fao_fallow_items()
     ),
     "without arable crop rows"
@@ -816,6 +833,7 @@ test_that("positive land targets require crop support", {
     whep::build_fao_arable_fallow_extension(
       base_extension = arable_only,
       arable_permanent = permanent_target,
+      temporary_grassland = .no_temp_grassland(),
       items_prod_full = .fao_fallow_items()
     ),
     "without positive perennial base area"


### PR DESCRIPTION
## What

Flips the default netting behaviour of `build_fao_arable_fallow_extension()`. Previously `temporary_grassland = NULL` meant **no netting**; now `NULL` **builds the grassland occupation extension internally and nets CBS 3002 out**.

## Why

Follows up #349. The land-balance footprint always passes the grassland occupation explicitly, so published numbers are unaffected either way. The difference is purely how the function behaves for a caller who uses it directly and forgets the argument:

- **Before:** silently no netting → if they then combine it with the grassland extension, temporary grassland is double-counted (the exact bug this whole line of work fixes).
- **Now:** the function does the right thing by default. It's slower (the internal grassland build reruns much of the pipeline), but **correctness beats speed** here — better to make an uninformed caller wait than hand them a quietly-wrong result.

Escape hatches unchanged: pass the grassland table (as the footprint does) to skip the rebuild; pass a table with no CBS 3002 rows to opt out of netting entirely.

## Changes

- `.temporary_grassland_ha()`: `NULL` now builds `build_grassland_land_extension(grassland_metric = "occupation")` instead of returning empty.
- Docstring (`@param` + temporary-grassland `@section`) updated to describe the new default and the cost.
- Reconciliation-mechanics tests now pass an explicit empty grassland (`.no_temp_grassland()`) so they stay pin-free and fast (a NULL default would otherwise trigger the real build).

## Validation

- `test_crop_land_extension.R` (40 tests) and `test_footprint_balance.R`: FAIL 0 / SKIP 0.
- `air format`, `lintr`, `roxygen2` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
