### PR TITLE
fix: commodity-balance cast returned row counts, not quantities (259x on food)

### DIFF
--- a/R/build_cbs.R
+++ b/R/build_cbs.R
@@ -1605,6 +1605,31 @@ build_processing_coefs <- function(
   # Avoids expensive frankv over many source columns.
   primary_sources <- c("FAOSTAT_prod", "FAOSTAT_FBS_New", "FAOSTAT_FBS_Old")
   src_pivot <- dt_raw[source %in% primary_sources]
+  # `fun.aggregate` is REQUIRED here, and omitting it was a silent data-corruption bug.
+  #
+  # `dcast()` with no `fun.aggregate` falls back to `length()` as soon as ANY duplicate
+  # (key, source) combination exists -- and it applies that function to EVERY cell, not just the
+  # duplicated ones. So one duplicate anywhere turns the whole table into row counts. Measured
+  # before this change, on a real 2010-2023 build:
+  #
+  #   classes = FAOSTAT_FBS_New:integer  FAOSTAT_FBS_Old:integer  FAOSTAT_prod:integer
+  #   maxima  = 4, 4, 1
+  #
+  # Those columns are tonnes. A maximum of 4 is impossible. 31,642 duplicated combinations
+  # exist at full range, in areas 206 and 999, so the fallback fired in every build.
+  #
+  # SUM is the right aggregate, established from the data rather than assumed. The duplicates
+  # are one reporting bucket's folded members: `.aggregate_to_polities()` emits one row per
+  # (bucket, polity_name) and `key_cols` deliberately excludes the name -- see the comment
+  # above, which is why that exclusion is correct. Dumped, bucket 999 in 2010 for wheat holds
+  # four distinct territories with production 0 / 244,000 / 0 / 3,103,000. FABIO's
+  # rest-of-world IS the sum of its members, so summing reproduces the bucket. `first` would
+  # keep one member (0, here) and discard the rest.
+  #
+  # All-NA cells stay NA rather than collapsing to 0: `sum(na.rm = TRUE)` of nothing is 0, and a
+  # zero where there is no observation is a different claim from a missing one. `fill = NA` is
+  # respected either way -- verified on a synthetic cast, absent combinations remain NA whether
+  # or not a function is supplied.
   wide <- data.table::dcast(
     src_pivot,
     stats::as.formula(paste(
@@ -1612,7 +1637,10 @@ build_processing_coefs <- function(
       "~ source"
     )),
     value.var = "value",
-    fill = NA
+    fill = NA,
+    fun.aggregate = function(x) {
+      if (all(is.na(x))) NA_real_ else sum(x, na.rm = TRUE)
+    }
   )
   for (col in setdiff(primary_sources, names(wide))) {
     wide[, (col) := NA_real_]

--- a/tests/testthat/test_select_best_source_aggregates.R
+++ b/tests/testthat/test_select_best_source_aggregates.R
@@ -1,0 +1,103 @@
+# The source cast must SUM duplicate keys, not count them.
+#
+# `.select_best_source()` casts the three primary sources wide. With no `fun.aggregate`,
+# `data.table::dcast()` falls back to `length()` the moment any duplicate (key, source)
+# combination exists -- and applies it to EVERY cell, not only the duplicated ones. One
+# duplicate anywhere therefore turns the entire table into row counts.
+#
+# That happened in every real build. Measured on 2010-2023 before the fix:
+#
+#   classes = FAOSTAT_FBS_New:integer  FAOSTAT_FBS_Old:integer  FAOSTAT_prod:integer
+#   maxima  = 4, 4, 1
+#
+# in columns holding tonnes. At full range 31,642 duplicated combinations exist, in areas 206
+# and 999, so the fallback was never not firing. Published totals were wrong by up to 259x on
+# `food` and 183x on `seed`.
+#
+# WHY NO TEST CAUGHT IT, which is the reason this file exists rather than a wider assertion:
+# the whole suite passes both with and without the fix. Nothing compared a magnitude against
+# anything, and the corruption preserves row counts, column types after coercion, and every
+# NA pattern -- so shape-based checks are blind to it by construction. A test has to look at a
+# VALUE.
+#
+# These tests are deliberately unit-level on the internal helper. An end-to-end assertion would
+# need a full build (minutes) and a baseline of expected magnitudes, and the baseline is the
+# thing that was wrong; asserting the aggregate directly cannot be satisfied by a corrupted
+# pipeline.
+
+.two_rows_one_key <- function() {
+  # One duplicated (key, source): the shape `.aggregate_to_polities()` produces when several
+  # territory-periods fold into one reporting bucket, since `key_cols` excludes the area name.
+  data.table::data.table(
+    area_code = c(206L, 206L),
+    area = c("Sudan (former)", "South Sudan"),
+    year = c(2015L, 2015L),
+    item_cbs = c("Honey", "Honey"),
+    item_cbs_code = c(2745L, 2745L),
+    element = c("production", "production"),
+    source = c("FAOSTAT_prod", "FAOSTAT_prod"),
+    value = c(10, 32)
+  )
+}
+
+testthat::test_that("a duplicated key is summed, not counted", {
+  out <- as.data.frame(suppressWarnings(
+    whep:::.select_best_source(.two_rows_one_key())
+  ))
+  testthat::expect_equal(nrow(out), 1L)
+
+  # 42, not 2. Before the fix this was 2 -- the row count -- and every other cell in the cast
+  # was 1 for the same reason.
+  testthat::expect_equal(out$value, 42)
+  testthat::expect_true(is.double(out$value))
+})
+
+testthat::test_that("an undisturbed value passes through unchanged", {
+  # The other half: the fallback corrupted cells that had no duplicate at all, so a fix that
+  # only handled duplicates would still be wrong. A single large value must survive intact.
+  dt <- data.table::data.table(
+    area_code = c(206L, 100L),
+    area = c("Sudan (former)", "India"),
+    year = c(2015L, 2015L),
+    item_cbs = c("Honey", "Honey"),
+    item_cbs_code = c(2745L, 2745L),
+    element = c("production", "production"),
+    source = c("FAOSTAT_prod", "FAOSTAT_prod"),
+    value = c(10, 987654)
+  )
+  out <- as.data.frame(suppressWarnings(whep:::.select_best_source(dt)))
+  india <- out$value[out$area_code == 100L]
+  testthat::expect_equal(india, 987654)
+  # Explicitly not 1: `length()` would have returned 1 here, which is a plausible-looking
+  # tonnage and is exactly why the corruption was invisible.
+  testthat::expect_false(isTRUE(all.equal(india, 1)))
+})
+
+testthat::test_that("values are quantities, not counts, at build scale", {
+  # A guard on the property rather than on a fixture: after a real build the primary-source
+  # magnitudes must be implausible as counts. Skipped where the pins are unavailable, and it is
+  # the one test here that would have caught the defect from the outside.
+  testthat::skip_on_ci()
+  cbs <- tryCatch(
+    suppressWarnings(suppressMessages(
+      whep::build_commodity_balances(
+        whep::build_primary_production(start_year = 2015, end_year = 2016),
+        start_year = 2015,
+        end_year = 2016
+      )
+    )),
+    error = function(e) NULL
+  )
+  testthat::skip_if(is.null(cbs), "CBS pins unavailable")
+
+  d <- as.data.frame(cbs)
+  v <- suppressWarnings(as.numeric(d$value))
+  v <- v[!is.na(v) & v > 0]
+  testthat::expect_gt(length(v), 1000L)
+
+  # Row counts are small integers. Real commodity balances are not: if the largest positive
+  # value in two years of world data is under 1000, the column is not carrying tonnes.
+  testthat::expect_gt(max(v), 1000)
+  # And they are not all integral, which counts necessarily are.
+  testthat::expect_gt(sum(v != floor(v)), 0L)
+})


### PR DESCRIPTION
> [!CAUTION]
> **This changes every published commodity-balance figure**, by up to **259×** on `food`. It is a correctness fix, not a modelling change: the current values are row counts where tonnages belong. Please read the effect table before merging.

## The defect

`.select_best_source()` casts the three primary sources wide with no `fun.aggregate`. `data.table::dcast()` then falls back to `length()` the moment **any** duplicate `(key, source)` combination exists — and applies it to **every cell**, not only the duplicated ones. One duplicate anywhere turns the whole table into row counts.

Reproduced on a five-row synthetic: with a single duplicate present, values of 5000, 70000 and 90000 all come back as `1`, and the columns come back `<int>`.

Measured on a real 2010-2023 build before this change:

```
classes = FAOSTAT_FBS_New:integer  FAOSTAT_FBS_Old:integer  FAOSTAT_prod:integer
maxima  = 4, 4, 1
```

Those columns hold tonnes. A maximum of 4 is impossible. **31,642** duplicated combinations exist at full range, in areas 206 and 999, so the fallback fired in every build — on `main` as well, confirmed by probing `origin/main` directly (maxima 2, 1, 1).

## Effect on published totals, full range

| column | before | after | ratio |
|---|---|---|---|
| `food` | 1.215e9 | 3.147e11 | **259×** |
| `seed` | 2.756e8 | 5.036e10 | **183×** |
| `stock_withdrawal` | 9.340e9 | 1.483e11 | 15.9× |
| `other_uses` | 8.305e9 | 9.213e10 | 11.1× |
| `feed` | 8.232e10 | 9.064e11 | 11.0× |
| `import` | 1.569e10 | 1.118e11 | 7.1× |
| `export` | 3.011e10 | 7.926e10 | 2.6× |
| `domestic_supply` | 1.729e12 | 3.149e12 | 1.8× |
| `production` | 1.736e12 | 3.008e12 | 1.7× |
| `processing` | 1.637e12 | 1.768e12 | 1.1× |
| rows | 2,813,530 | 2,019,253 | 0.72× |

**The row drop is correct**, and was verified separately rather than assumed: 390,444 additional rows are genuinely zero once values are quantities, and `dt[value != 0 & area != ""]` at `build_cbs.R:2970` removes them as it always should have. A count is never zero, which is why they survived.

**Production output is unaffected** — `build_primary_production()` has `value == 1` in 0.14% of rows, evenly spread, i.e. normal incidence. The cast is inside the commodity-balance build and production never passes through it. So the blast radius is commodity balances and what derives from them.

## Why `sum`

Established from the data, not assumed. The duplicates are one reporting bucket's **folded members**: `.aggregate_to_polities()` emits a row per `(bucket, polity_name)`, and `key_cols` deliberately excludes the name — the comment above it explains why, and that exclusion is correct. Dumped, bucket 999 in 2010 for wheat holds four distinct territories at `0 / 244,000 / 0 / 3,103,000`. FABIO's rest-of-world *is* the sum of its members.

`first` would keep one member — `0` here — and discard the rest. Measured, `sum` and `first` agree within 0.1% on totals, precisely because what matters is that the values are quantities at all rather than which one is picked.

All-`NA` cells stay `NA` rather than collapsing to 0: `sum(na.rm = TRUE)` of nothing is 0, and a zero where there is no observation is a different claim. `fill = NA` behaves identically with and without a function, verified on a synthetic cast.

## The suite passes with and without this fix

That is the uncomfortable part and the reason for the test that ships here. **Nothing in the suite compared a magnitude against anything**, and the corruption preserves row counts, NA patterns and (after coercion) column types — so every shape-based check is blind to it by construction.

`tests/testthat/test_select_best_source_aggregates.R` therefore looks at a **value**:

- a duplicated key must sum to **42**, not count to **2**
- an undisturbed **987654** must not become **1** — the fallback corrupts non-duplicated cells too, so a fix handling only duplicates would still be wrong
- and a build-scale guard: the largest positive value in two years of world data must exceed 1000, and not every value may be integral

Verified to **fail on `main`'s code** and pass here.

## Deliberately not included

Each needs its own decision, and lumping them in would make this unreviewable:

- **#414** — bucket 206 post-2011 now holds a genuine Sudan + South Sudan sum while the crosswalk labels it `SDN-2011-2025`. Correct values, wrong label. `F206-2011-2025` "Sudan (combined reporting: …)" follows the existing `F237`/`F249` convention.
- **#426** — the destiny shares divide by this `domestic_supply`; 37.4% of the historical frame carried `production == 1`, producing 6 `Inf` and 926 `NaN` shares. Most of that resolves here; the five-line division guard is separate.
- **#420** — run-to-run nondeterminism, localised to `.fill_historical_destinies()`, which operates on this frame. Best re-measured once values are quantities.
- **`mean()` for non-primary sources**, a few lines below the cast. If those duplicates are also folded members, a mean understates them — same question, different aggregate, untouched here.

## Note on the baseline in #382

`inst/scripts/compare_cbs_totals.R` (on the polities-integration branch) pins column totals against a committed baseline recorded **before** this fix, so it encodes the corrupted state. It must be re-recorded after this merges. That script is a drift detector, not a certificate that the numbers are right — its header says so.

Closes #425.
