### PR TITLE
chore(cbs): add food-supply vs FAOSTAT FBS diagnostic (#360 not reproducible)

### DIFF
--- a/inst/scripts/diagnose_food_supply.R
+++ b/inst/scripts/diagnose_food_supply.R
@@ -1,0 +1,387 @@
+# -----------------------------------------------------------------------
+# diagnose_food_supply.R
+#
+# Benchmarks WHEP's commodity-balance `food` element, and the per-capita
+# protein derived from it, against FAOSTAT's own Food Balance Sheets. Written
+# to settle issue #360, which reported that the `food` element over-allocates
+# supply to trade-heavy countries (Netherlands 7.0 kg/cap/day against a
+# claimed FAOSTAT ~2.0).
+#
+# What it measures, for one year:
+#
+#   1. Four candidate over-allocation mechanisms inside build_cbs():
+#        M1  `food := domestic_supply` in .cbs_final_balance() assigns rather
+#            than increments, replacing an estimated destiny split with the
+#            whole domestic supply (the dp_mask block).
+#        M2  .add_global_destiny_shares() applies a *global* food share where
+#            a country has no share of its own.
+#        M3  The trade -> CBS crosswalks dedup pairs, not keys, so a
+#            one-to-many mapping duplicates value instead of splitting (#164).
+#        M4  Destinies exceeding domestic supply, i.e. a broken supply-use
+#            identity (the #143 signature).
+#
+#   2. WHEP food tonnes and derived protein against FAOSTAT FBS, read from
+#      the pin. The per-capita FBS elements are dropped by .extract_fao()'s
+#      cb_elements filter but are present in the pin itself.
+#
+# Result on the 2010 build (see the PR that added this script): every
+# mechanism measures as noise, WHEP's food quantity tracks FAOSTAT at a
+# median ratio of 1.015, and the per-capita protein is inflated by a median
+# 1.21 because whep::biomass_coefs carries no edible-portion nitrogen
+# (Edible_N_kgFM is entirely empty, issue #361), so the coalesce chain falls
+# through to whole-product N x 6.25.
+#
+# Usage:
+#   source("inst/scripts/diagnose_food_supply.R")
+#   res <- diagnose_food_supply(year = 2010, out_dir = "diag_out")
+# -----------------------------------------------------------------------
+
+# Countries used for readable per-country reporting, with the WHEP figure
+# issue #360 reported for each. The issue's own FAOSTAT column is not carried:
+# it disagrees with FAOSTAT (it gives the Netherlands ~2.0 against an actual
+# 2.90) and was part of what made the issue look like a defect.
+.dfs_reference <- function() {
+  tibble::tribble(
+    ~area_iso3c, ~label,             ~issue_claim,
+    "NLD",       "Netherlands",      7.0,
+    "POL",       "Poland",           5.6,
+    "CHN",       "China (mainland)", 4.8,
+    "USA",       "USA",              2.9,
+    "BRA",       "Brazil",           2.3,
+    "NGA",       "Nigeria",          1.8,
+    "IND",       "India",            1.4
+  )
+}
+
+#' Benchmark the CBS food element and derived protein against FAOSTAT FBS.
+#'
+#' @param year Calendar year to diagnose.
+#' @param out_dir Directory for the CSV outputs.
+#' @return A named list with the mechanism attribution, the static crosswalk
+#'   check, the paired WHEP/FAOSTAT comparison and the reference-country table.
+diagnose_food_supply <- function(year = 2010L, out_dir = ".") {
+  dir.create(out_dir, showWarnings = FALSE, recursive = TRUE)
+
+  cli::cli_h1("M3 - static crosswalk fan-out check")
+  fanout <- .dfs_crosswalk_fanout()
+  print(as.data.frame(fanout))
+
+  cli::cli_h1("Building CBS for {year}")
+  built <- .dfs_build(year)
+  rows <- .dfs_row_diagnostics(.dfs_wide(built$cbs))
+
+  cli::cli_h1("Mechanism attribution")
+  attrib <- .dfs_attribute(rows, built$global_share_rows)
+  print(as.data.frame(attrib))
+
+  cli::cli_h1("WHEP against FAOSTAT FBS")
+  cmp <- .dfs_compare(.dfs_whep_national(rows), .dfs_fbs(year))
+  .dfs_report(cmp)
+
+  refs <- .dfs_reference_table(cmp)
+  print(as.data.frame(refs))
+
+  .dfs_write(out_dir, attrib, fanout, cmp, refs)
+  list(attrib = attrib, fanout = fanout, cmp = cmp, refs = refs)
+}
+
+# ---- Build -------------------------------------------------------------
+
+# Build one year of CBS, capturing which destiny rows fell back to the global
+# share (M2). The wrapper delegates to the real function and only records; the
+# original binding is restored on exit.
+.dfs_build <- function(year) {
+  captured <- new.env(parent = emptyenv())
+  original <- whep:::.add_global_destiny_shares
+  instrumented <- function(df) {
+    out <- original(df)
+    captured$rows <- .dfs_capture_global(out)
+    out
+  }
+  utils::assignInNamespace(".add_global_destiny_shares", instrumented, "whep")
+  on.exit(
+    utils::assignInNamespace(".add_global_destiny_shares", original, "whep"),
+    add = TRUE
+  )
+
+  primary <- build_primary_production(start_year = year, end_year = year)
+  cbs <- build_commodity_balances(primary, start_year = year, end_year = year)
+  list(cbs = tibble::as_tibble(cbs), global_share_rows = captured$rows)
+}
+
+# Food-destiny rows with no country share of their own, which therefore take
+# the global fallback. The tonnes are what that fallback contributes.
+.dfs_capture_global <- function(out) {
+  dt <- data.table::as.data.table(out)
+  if (!all(c("dest_share", "dest_share_global") %in% names(dt))) {
+    return(NULL)
+  }
+  dt[
+    element == "food" & is.na(dest_share) & !is.na(dest_share_global),
+    .(global_share_t = domestic_supply * dest_share_global)
+  ] |>
+    tibble::as_tibble()
+}
+
+# ---- CBS internal diagnostics ------------------------------------------
+
+# Long CBS to one row per country-item, all elements as columns.
+.dfs_wide <- function(cbs) {
+  cbs |>
+    dplyr::select("year", "area_code", "item_cbs_code", "element", "value") |>
+    tidyr::pivot_wider(
+      names_from = "element",
+      values_from = "value",
+      values_fill = 0
+    ) |>
+    .dfs_ensure_elements()
+}
+
+# Guarantee every element column exists, so the arithmetic never silently
+# skips a term that happens to be absent this year.
+.dfs_ensure_elements <- function(wide) {
+  needed <- c(
+    "production",
+    "import",
+    "export",
+    "stock_variation",
+    "domestic_supply",
+    "food",
+    "feed",
+    "seed",
+    "processing",
+    "other_uses"
+  )
+  missing <- setdiff(needed, names(wide))
+  if (length(missing) > 0L) {
+    wide[missing] <- 0
+  }
+  wide
+}
+
+# Per-row identity checks. `over_alloc` is the tonnage by which the destinies
+# exceed domestic supply; `dp_signature` marks rows carrying the fingerprint
+# of the M1 overwrite, food set to the whole domestic supply while the other
+# destinies are still non-zero.
+.dfs_row_diagnostics <- function(wide) {
+  wide |>
+    dplyr::mutate(
+      other_destinies = .data$feed +
+        .data$seed +
+        .data$processing +
+        .data$other_uses,
+      over_alloc = pmax(
+        .data$food + .data$other_destinies - .data$domestic_supply,
+        0
+      ),
+      supply_gap = .data$production +
+        .data$import -
+        .data$export -
+        .data$stock_variation -
+        .data$domestic_supply,
+      dp_signature = abs(.data$food - .data$domestic_supply) < 1e-6 &
+        .data$other_destinies > 0
+    )
+}
+
+# Global tonnage moved by each mechanism, so their sizes are comparable.
+.dfs_attribute <- function(rows, global_share_rows) {
+  total <- sum(rows$food, na.rm = TRUE)
+  m1 <- sum(rows$food[rows$dp_signature], na.rm = TRUE)
+  m2 <- if (is.null(global_share_rows)) {
+    NA_real_
+  } else {
+    sum(global_share_rows$global_share_t, na.rm = TRUE)
+  }
+  over <- sum(rows$over_alloc, na.rm = TRUE)
+  gap <- sum(abs(rows$supply_gap), na.rm = TRUE)
+  tibble::tibble(
+    mechanism = c(
+      "total food element",
+      "M1 default-destiny overwrite",
+      "M2 global destiny-share fallback",
+      "M4 destiny over-allocation",
+      "supply-side gap"
+    ),
+    tonnes = c(total, m1, m2, over, gap),
+    share_of_food = c(1, m1, m2, over, gap) / c(1, rep(total, 4))
+  )
+}
+
+# Both trade bridges dedup *pairs*. A key appearing with more than one target
+# fans out on merge, duplicating value rather than splitting it (#164).
+.dfs_crosswalk_fanout <- function() {
+  trade <- whep::cbs_trade_codes |>
+    dplyr::distinct(.data$item_code_trade, .data$item_cbs) |>
+    dplyr::count(.data$item_code_trade) |>
+    dplyr::filter(.data$n > 1)
+  items <- whep::items_full |>
+    dplyr::distinct(.data$item_cbs, .data$item_cbs_code) |>
+    dplyr::count(.data$item_cbs) |>
+    dplyr::filter(.data$n > 1)
+  tibble::tibble(
+    bridge = c("item_code_trade -> item_cbs", "item_cbs -> item_cbs_code"),
+    keys_fanning_out = c(nrow(trade), nrow(items)),
+    max_targets = c(.dfs_max_n(trade), .dfs_max_n(items))
+  )
+}
+
+.dfs_max_n <- function(x) {
+  if (nrow(x) == 0L) 0L else max(x$n)
+}
+
+# ---- FAOSTAT FBS benchmark ---------------------------------------------
+
+# FAO FBS item codes at or above 2900 are aggregates (Grand Total, Vegetal and
+# Animal Products, Cereals, ...) and 2501 is Population; everything else is a
+# leaf commodity. Summing leaves therefore reproduces the reported total
+# without double counting.
+.dfs_is_leaf <- function(code) {
+  code < 2900 & code != 2501
+}
+
+# National FAOSTAT reference: population, reported Grand Total protein, and
+# food supply summed over leaf commodities.
+.dfs_fbs <- function(year) {
+  f <- whep_read_file("faostat-fbs-new")
+  data.table::setDT(f)
+  data.table::setnames(
+    f,
+    c("Area Code", "Item Code", "Element", "Year", "Value"),
+    c("area_code", "item_code", "element", "year", "value")
+  )
+  # `year` is both the argument and a column; bind it to a distinct name so
+  # data.table's j/i scoping cannot resolve the column instead.
+  target_year <- year
+  .dfs_fbs_assemble(f[year == target_year])
+}
+
+.dfs_fbs_assemble <- function(f10) {
+  pop <- f10[
+    item_code == 2501L & element == "Total Population - Both sexes",
+    .(area_code, fao_pop = value * 1000)
+  ]
+  prot <- f10[
+    item_code == 2901L &
+      element == "Protein supply quantity (g/capita/day)",
+    .(area_code, fao_protein_g_day = value)
+  ]
+  food <- f10[
+    .dfs_is_leaf(item_code) &
+      element == "Food supply quantity (kg/capita/yr)",
+    .(fao_food_kg_day = sum(value, na.rm = TRUE) / 365),
+    by = area_code
+  ]
+  Reduce(
+    function(a, b) merge(a, b, by = "area_code"),
+    list(pop, prot, food)
+  ) |>
+    tibble::as_tibble()
+}
+
+# Protein per kg fresh matter, following build_food_supply()'s coalesce chain:
+# edible-portion N, then whole-product N, then dry-matter N; times 6.25.
+.dfs_protein_lookup <- function() {
+  nutrition <- whep::biomass_coefs |>
+    dplyr::transmute(
+      Name_biomass = .data$Name_biomass,
+      protein_frac_kgfm = dplyr::coalesce(
+        .data$Edible_N_kgFM,
+        .data$N_kgN_kgFM,
+        .data$Product_kgN_kgDM * .data$Product_kgDM_kgFM
+      ) *
+        6.25
+    ) |>
+    dplyr::distinct(.data$Name_biomass, .keep_all = TRUE)
+  whep::items_full |>
+    dplyr::distinct(.data$item_cbs_code, .data$Name_biomass) |>
+    dplyr::left_join(nutrition, by = "Name_biomass")
+}
+
+# National WHEP food tonnes and protein tonnes.
+.dfs_whep_national <- function(rows) {
+  rows |>
+    dplyr::select("area_code", "item_cbs_code", food_t = "food") |>
+    dplyr::left_join(.dfs_protein_lookup(), by = "item_cbs_code") |>
+    dplyr::summarise(
+      whep_food_t = sum(.data$food_t, na.rm = TRUE),
+      whep_protein_t = sum(
+        .data$food_t * .data$protein_frac_kgfm,
+        na.rm = TRUE
+      ),
+      .by = "area_code"
+    )
+}
+
+# Pair the two sources on FAO's own population, so the comparison cannot be
+# confounded by a different population series.
+.dfs_compare <- function(whep_nat, fao) {
+  whep_nat |>
+    dplyr::inner_join(fao, by = "area_code") |>
+    dplyr::filter(.data$fao_pop > 1e6, .data$fao_protein_g_day > 0) |>
+    dplyr::mutate(
+      whep_food_kg_day = .data$whep_food_t * 1000 / .data$fao_pop / 365,
+      whep_protein_g_day = .data$whep_protein_t * 1e6 / .data$fao_pop / 365,
+      food_ratio = .data$whep_food_kg_day / .data$fao_food_kg_day,
+      protein_ratio = .data$whep_protein_g_day / .data$fao_protein_g_day
+    )
+}
+
+# ---- Reporting ---------------------------------------------------------
+
+# The nourishment ceiling that separates Adequate from Over on the SJOS-N
+# axis, in g protein/cap/day. Kept literal: whep::nourishment_thresholds is
+# not on main.
+.dfs_over_ceiling <- function() 85.05
+
+.dfs_report <- function(cmp) {
+  ceiling_g <- .dfs_over_ceiling()
+  cli::cli_alert_info("Paired countries: {nrow(cmp)}.")
+  cli::cli_alert_info(
+    "Food kg/cap/day, median FAO {round(stats::median(cmp$fao_food_kg_day), 2)}
+     vs WHEP {round(stats::median(cmp$whep_food_kg_day), 2)}
+     (ratio {round(stats::median(cmp$food_ratio), 3)})."
+  )
+  cli::cli_alert_info(
+    "Protein g/cap/day, median FAO
+     {round(stats::median(cmp$fao_protein_g_day), 1)} vs WHEP
+     {round(stats::median(cmp$whep_protein_g_day), 1)}
+     (ratio {round(stats::median(cmp$protein_ratio), 3)})."
+  )
+  cli::cli_alert_info(
+    "Share at or above the {ceiling_g} g Over ceiling:
+     FAO {round(100 * mean(cmp$fao_protein_g_day >= ceiling_g), 1)}%,
+     WHEP {round(100 * mean(cmp$whep_protein_g_day >= ceiling_g), 1)}%."
+  )
+}
+
+.dfs_reference_table <- function(cmp) {
+  bridge <- dplyr::distinct(
+    whep::polity_area_crosswalk,
+    .data$area_code,
+    .data$area_iso3c
+  )
+  .dfs_reference() |>
+    dplyr::inner_join(
+      dplyr::inner_join(cmp, bridge, by = "area_code"),
+      by = "area_iso3c"
+    ) |>
+    dplyr::transmute(
+      label = .data$label,
+      issue_claim = .data$issue_claim,
+      whep_food = round(.data$whep_food_kg_day, 2),
+      fao_food = round(.data$fao_food_kg_day, 2),
+      food_ratio = round(.data$food_ratio, 2),
+      whep_protein = round(.data$whep_protein_g_day, 1),
+      fao_protein = round(.data$fao_protein_g_day, 1),
+      protein_ratio = round(.data$protein_ratio, 2)
+    )
+}
+
+.dfs_write <- function(out_dir, attrib, fanout, cmp, refs) {
+  data.table::fwrite(attrib, file.path(out_dir, "attribution.csv"))
+  data.table::fwrite(fanout, file.path(out_dir, "crosswalk_fanout.csv"))
+  data.table::fwrite(cmp, file.path(out_dir, "whep_vs_fbs.csv"))
+  data.table::fwrite(refs, file.path(out_dir, "reference_countries.csv"))
+  cli::cli_alert_success("Diagnostic CSVs written to {.path {out_dir}}.")
+}

--- a/inst/scripts/diagnose_food_supply.R
+++ b/inst/scripts/diagnose_food_supply.R
@@ -36,23 +36,6 @@
 #   res <- diagnose_food_supply(year = 2010, out_dir = "diag_out")
 # -----------------------------------------------------------------------
 
-# Countries used for readable per-country reporting, with the WHEP figure
-# issue #360 reported for each. The issue's own FAOSTAT column is not carried:
-# it disagrees with FAOSTAT (it gives the Netherlands ~2.0 against an actual
-# 2.90) and was part of what made the issue look like a defect.
-.dfs_reference <- function() {
-  tibble::tribble(
-    ~area_iso3c, ~label,             ~issue_claim,
-    "NLD",       "Netherlands",      7.0,
-    "POL",       "Poland",           5.6,
-    "CHN",       "China (mainland)", 4.8,
-    "USA",       "USA",              2.9,
-    "BRA",       "Brazil",           2.3,
-    "NGA",       "Nigeria",          1.8,
-    "IND",       "India",            1.4
-  )
-}
-
 #' Benchmark the CBS food element and derived protein against FAOSTAT FBS.
 #'
 #' @param year Calendar year to diagnose.
@@ -75,7 +58,9 @@ diagnose_food_supply <- function(year = 2010L, out_dir = ".") {
   print(as.data.frame(attrib))
 
   cli::cli_h1("WHEP against FAOSTAT FBS")
-  cmp <- .dfs_compare(.dfs_whep_national(rows), .dfs_fbs(year))
+  fao <- .dfs_fbs(year)
+  .dfs_check_leaf_rule(fao)
+  cmp <- .dfs_compare(.dfs_whep_national(rows), fao)
   .dfs_report(cmp)
 
   refs <- .dfs_reference_table(cmp)
@@ -104,8 +89,15 @@ diagnose_food_supply <- function(year = 2010L, out_dir = ".") {
     add = TRUE
   )
 
-  primary <- build_primary_production(start_year = year, end_year = year)
-  cbs <- build_commodity_balances(primary, start_year = year, end_year = year)
+  primary <- whep::build_primary_production(
+    start_year = year,
+    end_year = year
+  )
+  cbs <- whep::build_commodity_balances(
+    primary,
+    start_year = year,
+    end_year = year
+  )
   list(cbs = tibble::as_tibble(cbs), global_share_rows = captured$rows)
 }
 
@@ -243,7 +235,7 @@ diagnose_food_supply <- function(year = 2010L, out_dir = ".") {
 # National FAOSTAT reference: population, reported Grand Total protein, and
 # food supply summed over leaf commodities.
 .dfs_fbs <- function(year) {
-  f <- whep_read_file("faostat-fbs-new")
+  f <- whep::whep_read_file("faostat-fbs-new")
   data.table::setDT(f)
   data.table::setnames(
     f,
@@ -274,9 +266,41 @@ diagnose_food_supply <- function(year = 2010L, out_dir = ".") {
   ]
   Reduce(
     function(a, b) merge(a, b, by = "area_code"),
-    list(pop, prot, food)
+    list(pop, prot, food, .dfs_fbs_leaf_protein(f10))
   ) |>
     tibble::as_tibble()
+}
+
+# Protein summed over leaf commodities. Carried only to validate .dfs_is_leaf();
+# the reference protein used for comparison stays FAO's reported Grand Total.
+.dfs_fbs_leaf_protein <- function(f10) {
+  f10[
+    .dfs_is_leaf(item_code) &
+      element == "Protein supply quantity (g/capita/day)",
+    .(leaf_protein_g_day = sum(value, na.rm = TRUE)),
+    by = area_code
+  ]
+}
+
+# Self-check on .dfs_is_leaf(): summing leaves must reproduce FAO's own Grand
+# Total (item 2901). If it does not, the leaf rule is wrong and every quantity
+# this script sums over leaves is wrong with it, so say so loudly.
+.dfs_check_leaf_rule <- function(fao) {
+  ok <- fao[fao$fao_protein_g_day > 0, ]
+  rel <- abs(ok$leaf_protein_g_day - ok$fao_protein_g_day) /
+    ok$fao_protein_g_day
+  cli::cli_alert_info(
+    "Leaf-rule check on {nrow(ok)} areas, leaf sum against FAO Grand Total
+     protein: median relative difference {signif(stats::median(rel), 2)},
+     max {signif(max(rel), 2)}."
+  )
+  if (stats::median(rel) > 0.01) {
+    cli::cli_warn(
+      "The leaf-item rule does not reproduce FAO's Grand Total protein; the
+       food quantities summed over leaves are unreliable."
+    )
+  }
+  invisible(rel)
 }
 
 # Protein per kg fresh matter, following build_food_supply()'s coalesce chain:
@@ -352,6 +376,23 @@ diagnose_food_supply <- function(year = 2010L, out_dir = ".") {
     "Share at or above the {ceiling_g} g Over ceiling:
      FAO {round(100 * mean(cmp$fao_protein_g_day >= ceiling_g), 1)}%,
      WHEP {round(100 * mean(cmp$whep_protein_g_day >= ceiling_g), 1)}%."
+  )
+}
+
+# Countries used for readable per-country reporting, with the WHEP figure
+# issue #360 reported for each. The issue's own FAOSTAT column is not carried:
+# it disagrees with FAOSTAT (it gives the Netherlands ~2.0 against an actual
+# 2.90) and was part of what made the issue look like a defect.
+.dfs_reference <- function() {
+  tibble::tribble(
+    ~area_iso3c, ~label, ~issue_claim,
+    "NLD", "Netherlands", 7.0,
+    "POL", "Poland", 5.6,
+    "CHN", "China (mainland)", 4.8,
+    "USA", "USA", 2.9,
+    "BRA", "Brazil", 2.3,
+    "NGA", "Nigeria", 1.8,
+    "IND", "India", 1.4
   )
 }
 


### PR DESCRIPTION
## What

Adds `inst/scripts/diagnose_food_supply.R`, a diagnostic that benchmarks
WHEP's commodity-balance `food` element, and the per-capita protein derived
from it, against FAOSTAT's own Food Balance Sheets.

No package code changes. `R/` is untouched.

## Why

#360 reported that the CBS `food` element over-allocates supply to trade-heavy
countries — Netherlands 7.0 kg/cap/day against a stated FAOSTAT ~2.0 — and
blocked the SJOS-N nourishment axis on it. That diagnosis came from static
reading plus hand-transcribed reference figures. This script measures it.

> [!NOTE]
> **Build-range scope — raised in review, since resolved.** Every measurement
> below was taken on a **single-year (2010) build**, which at the time was the
> only configuration that avoided the `dcast()` count-corruption of #425. That
> defect has since been fixed in #429 (merged), and the same FAOSTAT comparison
> now passes on a full multi-year build at a median ratio of **1.016**. The
> figures below stand, and they are no longer single-year-only. See
> "Build-range scope".

## What it found

**#360's baseline does not reproduce**, on a single-year 2010 build.

| Country | #360's WHEP figure | Measured | FAOSTAT FBS (actual) | ratio |
|---|--:|--:|--:|--:|
| Netherlands | 7.0 | 2.91 | **2.90** | 1.00 |
| Poland | 5.6 | 2.63 | 2.43 | 1.08 |
| China (mainland) | 4.8 | 2.51 | 2.48 | 1.01 |
| USA | 2.9 | 2.87 | 2.78 | 1.04 |
| Brazil | 2.3 | 2.27 | 2.25 | 1.01 |
| Nigeria | 1.8 | 1.80 | 1.76 | 1.02 |
| India | 1.4 | 1.41 | 1.27 | 1.11 |

Both columns of the original table were off: #360 gives the Netherlands a
FAOSTAT value of ~2.0 where the pin says **2.90**. Across 147 countries paired
on FAO's own population, WHEP's food element tracks FAOSTAT at a **median
ratio of 1.015** (measured on a single-year build; **1.016** on a full
2010–2023 build once #425 is fixed — see "Build-range scope").

**Every proposed mechanism measures as noise** against 5.02 Gt of 2010 food:

| Mechanism | Measured |
|---|--:|
| `food := domestic_supply` overwrite in `.cbs_final_balance()` | 1.0e-13 t |
| Global destiny-share fallback | 1.13e7 t (0.22%) |
| Destinies exceeding domestic supply | 80 t |
| Supply-side gap | 370 t |
| Trade→CBS crosswalk fan-out (#164) | 0 keys in both bridges |

**The real defect is #361, the protein coefficients.** With correct food
quantities, per-capita protein is still inflated:

| | FAOSTAT | WHEP | ratio |
|---|--:|--:|--:|
| Median protein, g/cap/day | 83.9 | 100.9 | **1.209** |
| Share at or above the 85.05 g "Over" ceiling | 46.9% | **66.0%** | |

`Edible_N_kgFM` is populated in 0 of 421 rows, so `build_food_supply()`'s
coalesce chain always falls through to whole-product N × 6.25 — inedible mass
counted as eaten protein. This one is build-range independent: the column is
empty in the packaged data regardless of how the CBS is built.

## Build-range scope

This section replaces the original claim that the single- vs multi-year axis had
been ruled out. It had not been: the check used a 2008–2012 range, which turns
out to be a second *clean* configuration, so it compared two builds that both
dodge the bug and concluded the axis did not matter.

Measured directly, with `build_commodity_balances()`, before and after #429:

| Build | `dcast` fallback | `food` per year | 2010 slice vs FAOSTAT |
|---|---|--:|--:|
| `2010, 2010` before #429 | absent | 5.02 Gt | 1.015 |
| `2010, 2023` before #429 | **fires** | **43 Mt** | not measurable |
| `2010, 2010` after #429 | absent | 5.02 Gt (identical) | 1.015 |
| `2010, 2023` after #429 | absent | **5.65 Gt** | **1.016** |

Before the fix, the warning named exactly `.select_best_source()`'s cast keys
(`[area_code, year, item_cbs, item_cbs_code, element, source]`), `food` on the
multi-year build was **~117× too low**, `production` came out at 154 Mt/yr
against a real ~10 Gt/yr, and QC flagged 57.9% of rows as `carry_forward`. That
independently corroborated #425 in the same direction and order of magnitude as
its own 259× estimate.

After #429, all of that is gone: the warning does not fire, the multi-year
build's 2010 slice tracks FAOSTAT at **1.016** across the same 147 countries,
and the single-year figure is unchanged to the digit — the fix is correctly a
no-op where no duplicates exist. Multi-year and single-year now agree with each
other and with FAOSTAT.

This closes the loop on #425, which #429 itself could not: #429 established that
its values are *quantities* (`sum` and `first` agree within 0.1%), but nothing in
it compared a post-fix magnitude against an external reference. This script is
that check, and it passes.

One thing worth keeping: #360's conclusion never depended on the #425 bug. The
corruption replaced values with counts of 1–4, so it drove food *down*; it
cannot produce an inflated per-capita figure, and 7.0 kg/cap/day reproduces on
no build tested, before or after the fix.

## Verification

```r
source("inst/scripts/diagnose_food_supply.R")
res <- diagnose_food_supply(year = 2010, out_dir = "diag_out")
```

Runs in roughly 1 minute off the pins. Writes `attribution.csv`,
`crosswalk_fanout.csv`, `whep_vs_fbs.csv` and `reference_countries.csv`.

Three alternative explanations for the gap against #360 were ruled out: code
version (`edu/sjos-nitrogen` and `main` give byte-identical food tonnes), area
duplication (one `area_code` per country, zero CBS areas missing from
`polity_area_crosswalk`), and single- vs multi-year build. The third was
originally checked over 2008–2012, which turned out to be a second *clean*
range, so that check was too narrow to support the conclusion; it has since been
re-established properly over 2010–2023 post-#429. See "Build-range scope".

The FBS leaf-item definition used for summing (`code < 2900 & code != 2501`)
is self-checked in the script against FAO's reported Grand Total protein:
median relative difference 2e-4, max 1.1e-3.

## Gates

`air format .`, `devtools::document()`, `lintr::lint_package()` with the four
repo-disabled linters, `rcmdcheck::rcmdcheck()` and `devtools::test()`.

## Review follow-up commit

A second commit addresses three review findings, with no change to what the
script measures (the 2010 run reproduces every figure above unchanged):

- `build_primary_production()`, `build_commodity_balances()` and
  `whep_read_file()` are now `whep::`-prefixed, matching every sibling
  `diagnose_*` / `analyse_*` script and the repo's namespace rule. The bare
  calls only resolved because the project `.Rprofile` attaches the package, so
  the documented usage would have failed in a plain session.
- The leaf-rule self-check described above is now actually **in** the script, as
  `.dfs_check_leaf_rule()`. It was previously claimed here but never committed.
  It reports its result and warns above a 1% median, so a wrong leaf rule cannot
  pass silently.
- `.dfs_reference()` moved below the entry point, per the helpers-last
  convention.

## Follow-ups

- #360 closed as not reproducible, with the measurements attached.
- #361 updated: now quantified at +20.9% median on per-capita protein and
  identified as the SJOS-N nourishment blocker.
- #425 was the blocking defect for any multi-year CBS figure. Fixed in #429
  (merged), and confirmed here against FAOSTAT at 1.016 on a full 2010–2023
  build.
- Two new issues filed: `Losses`/`Residuals`/`Tourist consumption` dropped at
  `cb_elements`, and `faostat_fbs` wiring (the per-capita elements are already
  in the pin).
