### PR TITLE
fix(soc): repair cell × polity crosswalk, stop silent NaN drainage (#381)

### DIFF
--- a/R/water_balance.R
+++ b/R/water_balance.R
@@ -450,7 +450,47 @@ get_soc_climate_drivers <- function(
            {.field area_code}, {.field polity_frac}, {.field cell_area_ha}."
     ))
   }
-  dplyr::inner_join(terms, crosswalk, by = c("lon", "lat"))
+  .wb_warn_uncovered_cells(terms, crosswalk)
+  dplyr::inner_join(terms, crosswalk, by = c("lon", "lat")) |>
+    .wb_drop_unsimulated()
+}
+
+# Warn when simulated cells have no polity in the crosswalk (they are dropped by
+# the join, so their water would silently vanish from the polity totals). Keyed
+# on the water terms carrying a real (finite) drainage value.
+.wb_warn_uncovered_cells <- function(terms, crosswalk) {
+  sim <- terms |>
+    dplyr::filter(is.finite(.data$drainage_mm)) |>
+    dplyr::distinct(.data$lon, .data$lat)
+  missing <- dplyr::anti_join(sim, crosswalk, by = c("lon", "lat"))
+  if (nrow(missing) > 0) {
+    cli::cli_warn(c(
+      "!" = "{nrow(missing)} simulated cell{?s} ha{?s/ve} no polity in the
+        cell_polity crosswalk and are dropped from the polity aggregation.",
+      i = "Extend the crosswalk to cover the simulated grid to retain them."
+    ))
+  }
+}
+
+# Drop cell-polity rows that carry a polity label but no model data: crosswalk
+# cells outside the simulated (LPJmL) grid join in with non-finite drainage, and
+# passing that NaN downstream silently poisons leaching (see #381). Warn and
+# drop rather than propagate the NaN or silently discard it.
+.wb_drop_unsimulated <- function(joined) {
+  unsimulated <- !is.finite(joined$drainage_mm)
+  if (any(unsimulated)) {
+    cells <- joined[unsimulated, ] |>
+      dplyr::distinct(.data$lon, .data$lat)
+    cli::cli_warn(c(
+      "!" = "Dropped {sum(unsimulated)} cell-polity row{?s}
+        ({nrow(cells)} cell{?s}) with a polity label but no LPJmL model data
+        (crosswalk cells outside the simulated grid).",
+      i = "Restrict {.code data$cell_polity} to the simulated grid to avoid
+        the non-finite drainage they would otherwise inject."
+    ))
+    joined <- joined |> dplyr::filter(is.finite(.data$drainage_mm))
+  }
+  joined
 }
 
 # Stamp method_water (including the realized blue_green method), select the grid

