### PR TITLE
feat(consolidate_sources): positive-only coverage + per-source quality-tier variants

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -66,6 +66,13 @@
   `live_anim_code` is supplied as an integer.
 * Fix `build_io_model()` not passing the now-required `feed_mode` argument to
   the feed-redistribution step.
+* `consolidate_sources()` gains two opt-in `tie_break` options for panels whose
+  sources report exact zeros or several quality variants of one cell.
+  `coverage = "positive"` counts the coverage tie-break over strictly positive
+  values instead of non-missing ones, so a zero-padded series no longer wins on
+  inflated coverage; `quality_variants = TRUE` collapses a source's several
+  `quality_col` variants of a cell to its best-ranked one instead of aborting.
+  Both default to the previous behaviour (#139).
 
 # whep 0.3.0
 

--- a/R/consolidate_sources.R
+++ b/R/consolidate_sources.R
@@ -36,7 +36,11 @@
 #'   are broken by broader within-series coverage (the count of cells the source
 #'   reports across the `.by` group) when `tie_break$coverage`, then by
 #'   `tie_break$quality_col` ordered per `tie_break$quality_levels`, then by
-#'   ascending source name (reported when `verbose`).
+#'   ascending source name (reported when `verbose`). Coverage counts the cells
+#'   where `value_col` is non-missing, or only the strictly positive ones under
+#'   `tie_break$coverage = "positive"`, for panels where an exact zero reads as
+#'   "not reported" as often as "measured zero" and would otherwise inflate the
+#'   coverage of a mostly-zero series.
 #'
 #'   4. **Continuity override.** When enabled, an isolated single-period winner
 #'   flip is reverted: if the immediately preceding and following periods share
@@ -55,12 +59,17 @@
 #'   cannot arbitrate cells whose sources report different measures.
 #'
 #'   The input must hold at most one row per source per cell; pre-aggregate any
-#'   sub-detail rows first (the function aborts on duplicates rather than sum
-#'   silently).
+#'   sub-detail rows first (by default the function aborts on duplicates rather
+#'   than sum silently). Set `tie_break$quality_variants` when a source
+#'   legitimately contributes several `tie_break$quality_col` variants of one
+#'   cell (an observed and an interpolated estimate, say): the variants then
+#'   collapse to the best-ranked one before any other stage, and only rows
+#'   sharing a source, a cell *and* a quality level still abort.
 #'
 #' @param data A tibble with one row per source per (`.by`, `time_col`) cell.
 #' @param value_col Unquoted name of the value column. Coverage counts the cells
-#'   where this column is non-missing.
+#'   where this column is non-missing, or only those where it is strictly
+#'   positive when `tie_break$coverage` is `"positive"`.
 #' @param source_col Unquoted name of the source-label column.
 #' @param priority Source-to-rank map, as either a named integer vector
 #'   (`c(OWID = 1L, Malanima = 4L)`) or a two-column data frame (source, rank).
@@ -86,16 +95,24 @@
 #'     to, such as `~ region == "WLD"`, evaluated on the rows that survive
 #'     the hard drop. Default: `NULL`.
 #' @param tie_break Optional named list of options breaking equal-rank ties:
-#'   * `coverage`: logical, break ties by broader within-series coverage.
-#'     Default: `TRUE`.
+#'   * `coverage`: break ties by broader within-series coverage. `TRUE`
+#'     (default), or equivalently `"nonmissing"`, counts the cells where
+#'     `value_col` is non-missing; `"positive"` counts only the cells where it
+#'     is strictly positive (`value_col` must then be numeric); `FALSE`
+#'     disables the coverage tie-break.
 #'   * `quality_col`: string naming a quality column used as a tie-break
 #'     after coverage. Default: `NULL`.
 #'   * `quality_levels`: character vector ordering `quality_col` values best
 #'     first (unlisted values rank last). Required when `quality_col` is set.
+#'   * `quality_variants`: logical. When `TRUE`, a source contributing several
+#'     `quality_col` variants of one cell keeps its best-ranked variant instead
+#'     of aborting; rows sharing source, cell and quality level still abort, as
+#'     do variants whose best rank is not unique. Requires `quality_col`.
+#'     Default: `FALSE`.
 #' @param continuity_override Logical. Revert isolated single-period winner
 #'   flips. Default: `TRUE`.
-#' @param verbose Logical. Report the drop count, name-order ties, and
-#'   continuity reversions. Default: `TRUE`.
+#' @param verbose Logical. Report the drop count, any resolved quality variants,
+#'   name-order ties, and continuity reversions. Default: `TRUE`.
 #'
 #' @return
 #'   A tibble with the winning row per (`.by`, `time_col`) cell, the original
@@ -160,7 +177,7 @@ consolidate_sources <- function(
   if (nrow(work) == 0L) {
     return(.cs_empty_result(data))
   }
-  .cs_assert_unique(work, c(cell_keys, cols$source))
+  work <- .cs_resolve_variants(work, cell_keys, cols, tie_break, verbose)
 
   work <- .cs_add_effective_rank(work, measure)
   work <- .cs_add_tiebreaks(work, cols, tie_break)
@@ -180,8 +197,22 @@ consolidate_sources <- function(
 }
 
 .cs_tie_break_opts <- function(tie_break) {
-  defaults <- list(coverage = TRUE, quality_col = NULL, quality_levels = NULL)
+  defaults <- list(
+    coverage = TRUE,
+    quality_col = NULL,
+    quality_levels = NULL,
+    quality_variants = FALSE
+  )
   .cs_merge_opts(tie_break, defaults, "tie_break")
+}
+
+# "off" | "nonmissing" | "positive". `TRUE`/`FALSE` are the historical spellings
+# of "nonmissing"/"off" and stay accepted.
+.cs_coverage_mode <- function(coverage) {
+  if (rlang::is_bool(coverage)) {
+    return(if (coverage) "nonmissing" else "off")
+  }
+  coverage
 }
 
 .cs_merge_opts <- function(opts, defaults, arg_name) {
@@ -212,11 +243,7 @@ consolidate_sources <- function(
   if (length(missing) > 0L) {
     cli::cli_abort("Column{?s} not found in `data`: {.val {missing}}.")
   }
-  if (!is.null(tie_break$quality_col) && is.null(tie_break$quality_levels)) {
-    cli::cli_abort(
-      "`tie_break$quality_levels` is required when `tie_break$quality_col` is set."
-    )
-  }
+  .cs_check_tie_break(data, cols, tie_break)
   .cs_check_measure_basis(data, measure$basis, cols$source)
   reserved <- c("n_sources", "source_rank", "effective_rank", "measure_demoted")
   clash <- intersect(reserved, names(data))
@@ -224,6 +251,44 @@ consolidate_sources <- function(
     cli::cli_abort(
       "`data` already has reserved output column{?s}: {.val {clash}}."
     )
+  }
+  invisible(NULL)
+}
+
+.cs_check_tie_break <- function(data, cols, tie_break) {
+  if (!is.null(tie_break$quality_col) && is.null(tie_break$quality_levels)) {
+    cli::cli_abort(
+      "`tie_break$quality_levels` is required when `tie_break$quality_col` is set."
+    )
+  }
+  .cs_check_coverage_opt(tie_break$coverage, data, cols$value)
+  if (!rlang::is_bool(tie_break$quality_variants)) {
+    cli::cli_abort("`tie_break$quality_variants` must be `TRUE` or `FALSE`.")
+  }
+  if (tie_break$quality_variants && is.null(tie_break$quality_col)) {
+    cli::cli_abort(c(
+      "`tie_break$quality_variants` requires `tie_break$quality_col`.",
+      "i" = "Variants are resolved by `tie_break$quality_levels` order."
+    ))
+  }
+  invisible(NULL)
+}
+
+.cs_check_coverage_opt <- function(coverage, data, value_name) {
+  known <- c("nonmissing", "positive")
+  ok <- rlang::is_bool(coverage) ||
+    (rlang::is_string(coverage) && coverage %in% known)
+  if (!ok) {
+    cli::cli_abort(
+      "`tie_break$coverage` must be {.code TRUE}, {.code FALSE}, {.val nonmissing} or {.val positive}."
+    )
+  }
+  positive <- identical(.cs_coverage_mode(coverage), "positive")
+  if (positive && !is.numeric(data[[value_name]])) {
+    cli::cli_abort(c(
+      "`tie_break$coverage = \"positive\"` needs a numeric value column.",
+      "i" = "{.val {value_name}} is {.cls {class(data[[value_name]])}}."
+    ))
   }
   invisible(NULL)
 }
@@ -247,14 +312,21 @@ consolidate_sources <- function(
   invisible(NULL)
 }
 
-.cs_assert_unique <- function(work, keys) {
-  if (anyDuplicated(work[keys]) > 0L) {
+.cs_assert_unique <- function(work, keys, quality_col = NULL) {
+  if (anyDuplicated(work[keys]) == 0L) {
+    return(invisible(NULL))
+  }
+  if (is.null(quality_col)) {
     cli::cli_abort(c(
       "Multiple rows share the same source and cell.",
-      "i" = "Pre-aggregate `data` to one row per source per cell first."
+      "i" = "Pre-aggregate `data` to one row per source per cell first.",
+      "i" = "Set `tie_break$quality_variants = TRUE` to keep a source's best quality variant instead."
     ))
   }
-  invisible(NULL)
+  cli::cli_abort(c(
+    "Multiple rows share the same source, cell and {.val {quality_col}} value.",
+    "i" = "Pre-aggregate `data` to one row per source per cell and quality level first."
+  ))
 }
 
 # --- Priority and hard drop ---------------------------------------------------
@@ -299,6 +371,64 @@ consolidate_sources <- function(
   out$effective_rank <- integer(0)
   out$measure_demoted <- logical(0)
   out
+}
+
+# --- Per-source quality variants ----------------------------------------------
+
+# Duplicate (cell, source) rows abort by default: silently summing them would
+# hide a double-counted series. When `tie_break$quality_variants` is on they are
+# read as one source's quality variants of the same cell (an observed and an
+# interpolated estimate, say) and collapse to the best-ranked variant. This runs
+# before coverage and rank, so every later stage still sees one row per source
+# per cell. It only ever drops rows, never reorders them.
+.cs_resolve_variants <- function(work, cell_keys, cols, tie_break, verbose) {
+  keys <- c(cell_keys, cols$source)
+  if (!tie_break$quality_variants) {
+    .cs_assert_unique(work, keys)
+    return(work)
+  }
+  quality_col <- tie_break$quality_col
+  .cs_assert_unique(work, c(keys, quality_col), quality_col)
+  best <- .cs_best_variant_mask(
+    work[keys],
+    .cs_quality_rank(work[[quality_col]], tie_break$quality_levels)
+  )
+  .cs_check_variant_tie(work[best, keys, drop = FALSE])
+  .cs_log_variants(sum(!best), verbose)
+  work[best, , drop = FALSE]
+}
+
+.cs_best_variant_mask <- function(key_df, rank) {
+  key_names <- names(key_df)
+  key_df$.variant_rank <- rank
+  key_df |>
+    dplyr::mutate(
+      .best_variant = .variant_rank == min(.variant_rank),
+      .by = dplyr::all_of(key_names)
+    ) |>
+    dplyr::pull(.best_variant)
+}
+
+# Every quality value outside `quality_levels` ranks last, so two unlisted
+# variants of one cell tie for best. Resolving that would need a tie-break the
+# caller never stated, so it aborts instead.
+.cs_check_variant_tie <- function(best_keys) {
+  if (anyDuplicated(best_keys) > 0L) {
+    cli::cli_abort(c(
+      "Per-source cell variants tie on best quality rank.",
+      "i" = "Values outside `tie_break$quality_levels` all rank last; list every quality level to break the tie."
+    ))
+  }
+  invisible(NULL)
+}
+
+.cs_log_variants <- function(n_dropped, verbose) {
+  if (verbose && n_dropped > 0L) {
+    cli::cli_alert_info(
+      "Resolved {n_dropped} per-source cell variant{?s} to the best quality level."
+    )
+  }
+  invisible(NULL)
 }
 
 # --- Effective rank (measure demotion) ----------------------------------------
@@ -348,9 +478,10 @@ consolidate_sources <- function(
 
 .cs_add_tiebreaks <- function(work, cols, tie_break) {
   cell_keys <- c(cols$by, cols$time)
+  mode <- .cs_coverage_mode(tie_break$coverage)
   work$.value_na <- is.na(work[[cols$value]])
-  work <- .cs_add_coverage(work, cols$by, cols$source, cols$value, cols$time)
-  work$.coverage_ord <- if (tie_break$coverage) work$.coverage else 0L
+  work <- .cs_add_coverage(work, cols, mode)
+  work$.coverage_ord <- if (mode == "off") 0L else work$.coverage
   work$.quality_rank <- if (is.null(tie_break$quality_col)) {
     0L
   } else {
@@ -362,9 +493,10 @@ consolidate_sources <- function(
   .cs_add_n_sources(work, cell_keys, cols$source)
 }
 
-.cs_add_coverage <- function(work, by, source_name, value_name, time_name) {
-  grp <- c(by, source_name)
-  cov <- work[!is.na(work[[value_name]]), c(grp, time_name), drop = FALSE]
+.cs_add_coverage <- function(work, cols, mode) {
+  grp <- c(cols$by, cols$source)
+  counted <- .cs_coverage_keep(work[[cols$value]], mode)
+  cov <- work[counted, c(grp, cols$time), drop = FALSE]
   cov <- dplyr::distinct(cov)
   cov <- dplyr::count(
     cov,
@@ -374,6 +506,16 @@ consolidate_sources <- function(
   out <- dplyr::left_join(work, cov, by = grp)
   out$.coverage <- dplyr::coalesce(out$.coverage, 0L)
   out
+}
+
+# Which cells count towards a source's coverage. "positive" exists for panels
+# where an exact zero reads as "not reported" as often as "measured zero", so
+# counting it would inflate the coverage of a series that is mostly zeros.
+.cs_coverage_keep <- function(x, mode) {
+  if (identical(mode, "positive")) {
+    return(!is.na(x) & x > 0)
+  }
+  !is.na(x)
 }
 
 .cs_add_n_sources <- function(work, cell_keys, source_name) {

--- a/R/utils.R
+++ b/R/utils.R
@@ -1461,6 +1461,8 @@ utils::globalVariables(
     ".effective_rank",
     ".coverage_ord",
     ".quality_rank",
+    ".variant_rank",
+    ".best_variant",
     ".prev_source",
     ".next_source",
     ".prev_time",

--- a/man/consolidate_sources.Rd
+++ b/man/consolidate_sources.Rd
@@ -22,7 +22,8 @@ consolidate_sources(
 \item{data}{A tibble with one row per source per (\code{.by}, \code{time_col}) cell.}
 
 \item{value_col}{Unquoted name of the value column. Coverage counts the cells
-where this column is non-missing.}
+where this column is non-missing, or only those where it is strictly
+positive when \code{tie_break$coverage} is \code{"positive"}.}
 
 \item{source_col}{Unquoted name of the source-label column.}
 
@@ -58,19 +59,27 @@ the hard drop. Default: \code{NULL}.
 
 \item{tie_break}{Optional named list of options breaking equal-rank ties:
 \itemize{
-\item \code{coverage}: logical, break ties by broader within-series coverage.
-Default: \code{TRUE}.
+\item \code{coverage}: break ties by broader within-series coverage. \code{TRUE}
+(default), or equivalently \code{"nonmissing"}, counts the cells where
+\code{value_col} is non-missing; \code{"positive"} counts only the cells where it
+is strictly positive (\code{value_col} must then be numeric); \code{FALSE}
+disables the coverage tie-break.
 \item \code{quality_col}: string naming a quality column used as a tie-break
 after coverage. Default: \code{NULL}.
 \item \code{quality_levels}: character vector ordering \code{quality_col} values best
 first (unlisted values rank last). Required when \code{quality_col} is set.
+\item \code{quality_variants}: logical. When \code{TRUE}, a source contributing several
+\code{quality_col} variants of one cell keeps its best-ranked variant instead
+of aborting; rows sharing source, cell and quality level still abort, as
+do variants whose best rank is not unique. Requires \code{quality_col}.
+Default: \code{FALSE}.
 }}
 
 \item{continuity_override}{Logical. Revert isolated single-period winner
 flips. Default: \code{TRUE}.}
 
-\item{verbose}{Logical. Report the drop count, name-order ties, and
-continuity reversions. Default: \code{TRUE}.}
+\item{verbose}{Logical. Report the drop count, any resolved quality variants,
+name-order ties, and continuity reversions. Default: \code{TRUE}.}
 }
 \value{
 A tibble with the winning row per (\code{.by}, \code{time_col}) cell, the original
@@ -116,7 +125,11 @@ rows with a real value the winner is the row of lowest effective rank; ties
 are broken by broader within-series coverage (the count of cells the source
 reports across the \code{.by} group) when \code{tie_break$coverage}, then by
 \code{tie_break$quality_col} ordered per \code{tie_break$quality_levels}, then by
-ascending source name (reported when \code{verbose}).
+ascending source name (reported when \code{verbose}). Coverage counts the cells
+where \code{value_col} is non-missing, or only the strictly positive ones under
+\code{tie_break$coverage = "positive"}, for panels where an exact zero reads as
+"not reported" as often as "measured zero" and would otherwise inflate the
+coverage of a mostly-zero series.
 \item \strong{Continuity override.} When enabled, an isolated single-period winner
 flip is reverted: if the immediately preceding and following periods share
 a different winner that also reports the middle period, that continuous
@@ -135,8 +148,12 @@ measure identity is part of the dedup key's semantics, and priority alone
 cannot arbitrate cells whose sources report different measures.
 
 The input must hold at most one row per source per cell; pre-aggregate any
-sub-detail rows first (the function aborts on duplicates rather than sum
-silently).
+sub-detail rows first (by default the function aborts on duplicates rather
+than sum silently). Set \code{tie_break$quality_variants} when a source
+legitimately contributes several \code{tie_break$quality_col} variants of one
+cell (an observed and an interpolated estimate, say): the variants then
+collapse to the best-ranked one before any other stage, and only rows
+sharing a source, a cell \emph{and} a quality level still abort.
 }
 \examples{
 panel <- tibble::tribble(

--- a/tests/testthat/test_consolidate_sources.R
+++ b/tests/testthat/test_consolidate_sources.R
@@ -150,6 +150,108 @@ testthat::test_that("broader coverage breaks an equal-rank tie and beats name or
   )
 })
 
+# Positive-only coverage -------------------------------------------------------
+
+# A mostly-zero series and a shorter all-positive one, both rank 4, contesting
+# 1902. Non-missing coverage counts the zeros (5 > 3) and picks the zero-padded
+# source; strictly-positive coverage counts only real quantities (3 > 1) and
+# picks the shorter one. The source names are chosen so that in each direction
+# the expected winner is NOT the one ascending name order would pick, which
+# rules out the name-order fallback deciding the cell.
+zero_padded_panel <- function(wide_source, narrow_source) {
+  tibble::tribble(
+    ~year, ~region, ~category, ~source, ~value,
+    1900, "GBR", "Biomass", wide_source, 0,
+    1901, "GBR", "Biomass", wide_source, 0,
+    1902, "GBR", "Biomass", wide_source, 5,
+    1903, "GBR", "Biomass", wide_source, 0,
+    1904, "GBR", "Biomass", wide_source, 0,
+    1901, "GBR", "Biomass", narrow_source, 7,
+    1902, "GBR", "Biomass", narrow_source, 8,
+    1903, "GBR", "Biomass", narrow_source, 9
+  )
+}
+
+consolidate_zero_padded <- function(panel, coverage) {
+  whep::consolidate_sources(
+    panel,
+    value_col = value,
+    source_col = source,
+    priority = c(Zeta = 4L, Beta = 4L, Alpha = 4L, Zulu = 4L),
+    .by = c("region", "category"),
+    tie_break = list(coverage = coverage),
+    verbose = FALSE
+  )
+}
+
+testthat::test_that("coverage counts non-missing cells by default", {
+  # Zeta pads four zero-years around a single real 1902 value; Beta reports
+  # three real years. Non-missing coverage is 5 vs 3, so Zeta takes 1902 even
+  # though ascending name order would have picked Beta.
+  panel <- zero_padded_panel("Zeta", "Beta")
+
+  default <- consolidate_zero_padded(panel, coverage = TRUE)
+  win_1902 <- default[default$year == 1902, ]
+  testthat::expect_equal(win_1902$source, "Zeta")
+  testthat::expect_equal(win_1902$value, 5)
+
+  # `TRUE` and "nonmissing" are the same option spelled two ways.
+  spelled <- consolidate_zero_padded(panel, coverage = "nonmissing")
+  testthat::expect_equal(spelled, default)
+
+  # Omitting `tie_break` entirely must match the explicit default.
+  implicit <- whep::consolidate_sources(
+    panel,
+    value_col = value,
+    source_col = source,
+    priority = c(Zeta = 4L, Beta = 4L),
+    .by = c("region", "category"),
+    verbose = FALSE
+  )
+  testthat::expect_equal(implicit, default)
+})
+
+testthat::test_that("coverage = 'positive' flips a tie the zeros would decide", {
+  # Same shape, names swapped so the strictly-positive winner is the one
+  # ascending name order would NOT pick: Alpha pads zeros, Zulu reports three
+  # real years. Positive coverage is 1 vs 3, so Zulu takes 1902.
+  panel <- zero_padded_panel("Alpha", "Zulu")
+
+  nonmissing <- consolidate_zero_padded(panel, coverage = TRUE)
+  testthat::expect_equal(nonmissing[nonmissing$year == 1902, ]$source, "Alpha")
+
+  positive <- consolidate_zero_padded(panel, coverage = "positive")
+  win_1902 <- positive[positive$year == 1902, ]
+  testthat::expect_equal(win_1902$source, "Zulu")
+  testthat::expect_equal(win_1902$value, 8)
+
+  # The zero-padded source still wins the years only it reports: positive
+  # coverage changes the tie-break, not which cells exist.
+  testthat::expect_equal(positive[positive$year == 1900, ]$source, "Alpha")
+  testthat::expect_equal(positive[positive$year == 1900, ]$value, 0)
+})
+
+testthat::test_that("coverage option is validated", {
+  panel <- zero_padded_panel("Alpha", "Zulu")
+
+  testthat::expect_error(
+    consolidate_zero_padded(panel, coverage = "nonzero"),
+    "must be"
+  )
+  testthat::expect_error(
+    consolidate_zero_padded(panel, coverage = c("positive", "positive")),
+    "must be"
+  )
+
+  # Strict positivity is undefined for a non-numeric value column.
+  chr_panel <- panel
+  chr_panel$value <- as.character(chr_panel$value)
+  testthat::expect_error(
+    consolidate_zero_padded(chr_panel, coverage = "positive"),
+    "numeric value column"
+  )
+})
+
 # Quality preference -----------------------------------------------------------
 
 testthat::test_that("quality_col decides an equal-rank, equal-coverage tie", {
@@ -499,4 +601,136 @@ testthat::test_that("consolidate_sources aborts on duplicate source-cell rows", 
     ),
     "one row per source per cell"
   )
+})
+
+# Per-source quality variants --------------------------------------------------
+
+# BOKU contributes two data-tier variants of the same 1919 cell (an Estimated
+# and an Interpolated figure), the pattern the energy-hist panel carries into
+# its own tier tie-break. IEA reports the cell once at a worse priority.
+variant_panel <- tibble::tribble(
+  ~year, ~region, ~category, ~source, ~value, ~tier,
+  1919, "AUT", "Food_feed", "BOKU", 1.5, "Estimated",
+  1919, "AUT", "Food_feed", "BOKU", 9.9, "Interpolated",
+  1919, "AUT", "Food_feed", "IEA", 3.0, "Observed"
+)
+
+consolidate_variants <- function(panel, levels = tier_levels, ...) {
+  whep::consolidate_sources(
+    panel,
+    value_col = value,
+    source_col = source,
+    priority = c(BOKU = 2L, IEA = 5L),
+    .by = c("region", "category"),
+    tie_break = list(
+      quality_col = "tier",
+      quality_levels = levels,
+      quality_variants = TRUE
+    ),
+    ...
+  )
+}
+
+testthat::test_that("quality_variants keeps a source's best tier variant", {
+  won <- consolidate_variants(variant_panel, verbose = FALSE)
+
+  # BOKU outranks IEA, and its Estimated variant outranks its Interpolated one.
+  testthat::expect_equal(nrow(won), 1L)
+  testthat::expect_equal(won$source, "BOKU")
+  testthat::expect_equal(won$tier, "Estimated")
+  testthat::expect_equal(won$value, 1.5)
+  # The collapsed variant must not inflate the contesting-source count.
+  testthat::expect_equal(won$n_sources, 2L)
+
+  # The variant is chosen by `quality_levels` order, not by row order: reversing
+  # the ordering hands the cell to the Interpolated row.
+  reversed <- consolidate_variants(
+    variant_panel,
+    levels = rev(tier_levels),
+    verbose = FALSE
+  )
+  testthat::expect_equal(reversed$tier, "Interpolated")
+  testthat::expect_equal(reversed$value, 9.9)
+})
+
+testthat::test_that("quality_variants is opt-in and off by default", {
+  # The same panel aborts under the default: a source with two rows in one cell
+  # is a double-count until the caller says otherwise.
+  testthat::expect_error(
+    whep::consolidate_sources(
+      variant_panel,
+      value_col = value,
+      source_col = source,
+      priority = c(BOKU = 2L, IEA = 5L),
+      .by = c("region", "category"),
+      tie_break = list(quality_col = "tier", quality_levels = tier_levels),
+      verbose = FALSE
+    ),
+    "one row per source per cell"
+  )
+
+  # It also needs a quality column to resolve the variants with.
+  testthat::expect_error(
+    whep::consolidate_sources(
+      variant_panel,
+      value_col = value,
+      source_col = source,
+      priority = c(BOKU = 2L, IEA = 5L),
+      .by = c("region", "category"),
+      tie_break = list(quality_variants = TRUE),
+      verbose = FALSE
+    ),
+    "requires `tie_break\\$quality_col`"
+  )
+})
+
+testthat::test_that("quality_variants still aborts on unresolvable duplicates", {
+  # Two rows sharing source, cell AND tier are a true duplicate, not a variant.
+  same_tier <- tibble::tribble(
+    ~year, ~region, ~category, ~source, ~value, ~tier,
+    1919, "AUT", "Food_feed", "BOKU", 1.5, "Estimated",
+    1919, "AUT", "Food_feed", "BOKU", 9.9, "Estimated"
+  )
+  testthat::expect_error(
+    consolidate_variants(same_tier, verbose = FALSE),
+    "one row per source per cell and quality level"
+  )
+
+  # Two variants whose tiers are both outside `quality_levels` tie for best
+  # rank, and resolving that would need a tie-break the caller never stated.
+  unlisted <- tibble::tribble(
+    ~year, ~region, ~category, ~source, ~value, ~tier,
+    1919, "AUT", "Food_feed", "BOKU", 1.5, "Guessed",
+    1919, "AUT", "Food_feed", "BOKU", 9.9, "Assumed"
+  )
+  testthat::expect_error(
+    consolidate_variants(unlisted, verbose = FALSE),
+    "tie on best quality rank"
+  )
+})
+
+testthat::test_that("verbose mode reports resolved quality variants", {
+  msgs <- testthat::capture_messages(
+    consolidate_variants(variant_panel, verbose = TRUE)
+  )
+  testthat::expect_true(any(grepl("Resolved 1 per-source cell variant", msgs)))
+})
+
+testthat::test_that("quality_variants is inert on a panel without variants", {
+  # Turning the option on must not change a panel that already holds one row
+  # per source per cell: the resolution only ever drops losing variants.
+  panel <- variant_panel[variant_panel$tier != "Interpolated", ]
+
+  opted_in <- consolidate_variants(panel, verbose = FALSE)
+  plain <- whep::consolidate_sources(
+    panel,
+    value_col = value,
+    source_col = source,
+    priority = c(BOKU = 2L, IEA = 5L),
+    .by = c("region", "category"),
+    tie_break = list(quality_col = "tier", quality_levels = tier_levels),
+    verbose = FALSE
+  )
+
+  testthat::expect_equal(opted_in, plain)
 })

--- a/tests/testthat/test_consolidate_sources.R
+++ b/tests/testthat/test_consolidate_sources.R
@@ -716,6 +716,42 @@ testthat::test_that("verbose mode reports resolved quality variants", {
   testthat::expect_true(any(grepl("Resolved 1 per-source cell variant", msgs)))
 })
 
+testthat::test_that("positive coverage counts the surviving best variant", {
+  # Pins the ordering of the two options: variants are resolved BEFORE coverage
+  # is counted. BOKU's 1919 coverage therefore comes from the Estimated 0 that
+  # wins its variant contest, not from the Interpolated 4 that loses it, so
+  # BOKU covers one positive year against Zed's two and Zed takes 1919 --
+  # against the ascending name order, which would have picked BOKU.
+  panel <- tibble::tribble(
+    ~year, ~region, ~category, ~source, ~value, ~tier,
+    1919, "AUT", "Food_feed", "BOKU", 0, "Estimated",
+    1919, "AUT", "Food_feed", "BOKU", 4, "Interpolated",
+    1920, "AUT", "Food_feed", "BOKU", 3, "Estimated",
+    1919, "AUT", "Food_feed", "Zed", 9, "Observed",
+    1920, "AUT", "Food_feed", "Zed", 8, "Observed"
+  )
+
+  won <- whep::consolidate_sources(
+    panel,
+    value_col = value,
+    source_col = source,
+    priority = c(BOKU = 4L, Zed = 4L),
+    .by = c("region", "category"),
+    tie_break = list(
+      coverage = "positive",
+      quality_col = "tier",
+      quality_levels = tier_levels,
+      quality_variants = TRUE
+    ),
+    verbose = FALSE
+  )
+
+  win_1919 <- won[won$year == 1919, ]
+  testthat::expect_equal(win_1919$source, "Zed")
+  testthat::expect_equal(win_1919$value, 9)
+  testthat::expect_equal(win_1919$n_sources, 2L)
+})
+
 testthat::test_that("quality_variants is inert on a panel without variants", {
   # Turning the option on must not change a panel that already holds one row
   # per source per cell: the resolution only ever drops losing variants.


### PR DESCRIPTION
Closes #139.

## Motivation

energy-hist's W1 gate evaluated `consolidate_sources()` as the replacement for its local category-winner engine (`collapse_to_category_winner()`, `R/long-term-energy/utils.R`). The argument mapping was faithful, but the consolidated panel's md5 changed, so under the gate's rule (divergences are fixed in WHEP, not shipped downstream) the swap was reverted. Two semantic gaps caused the divergence. This PR closes both as opt-in `tie_break` options, so the re-swap can run under the same bit-identical md5 gate.

## (a) `tie_break$coverage` accepts a counting basis

`coverage` was a logical on/off switch and coverage was always the count of non-missing cells. It now also accepts a string:

| value | meaning |
|---|---|
| `TRUE` (default) | count the cells where `value_col` is non-missing |
| `"nonmissing"` | the same, spelled out |
| `"positive"` | count only the cells where `value_col` is strictly positive |
| `FALSE` | no coverage tie-break |

In energy data an exact zero means "not reported" about as often as "measured zero", so a series padded with zeros (a fuel before its onset, an all-zero seed) gets inflated coverage and wins the tie-break against a shorter series of real quantities. That flipped roughly 123 winner cells in the energy-hist panel. `"positive"` requires a numeric `value_col` and aborts otherwise, since strict positivity is undefined for anything else.

## (b) `tie_break$quality_variants` tolerates per-source quality variants

`quality_variants` is a new logical, default `FALSE`. It requires `quality_col` (and therefore `quality_levels`).

When `TRUE`, several rows of one source in one cell are read as that source's quality variants (an observed and an interpolated estimate of the same quantity; 184 such cells in the energy-hist panel) and collapse to the best-ranked variant by `quality_levels` order, instead of aborting. It still aborts on:

- rows sharing source, cell **and** quality level, which are a true duplicate rather than a variant, and
- variants whose best rank is not unique. Every value outside `quality_levels` ranks last, so two unlisted variants tie for best, and resolving that would need a tie-break the caller never stated.

The resolution runs before coverage and rank and only ever drops rows, never reorders them, so every later stage still sees exactly one row per source per cell.

## Backward compatibility

Both behaviours are opt-in and every existing default is untouched.

Beyond running the existing test file unchanged, I pinned a golden snapshot of the function on `origin/main` before touching it: a seeded 2,320-row panel (383 exact zeros, 301 `NA`s, six sources across four regions, three categories and 71 years) run through 12 argument configurations, capturing both the returned tibble and the `cli` message stream. Replayed against this branch:

```
panel            identical=TRUE
default          identical=TRUE
verbose          identical=TRUE
no_coverage      identical=TRUE
quality          identical=TRUE
quality_no_cov   identical=TRUE
measure          identical=TRUE
measure_exempt   identical=TRUE
no_continuity    identical=TRUE
drop_at          identical=TRUE
all_options      identical=TRUE
by_null          identical=TRUE
all_dropped      identical=TRUE
errors           identical=FALSE
```

`errors` is the one intentional difference, and it is message text rather than a result. The duplicate-row abort gains a third bullet so a caller who hits it can discover the new option; the two existing lines are byte-identical:

```
  Multiple rows share the same source and cell.
  i Pre-aggregate `data` to one row per source per cell first.
+ i Set `tie_break$quality_variants = TRUE` to keep a source's best quality variant instead.
```

## Two things worth a reviewer's scrutiny

**1. `coverage` is now type-overloaded (logical or string).** The alternative was a second option (`coverage` staying logical, plus a `coverage_basis` string), which I rejected because it admits a silent no-op state: `coverage = FALSE, coverage_basis = "positive"` would mean nothing. One option with four valid values has no invalid combinations, and it matches the shape proposed in the issue.

**2. Variants are resolved *before* coverage is counted.** The issue asks to "pre-resolve", and pre-resolving keeps every later stage on a clean one-row-per-source-per-cell frame. This is one place where the reference engine can still differ: `collapse_to_category_winner()` computes `src_coverage` over *all* tier variants and then ranks, so a year counts towards a source's coverage if *any* of its variants is positive there, whereas here a year counts only if the *surviving best* variant is positive. The two agree unless a source has, in the same year, a best-quality variant that is missing or non-positive alongside a worse-quality variant that is positive (in the AUT/BOKU Estimated + Interpolated cases both variants are positive, so they agree). `test_consolidate_sources.R` pins the ordering explicitly using the case where they would differ, so the choice is visible rather than incidental.

## Tests

Nine new `testthat` blocks in `tests/testthat/test_consolidate_sources.R`:

- coverage counts non-missing by default, with `TRUE`, `"nonmissing"` and an omitted `tie_break` all producing the same result;
- `coverage = "positive"` flips a tie that non-missing coverage decides the other way. Two mirrored fixtures, with the source names chosen so that in *each* direction the expected winner is not the one ascending name order would pick, which rules out the name-order fallback deciding the cell;
- `coverage` validation: unknown string, non-scalar, and a non-numeric value column;
- `quality_variants` keeps a source's best tier variant, does not inflate `n_sources`, and picks by `quality_levels` order rather than row order (reversing the ordering hands the cell to the other variant);
- the same panel still aborts under the default, and `quality_variants` without `quality_col` aborts;
- `quality_variants` still aborts on a same-tier duplicate and on an unresolvable tie between two unlisted quality values;
- the verbose variant-resolution message;
- `quality_variants` is inert on a panel that has no variants;
- the variant/coverage ordering described above.

## Verification

| Gate | Result |
|---|---|
| `devtools::test(filter = "consolidate_sources")` | `FAIL 0 \| WARN 0 \| SKIP 0 \| PASS 77` |
| `origin/main`'s **unmodified** `test_consolidate_sources.R` run against this branch | 49 assertions, 0 failures (the pre-existing tests pass without a single edit) |
| `lintr::lint_package()` (CI linter set) | `TOTAL LINTS: 0` / `No lints found.` |
| `air format --check .` | clean (exit 0) |
| `R CMD check` (`--no-tests --ignore-vignettes`, `_R_CHECK_FORCE_SUGGESTS_=false`) | 0 errors, 0 warnings, 1 NOTE. The NOTE is pre-existing and unrelated: `Namespace in Imports field not imported from: 'readxl'` (`readxl::` appears nowhere in `R/` on `main` either). `checking examples ... OK`. |
| `devtools::document()` | run; `man/consolidate_sources.Rd` regenerated and committed |
| pkgdown reference index | no new topics; every `man/*.Rd` still present in `_pkgdown.yml` |
| Full test suite | green on all five CI platforms. `check-r-package` runs `R CMD check` **with** tests (no `--no-tests`), so ubuntu release/devel/oldrel-1, windows-release and macos-release each ran the whole suite: all pass. `test-coverage`, `pkgdown` and `format-suggest` also pass. My local `devtools::test()` was killed mid-run by memory pressure on a shared box before it reached a results block, so the CI runs are the evidence here rather than a local number. |

🤖 Generated with [Claude Code](https://claude.com/claude-code)
