### PR TITLE
perf(reads): unblock + speed up the global input-reading path (#367)

### DIFF
--- a/R/build_cbs.R
+++ b/R/build_cbs.R
@@ -1679,13 +1679,18 @@ build_processing_coefs <- function(
     )
   ]
 
-  # Source selection: Primary > FBS_New > scaled FBS_Old > other
+  # Source selection: Primary > FBS_New > scaled FBS_Old > other. Coerce every
+  # source to double first: the pivoted FAOSTAT_prod / FAOSTAT_FBS_New inherit
+  # the raw `value` type (integer for some global sources), while FBS_Old_scaled
+  # and other_mean are computed doubles, and fcoalesce() aborts on a mixed
+  # integer/double set. Production quantities are continuous, so double is the
+  # correct common type.
   wide[,
     value := data.table::fcoalesce(
-      FAOSTAT_prod,
-      FAOSTAT_FBS_New,
-      FBS_Old_scaled,
-      other_mean
+      as.double(FAOSTAT_prod),
+      as.double(FAOSTAT_FBS_New),
+      as.double(FBS_Old_scaled),
+      as.double(other_mean)
     )
   ]
   wide[,

--- a/R/build_cbs.R
+++ b/R/build_cbs.R
@@ -1047,13 +1047,22 @@ build_processing_coefs <- function(
     "item_cbs_code",
     "element"
   )
-  out <- dt[,
-    .(
-      value = mean(value, na.rm = TRUE),
-      source = .best_cbs_source(source, year[1L])
-    ),
-    by = key_cols
+  # Best source per group WITHOUT calling .best_cbs_source() per group (which
+  # re-ran .cbs_source_rank()'s case_when for every group). Rank every row once,
+  # then take the mean value and the lowest-ranked (then alphabetical) non-NA
+  # source per group by ordering. Left join reproduces NA source for all-NA
+  # groups, exactly as the per-group call returned.
+  dt[, .src_rank := .cbs_source_rank(source, year)]
+  dt[is.na(.src_rank), .src_rank := .Machine$integer.max]
+  val <- dt[, .(value = mean(value, na.rm = TRUE)), by = key_cols]
+  src <- dt[!is.na(source)]
+  data.table::setorderv(src, c(key_cols, ".src_rank", "source"))
+  src <- src[
+    src[, .I[1L], by = key_cols]$V1,
+    c(key_cols, "source"),
+    with = FALSE
   ]
+  out <- merge(val, src, by = key_cols, all.x = TRUE, sort = FALSE)
   out <- out[!is.nan(value)]
   if (nrow(out) < n_in) {
     cli::cli_alert_info(
@@ -1122,15 +1131,6 @@ build_processing_coefs <- function(
   out <- dt[dt[, .I[1L], by = key_cols]$V1]
   out[, .source_rank := NULL]
   tibble::as_tibble(out)
-}
-
-.best_cbs_source <- function(source, year) {
-  source <- source[!is.na(source)]
-  if (length(source) == 0L) {
-    return(NA_character_)
-  }
-  year <- rep(year, length.out = length(source))
-  source[order(.cbs_source_rank(source, year), source)][[1L]]
 }
 
 .cbs_source_rank <- function(source, year) {
@@ -1757,11 +1757,32 @@ build_processing_coefs <- function(
     ) |>
     .collapse_cbs_observations()
 
-  observed_sources <- data.table::as.data.table(cbs_hist)[
-    !is.na(value),
-    .(observed_source = .best_cbs_source(source, year[1L])),
-    by = c("year", "area", "area_code", "item_cbs", "item_cbs_code", "element")
+  # Vectorised equivalent of the per-group .best_cbs_source() call: rank once,
+  # sort NA/unrecognised sources last, then take the first (best) source per
+  # group. Keeps every !is.na(value) group so all-NA-source groups still yield
+  # observed_source = NA, matching the per-group call.
+  obs_keys <- c(
+    "year",
+    "area",
+    "area_code",
+    "item_cbs",
+    "item_cbs_code",
+    "element"
+  )
+  obs_dt <- data.table::as.data.table(cbs_hist)[!is.na(value)]
+  obs_dt[, .src_rank := .cbs_source_rank(source, year)]
+  obs_dt[is.na(.src_rank) | is.na(source), .src_rank := .Machine$integer.max]
+  data.table::setorderv(
+    obs_dt,
+    c(obs_keys, ".src_rank", "source"),
+    na.last = TRUE
+  )
+  observed_sources <- obs_dt[
+    obs_dt[, .I[1L], by = obs_keys]$V1,
+    c(obs_keys, "source"),
+    with = FALSE
   ]
+  data.table::setnames(observed_sources, "source", "observed_source")
 
   cbs_hist <- cbs_hist |>
     dplyr::select(-dplyr::any_of("source"))

--- a/R/build_production.R
+++ b/R/build_production.R
@@ -2700,17 +2700,25 @@ build_primary_production <- function(
   }
 
   source_key <- c("year", "area", "area_code", "item_prod", "item_prod_code")
-  src_lookup_prod <- df[
+  # Pick the best source per key by ranking every row ONCE and taking the
+  # lowest-ranked (then alphabetical) source per group, instead of calling
+  # .best_prod_source() per group. The per-group call re-ran dplyr::case_when's
+  # formula parsing for every one of millions of groups, which dominated this
+  # step (a ~26 min "Adding historical yields" phase on a global run). Dropping
+  # NA sources up front matches .best_prod_source()'s own NA handling; groups
+  # with only NA sources are simply absent here and pick up NA via the later
+  # left join, exactly as before.
+  ranked <- df[!is.na(source)]
+  ranked[, .src_rank := .prod_source_rank(source)]
+  ranked[is.na(.src_rank), .src_rank := .Machine$integer.max]
+  data.table::setorderv(ranked, c(".src_rank", "source"))
+  src_lookup_prod <- ranked[
     unit %in% c("tonnes", "t"),
-    .(
-      source_prod = .best_prod_source(source)
-    ),
+    .(source_prod = source[1L]),
     by = source_key
   ]
-  src_lookup_any <- df[,
-    .(
-      source_any = .best_prod_source(source)
-    ),
+  src_lookup_any <- ranked[,
+    .(source_any = source[1L]),
     by = source_key
   ]
 

--- a/R/soil_carbon_inputs.R
+++ b/R/soil_carbon_inputs.R
@@ -363,26 +363,41 @@ build_soil_carbon_inputs <- function(
 # polity grain recovers the polity crop area, the grid grain the cell area.
 .sci_sum_components <- function(gridded, keys) {
   cell_keys <- unique(c(keys, "lon", "lat"))
-  per_cell <- gridded |>
-    dplyr::summarise(
-      crop_area_ha = .data$crop_area_ha[1],
-      residue_c_mg = sum(
-        .data$c_mass_mg[.data$input_type == "crop_residue"]
-      ),
-      root_c_mg = sum(.data$c_mass_mg[.data$input_type == "root"]),
-      weed_c_mg = sum(.data$c_mass_mg[.data$input_type == "weed"]),
-      manure_c_mg = sum(.data$c_mass_mg[.data$input_type == "manure"]),
-      .by = dplyr::all_of(cell_keys)
-    )
-  per_cell |>
-    dplyr::summarise(
-      crop_area_ha = sum(.data$crop_area_ha),
-      residue_c_mg = sum(.data$residue_c_mg),
-      root_c_mg = sum(.data$root_c_mg),
-      weed_c_mg = sum(.data$weed_c_mg),
-      manure_c_mg = sum(.data$manure_c_mg),
-      .by = dplyr::all_of(keys)
-    )
+  # Pre-mask the carbon mass by input_type ONCE (vectorised) so the per-cell
+  # aggregation is a plain GForce grouped sum, instead of a dplyr summarise that
+  # re-resolves .data and sub-sets c_mass_mg per group. At global cell grain the
+  # per-group .data-pronoun path dominated the whole soil-carbon-input read.
+  # fifelse propagates NA (in c_mass_mg or input_type) exactly as the
+  # `c_mass_mg[input_type == ...]` subset did; data.table `by=` keeps
+  # first-appearance group order, matching dplyr `.by`.
+  dt <- data.table::as.data.table(gridded)
+  dt[, `:=`(
+    .residue = data.table::fifelse(input_type == "crop_residue", c_mass_mg, 0),
+    .root = data.table::fifelse(input_type == "root", c_mass_mg, 0),
+    .weed = data.table::fifelse(input_type == "weed", c_mass_mg, 0),
+    .manure = data.table::fifelse(input_type == "manure", c_mass_mg, 0)
+  )]
+  per_cell <- dt[,
+    .(
+      crop_area_ha = crop_area_ha[1L],
+      residue_c_mg = sum(.residue),
+      root_c_mg = sum(.root),
+      weed_c_mg = sum(.weed),
+      manure_c_mg = sum(.manure)
+    ),
+    by = cell_keys
+  ]
+  out <- per_cell[,
+    .(
+      crop_area_ha = sum(crop_area_ha),
+      residue_c_mg = sum(residue_c_mg),
+      root_c_mg = sum(root_c_mg),
+      weed_c_mg = sum(weed_c_mg),
+      manure_c_mg = sum(manure_c_mg)
+    ),
+    by = keys
+  ]
+  tibble::as_tibble(as.data.frame(out))
 }
 
 # Per-hectare carbon by dividing the grain's carbon mass by its crop area.

--- a/tests/testthat/test_build_cbs.R
+++ b/tests/testthat/test_build_cbs.R
@@ -249,6 +249,24 @@ test_that(".select_best_source prioritises FAOSTAT_prod source", {
   )
 })
 
+test_that(".select_best_source coalesces integer and double source values", {
+  # Global sources disagree on storage type: the pivoted FAOSTAT_prod /
+  # FAOSTAT_FBS_New inherit an integer raw `value`, while the scaled FBS_Old and
+  # the other-source mean are doubles. fcoalesce() aborts on a mixed set, so the
+  # sources must be coerced to a common numeric type first. Regression for the
+  # global CBS build crashing in `Combining CBS sources`.
+  cbs_raw_all <- tibble::tribble(
+    ~area, ~area_code, ~item_cbs, ~item_cbs_code, ~element, ~year, ~value, ~source, ~unit,
+    "China", 41L, "Wheat", 2511L, "production", 2000L, 100L, "FAOSTAT_prod", "tonnes",
+    "China", 41L, "Wheat", 2511L, "production", 2000L, 90.5, "FAOSTAT_FBS_Old", "tonnes",
+    "Brazil", 21L, "Maize", 2514L, "production", 2000L, 55.2, "FAOSTAT_FBS_Old", "tonnes"
+  )
+  result <- whep:::.select_best_source(cbs_raw_all)
+  expect_type(result$value, "double")
+  expect_equal(result$value[result$area_code == 41L], 100)
+  expect_equal(result$value[result$area_code == 21L], 55.2)
+})
+
 test_that(".select_best_source keys on area_code, not periodized name", {
   # Sources disagree on the `area` name for the same `area_code` (plain name
   # vs periodized polity name). They must still compete on the integer code


### PR DESCRIPTION
## Input-reading path: make global runs possible, then fast (#367, input half)

Input-reading counterpart to #376 (SOC-engine half). Found while running a **global** `build_carbon_balance` end-to-end.

### Part 1 — unblock global runs
A global `build_commodity_balances()` **crashed** in `Combining CBS sources`:
`fcoalesce(FAOSTAT_prod, FAOSTAT_FBS_New, FBS_Old_scaled, other_mean)` mixed integer and double source columns (the pivoted sources inherit the raw `value` type; the scaled/mean sources are doubles), which `fcoalesce()` rejects. The in-package fixtures are all-double, so this only tripped on real global data — **global CBS builds (and thus global carbon-balance runs) were impossible**. Fixed by coercing sources to `double` before coalescing. Regression test added.

### Part 2 — vectorise the source-selection hot paths
Profiling (line-level `Rprof`) showed the ~50-min global read was dominated by **per-group `dplyr::case_when`**: `.best_prod_source` / `.best_cbs_source` were called once per group, each re-parsing an 11-branch `case_when`, over millions of `(year, area, item)` groups. Rewrote all three sites (`.add_historical_yields`, `.prepare_historical_cbs`, `.cbs_extend_historical`) to **rank every row once, then pick the best source per group by ordering** — no R-function-per-group. Removed the now-dead `.best_cbs_source`. Each change verified **byte-identical** to the per-group logic across NA / tie / unrecognised / year-dependent-historical edge cases.

### Part 3 — vectorise the gridding carbon-input aggregation
`.sci_sum_components` (the per-cell aggregation in `build_soil_carbon_inputs`) ran four filtered `sum(.data$c_mass_mg[.data$input_type == "…"])` aggregations per cell via `dplyr::summarise`, re-resolving the `.data` pronoun over millions of global cells (~33% of that read). Rewrote it to pre-mask by `input_type` once with `data.table::fifelse`, then plain GForce grouped sums — **byte-identical** (`identical()` TRUE across missing-type / NA / tie cases; `data.table` `by=` preserves dplyr `.by`'s first-appearance order). `build_soil_carbon_inputs(years = 2000:2002)`: **1244 s → 428 s** (~2.9×).

### Measured impact (global, 1850–2023)

| Stage | Before | After |
|---|---|---|
| `build_primary_production` | (in the ~50-min read; `Adding historical yields` alone 26 min) | **2.6 min** |
| `build_commodity_balances` | crashed in source combining | **4.0 min** |
| **prod + CBS total** | ~50 min **and crashing** | **6.6 min** |

(Representative micro-timings: `build_primary_production(1940,1975)` 327s→43s; `build_commodity_balances(pp)` 312s→139s.)

### Deferred (tracked, non-blocking)
- **#388** — the residual CBS cost is now distributed data.table `setkey`/`merge` across the `.fix_cbs` balancing chain (no single-line anti-pattern); a deeper key-once/`on=`-join restructuring is tracked there. Not forced here because it can't be made byte-identical-safe as a quick change.
- **#390** — after the `.sci_sum_components` fix, the gridding/livestock read's residual cost is likewise distributed data.table `forderv`/`bmerge` (the `.sci_to_grid` many-to-many spread + livestock-flow merges); same nature as #388, deferred for the same reason.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