--- a/inst/scripts/prepare_spatialize_all.R
+++ b/inst/scripts/prepare_spatialize_all.R
@@ -868,6 +868,22 @@ cft_to_pft <- c(
 #
 # Rasterize NaturalEarth to a 0.5-degree grid with WHEP area_code.
 
+# iso3c -> area_code from inst/extdata/regions.csv. whep::polities dropped its
+# area_code column in the polity restructure, which silently broke both
+# rasterisation sections against the current schema (#381); this is the
+# canonical replacement, shared so the country grid and the cell x polity
+# crosswalk stay consistent. Verified to reproduce the existing 58,795-cell
+# country_grid pin cell-for-cell with identical codes.
+.spatialize_area_lookup <- function() {
+  path <- system.file("extdata", "regions.csv", package = "whep")
+  regions <- utils::read.csv(path, stringsAsFactors = FALSE)
+  lookup <- regions[
+    !is.na(regions$iso3c) & !is.na(regions$area_code),
+    c("iso3c", "area_code")
+  ]
+  lookup[!duplicated(lookup$iso3c), ]
+}
+
 prepare_country_grid <- function(l_files_dir, target_res) {
   cli::cli_h2("Section 1: Country grid")
 
@@ -878,8 +894,6 @@ prepare_country_grid <- function(l_files_dir, target_res) {
     "ne_10m_admin_0_countries.shp"
   )
   countries <- terra::vect(shp_path)
-  polities <- whep::polities
-
   iso_raw <- as.character(countries$ISO_A3)
   iso_eh <- as.character(countries$ISO_A3_EH)
   iso_adm <- as.character(countries$ADM0_A3)
@@ -889,12 +903,11 @@ prepare_country_grid <- function(l_files_dir, target_res) {
     dplyr::if_else(iso_eh != "-99", iso_eh, iso_adm)
   )
 
-  ne_data <- tibble::tibble(iso3c = iso3c) |>
-    dplyr::left_join(
-      dplyr::select(polities, "iso3c", "area_code"),
-      by = "iso3c"
-    )
-  countries$area_code <- ne_data$area_code
+  countries$area_code <- dplyr::left_join(
+    tibble::tibble(iso3c = iso3c),
+    .spatialize_area_lookup(),
+    by = "iso3c"
+  )$area_code
 
   ref <- terra::rast(
     resolution = target_res,
@@ -907,9 +920,13 @@ prepare_country_grid <- function(l_files_dir, target_res) {
   cli::cli_alert_info("Rasterizing shapefile to {target_res}-degree grid")
   grid_rast <- terra::rasterize(countries, ref, field = "area_code")
 
+  # Coerce to integer BEFORE dropping NA: terra writes its integer NoData as the
+  # sentinel -2147483648, which is not NA, so filtering first would leave those
+  # ocean/unassigned cells in and only NA them at as.integer(). as.integer()
+  # maps the sentinel to NA, then the filter drops it (#381).
   result <- .raster_to_tibble(grid_rast, "area_code") |>
-    dplyr::filter(!is.na(area_code)) |>
-    dplyr::mutate(area_code = as.integer(area_code))
+    dplyr::mutate(area_code = as.integer(area_code)) |>
+    dplyr::filter(!is.na(area_code))
 
   cli::cli_alert_success("country_grid: {nrow(result)} cells")
   result
@@ -947,16 +964,11 @@ build_cell_polity_fraction <- function(
     iso_raw,
     dplyr::if_else(iso_eh != "-99", iso_eh, iso_adm)
   )
-  # whep::polities dropped its area_code column in the polity restructure, so
-  # map iso3c -> area_code via whep::regions_full (its canonical iso3c -> code
-  # crosswalk), deduping the few iso3c that appear more than once.
-  iso_lookup <- whep::regions_full |>
-    dplyr::filter(!is.na(.data$iso3c)) |>
-    dplyr::transmute(iso3c = .data$iso3c, area_code = .data$code)
-  iso_lookup <- iso_lookup[!duplicated(iso_lookup$iso3c), ]
+  # Same iso3c -> area_code lookup as the country grid (regions.csv), so the
+  # crosswalk covers exactly the same countries as the simulated grid.
   matched <- dplyr::left_join(
     tibble::tibble(iso3c = iso3c),
-    iso_lookup,
+    .spatialize_area_lookup(),
     by = "iso3c"
   )$area_code
   countries$area_code <- matched

--- a/inst/scripts/prepare_spatialize_all.R
+++ b/inst/scripts/prepare_spatialize_all.R
@@ -938,7 +938,6 @@ build_cell_polity_fraction <- function(
     "ne_10m_admin_0_countries.shp"
   )
   countries <- terra::vect(shp_path)
-  polities <- whep::polities
   iso_raw <- as.character(countries$ISO_A3)
   iso_eh <- as.character(countries$ISO_A3_EH)
   iso_adm <- as.character(countries$ADM0_A3)
@@ -947,11 +946,32 @@ build_cell_polity_fraction <- function(
     iso_raw,
     dplyr::if_else(iso_eh != "-99", iso_eh, iso_adm)
   )
-  countries$area_code <- dplyr::left_join(
+  # whep::polities dropped its area_code column in the polity restructure, so
+  # map iso3c -> area_code via whep::regions_full (its canonical iso3c -> code
+  # crosswalk), deduping the few iso3c that appear more than once.
+  iso_lookup <- whep::regions_full |>
+    dplyr::filter(!is.na(.data$iso3c)) |>
+    dplyr::transmute(iso3c = .data$iso3c, area_code = .data$code)
+  iso_lookup <- iso_lookup[!duplicated(iso_lookup$iso3c), ]
+  matched <- dplyr::left_join(
     tibble::tibble(iso3c = iso3c),
-    dplyr::select(polities, "iso3c", "area_code"),
+    iso_lookup,
     by = "iso3c"
   )$area_code
+  countries$area_code <- matched
+  n_features <- length(matched)
+  n_matched <- sum(!is.na(matched))
+  cli::cli_alert_info(
+    "iso3c -> area_code: matched {n_matched} of {n_features} country features"
+  )
+  if (n_matched < n_features) {
+    unmatched <- sort(unique(iso3c[is.na(matched) & iso3c != "-99"]))
+    cli::cli_warn(c(
+      "!" = "{length(unmatched)} country feature{?s} had no area_code and
+        contribute no cells.",
+      i = "Unmatched iso3c: {unmatched}."
+    ))
+  }
 
   ref <- terra::rast(
     resolution = target_res / subcells,
@@ -6258,6 +6278,11 @@ prepare_spatialize_all <- function(
   # Section 1: Country grid
   country_grid <- prepare_country_grid(l_files_dir, target_res)
   .save_parquet(country_grid, output_dir, "country_grid")
+
+  # Section 1b: Cell x polity fractions (fractional crosswalk for the balance
+  # modules; build_cell_polity() reads this parquet).
+  cell_polity_fraction <- build_cell_polity_fraction(l_files_dir, target_res)
+  .save_parquet(cell_polity_fraction, output_dir, "cell_polity_fraction")
 
   # Section 5: MIRCA irrigation (run before country_areas so MIRCA
   # is available on the first pass)

--- a/inst/scripts/prepare_spatialize_all.R
+++ b/inst/scripts/prepare_spatialize_all.R
@@ -927,6 +927,7 @@ prepare_country_grid <- function(l_files_dir, target_res) {
 
 build_cell_polity_fraction <- function(
   l_files_dir,
+  country_grid,
   target_res = 0.5,
   subcells = 6L
 ) {
@@ -988,11 +989,29 @@ build_cell_polity_fraction <- function(
   ]
   d[, lat := floor((lat + 90) / target_res) * target_res - 90 + target_res / 2]
   counts <- d[, .(n = .N), by = .(lon, lat, area_code)]
+  # Coerce to the integer polity code and drop any subcells that carry no valid
+  # code, before the fraction is normalised, so the crosswalk never emits an NA
+  # area_code and the surviving fractions still sum to 1.
+  counts[, area_code := as.integer(area_code)]
+  counts <- counts[!is.na(area_code)]
+  # Restrict to the simulated model grid: without this the Natural Earth land
+  # mask (Antarctica, small territories, etc.) injects cells LPJmL never
+  # simulates, which arrive downstream with non-finite drainage (see #381). The
+  # cell filter keeps every polity fragment of a retained cell.
+  grid_cells <- unique(
+    data.table::as.data.table(country_grid)[, .(lon, lat)]
+  )
+  before <- nrow(unique(counts[, .(lon, lat)]))
+  counts <- merge(counts, grid_cells, by = c("lon", "lat"))
+  after <- nrow(unique(counts[, .(lon, lat)]))
+  cli::cli_alert_info(
+    "restricted crosswalk to the simulated grid: {before} -> {after} cells"
+  )
+  # Renormalise so each retained cell's polity fractions still sum to 1 after
+  # dropping unassigned subcells.
   counts[, polity_frac := n / sum(n), by = .(lon, lat)]
   cli::cli_alert_success("cell x polity: {nrow(counts)} (cell, polity) rows")
-  tibble::as_tibble(
-    counts[, .(lon, lat, area_code = as.integer(area_code), polity_frac)]
-  )
+  tibble::as_tibble(counts[, .(lon, lat, area_code, polity_frac)])
 }
 
 
@@ -6281,7 +6300,11 @@ prepare_spatialize_all <- function(
 
   # Section 1b: Cell x polity fractions (fractional crosswalk for the balance
   # modules; build_cell_polity() reads this parquet).
-  cell_polity_fraction <- build_cell_polity_fraction(l_files_dir, target_res)
+  cell_polity_fraction <- build_cell_polity_fraction(
+    l_files_dir,
+    country_grid,
+    target_res
+  )
   .save_parquet(cell_polity_fraction, output_dir, "cell_polity_fraction")
 
   # Section 5: MIRCA irrigation (run before country_areas so MIRCA

--- a/tests/testthat/test_water_balance.R
+++ b/tests/testthat/test_water_balance.R
@@ -850,12 +850,15 @@ testthat::test_that(".wb_attach_polity drops unsimulated cells and warns (#381)"
   testthat::expect_true(all(is.finite(out$drainage_mm)))
 })
 
-testthat::test_that("regions_full carries the iso3c->code crosswalk (#381 guard)", {
-  # inst/scripts/prepare_spatialize_all.R build_cell_polity_fraction() maps
-  # iso3c -> area_code via whep::regions_full$code. Guard the columns it needs
-  # so a future schema drift (like the polities restructure that removed
-  # area_code, which silently broke the orphaned builder) fails loudly here.
-  testthat::expect_true(all(c("iso3c", "code") %in% names(whep::regions_full)))
-  lookup <- whep::regions_full[!is.na(whep::regions_full$iso3c), ]
-  testthat::expect_true(any(!is.na(lookup$code)))
+testthat::test_that("regions.csv carries the iso3c->area_code crosswalk (#381 guard)", {
+  # inst/scripts/prepare_spatialize_all.R maps iso3c -> area_code via
+  # inst/extdata/regions.csv for both the country grid and the cell x polity
+  # crosswalk. Guard the columns it needs so a future schema drift (like the
+  # polities restructure that removed area_code, which silently broke both
+  # rasterisation sections) fails loudly here instead.
+  path <- system.file("extdata", "regions.csv", package = "whep")
+  testthat::expect_true(nzchar(path))
+  regions <- utils::read.csv(path, stringsAsFactors = FALSE)
+  testthat::expect_true(all(c("iso3c", "area_code") %in% names(regions)))
+  testthat::expect_true(any(!is.na(regions$area_code)))
 })

--- a/tests/testthat/test_water_balance.R
+++ b/tests/testthat/test_water_balance.R
@@ -812,3 +812,50 @@ testthat::test_that("a genuinely mixed NA-weight polity keeps only the valid cel
   )
   testthat::expect_equal(pol$water_input_mm, 860, tolerance = 1e-8)
 })
+
+testthat::test_that(".wb_attach_polity drops unsimulated cells and warns (#381)", {
+  # A, B: simulated (finite drainage) and in the crosswalk -> kept.
+  # C: in the crosswalk but no model data (non-finite drainage, a crosswalk
+  #    cell outside the simulated grid) -> must be dropped, not passed as NaN.
+  # E: simulated but absent from the crosswalk -> warned (would be dropped by
+  #    the join and silently lost from the polity aggregation).
+  terms <- tibble::tribble(
+    ~lon, ~lat, ~drainage_mm, ~aet_mm,
+    0.25, 0.25, 100, 1,
+    0.75, 0.25, 120, 1,
+    0.25, 0.75, NaN, 1,
+    0.75, 0.75, 90, 1
+  )
+  crosswalk <- tibble::tribble(
+    ~lon, ~lat, ~area_code, ~polity_frac, ~cell_area_ha,
+    0.25, 0.25, 11L, 1, 30000,
+    0.75, 0.25, 203L, 1, 30000,
+    0.25, 0.75, 250L, 1, 30000,
+    0.15, 0.15, 76L, 1, 30000
+  )
+  warnings <- character(0)
+  out <- withCallingHandlers(
+    whep:::.wb_attach_polity(terms, list(cell_polity = crosswalk)),
+    warning = function(cond) {
+      warnings <<- c(warnings, conditionMessage(cond))
+      invokeRestart("muffleWarning")
+    }
+  )
+  testthat::expect_true(any(grepl("no polity", warnings)))
+  testthat::expect_true(any(grepl("no LPJmL model data", warnings)))
+  testthat::expect_setequal(
+    paste(out$lon, out$lat),
+    c("0.25 0.25", "0.75 0.25")
+  )
+  testthat::expect_true(all(is.finite(out$drainage_mm)))
+})
+
+testthat::test_that("regions_full carries the iso3c->code crosswalk (#381 guard)", {
+  # inst/scripts/prepare_spatialize_all.R build_cell_polity_fraction() maps
+  # iso3c -> area_code via whep::regions_full$code. Guard the columns it needs
+  # so a future schema drift (like the polities restructure that removed
+  # area_code, which silently broke the orphaned builder) fails loudly here.
+  testthat::expect_true(all(c("iso3c", "code") %in% names(whep::regions_full)))
+  lookup <- whep::regions_full[!is.na(whep::regions_full$iso3c), ]
+  testthat::expect_true(any(!is.na(lookup$code)))
+})


### PR DESCRIPTION
## What #381 was

The cell × polity crosswalk (`cell_polity_fraction.parquet`) and the country
grid it derives from could no longer be rebuilt from WHEP code. The `polities`
restructure removed the `area_code` column, and both rasterisation sections in
`inst/scripts/prepare_spatialize_all.R` still looked it up on `polities`, so
`prepare_country_grid()` (Section 1) and `build_cell_polity_fraction()`
(Section 1b) crashed. On top of that, water-balance rows in cells LPJmL never
simulated carried non-finite drainage that silently propagated as NaN.

## What this PR does

**1. Repair the country-grid generation (both sections).**
Added a shared `.spatialize_area_lookup()` reading `inst/extdata/regions.csv`
(iso3c → area_code), replacing the removed `polities$area_code`. Both
`prepare_country_grid()` and `build_cell_polity_fraction()` use it.

**2. Fix the terra NoData sentinel leak.**
terra writes integer NoData as `-2147483648`, which is not NA, so the old
`filter(!is.na) |> as.integer` left ocean cells in and only NA'd them at
coercion. Coercing to integer *before* the NA filter drops them.

**3. Stop silent NaN drainage.**
`.wb_warn_uncovered_cells()` / `.wb_drop_unsimulated()` warn about and drop
water-balance rows in cells LPJmL never simulated (non-finite drainage),
instead of letting NaN propagate into footprints.

## Verification (real data, 58,795-cell simulated grid)

- **`prepare_country_grid()` reproduces the existing pin cell-for-cell**:
  58,795 cells, 0 NA, `all.equal()` identical codes vs `spatialize-country-grid`.
- **`build_cell_polity_fraction()`**: 58,791 cells, 0 NA, 0 cells outside the
  grid, per-cell fractions sum to 1.
- The fixed `country_grid` also feeds the existing `write_lpjml_static_inputs()`
  NetCDF writer, which then emits a correct `cow_gadm_30arcmin.nc` (0 area_codes
  unmatched by `cow_to_lpjml.csv`; 99.2% agreement with the LandInG reference
  where WHEP has a cell) — no gadm-bin dependency.
- Full `test_water_balance.R` suite green; `#381 guard` test now targets
  `regions.csv`.

Closes #381