### PR TITLE
fix(spatialize): stop the unallocated-total warnings aborting on many area codes

### DIFF
--- a/R/spatialize.R
+++ b/R/spatialize.R
@@ -921,11 +921,14 @@ build_gridded_landuse <- function(
   if (nrow(leaked) == 0L) {
     return(invisible(NULL))
   }
+  # `codes` is integer, so the plural marker must follow an explicit scalar
+  # count: cli's make_quantity() errors on a numeric vector of length > 1.
+  codes <- sort(unique(leaked$area_code))
   cli::cli_warn(c(
     "{nrow(leaked)} (country, crop) pair{?s} in year {yr} have national \\
      harvested area but no allocatable grid cell; \\
      {round(sum(leaked$national_area))} ha dropped:",
-    "x" = "area_code{?s} {.val {sort(unique(leaked$area_code))}}."
+    "x" = "{length(codes)} area_code{?s}: {.val {codes}}."
   ))
 }
 

--- a/R/spatialize_livestock.R
+++ b/R/spatialize_livestock.R
@@ -587,6 +587,9 @@ build_gridded_livestock <- function(
   } else {
     " ({round(lost_heads)} head{?s} dropped)"
   }
+  # `codes` is integer, so the plural marker must follow an explicit scalar
+  # count: cli's make_quantity() errors on a numeric vector of length > 1.
+  codes <- sort(dropped)
   cli::cli_warn(c(
     paste0(
       "{length(dropped)} countr{?y/ies} have national livestock totals ",
@@ -594,7 +597,7 @@ build_gridded_livestock <- function(
       head_msg,
       ":"
     ),
-    "x" = "area_code{?s} {.val {sort(dropped)}}."
+    "x" = "{length(codes)} area_code{?s}: {.val {codes}}."
   ))
 }
 

--- a/tests/testthat/test_spatialize.R
+++ b/tests/testthat/test_spatialize.R
@@ -145,6 +145,46 @@ testthat::test_that("country-crop with area but no grid cell warns and keeps oth
   testthat::expect_equal(total, 1000, tolerance = 1e-4)
 })
 
+testthat::test_that("unallocated-crop warning survives several area codes", {
+  # Two unallocatable area codes, not one. `area_code` is integer, and cli's
+  # make_quantity() aborts on a numeric quantity of length > 1, so a plural
+  # marker reading the code vector turned this warning into a hard error on
+  # real data (where many countries are unallocatable) while the single-code
+  # fixture above passed.
+  fix <- two_country_fixture()
+  fix$country_areas <- tibble::tribble(
+    ~year, ~area_code, ~item_prod_code, ~harvested_area_ha,
+    2000L,         1L,             15L,               1000,
+    2000L,         3L,             15L,                700,
+    2000L,         4L,             15L,                300
+  )
+
+  testthat::expect_warning(
+    result <- build_gridded_landuse(
+      fix$country_areas,
+      fix$crop_patterns,
+      fix$gridded_cropland,
+      fix$country_grid
+    ),
+    "no allocatable grid cell"
+  )
+
+  # Both unallocatable codes are named, and the placeable country is intact.
+  testthat::expect_warning(
+    build_gridded_landuse(
+      fix$country_areas,
+      fix$crop_patterns,
+      fix$gridded_cropland,
+      fix$country_grid
+    ),
+    "2 area_codes"
+  )
+  total <- result |>
+    dplyr::summarise(total = sum(rainfed_ha + irrigated_ha)) |>
+    dplyr::pull(total)
+  testthat::expect_equal(total, 1000, tolerance = 1e-4)
+})
+
 testthat::test_that("build_gridded_landuse applies capacity constraint by default", {
   fix <- two_country_fixture()
   result <- build_gridded_landuse(

--- a/tests/testthat/test_spatialize_livestock.R
+++ b/tests/testthat/test_spatialize_livestock.R
@@ -429,6 +429,31 @@ test_that("country with totals but no proxy cell warns and keeps others", {
   expect_equal(sum(result$heads), 10000, tolerance = 1e-6)
 })
 
+test_that("no-proxy-cell warning survives several area codes", {
+  # Two cell-less countries, not one. `area_code` is integer and cli's
+  # make_quantity() aborts on a numeric quantity of length > 1, so a plural
+  # marker reading the code vector made this warning a hard error whenever
+  # more than one country was unallocatable.
+  ld <- tibble::tribble(
+    ~year, ~area_code, ~species_group, ~heads,
+    2000L,         1L,       "cattle",  10000,
+    2000L,         3L,       "cattle",   7000,
+    2000L,         4L,       "cattle",   2000
+  )
+
+  expect_warning(
+    result <- build_gridded_livestock(
+      ld,
+      gridded_pasture,
+      gridded_cropland,
+      country_grid
+    ),
+    "2 area_codes"
+  )
+
+  expect_equal(sum(result$heads), 10000, tolerance = 1e-6)
+})
+
 test_that(".build_proxy_grid weights grazer cells by grass productivity", {
   pasture <- tibble::tibble(
     lon = c(0.25, 1.25),


### PR DESCRIPTION
## Problem

`build_gridded_landuse()` and `build_gridded_livestock()` **abort on real data**:

```
Error in `.warn_unallocated_crops(dat, yr)`
Caused by error in `make_quantity()`:
! length(object) == 1 is not TRUE
```

The unallocated-total warnings added in #300 pluralize on the integer
`area_code` vector. cli's `make_quantity()` takes a *character* vector as a
quantity (it uses `length()`), but **hard-errors on a numeric vector longer
than one**:

```r
v <- c(10L, 20L)
cli::cli_warn("area_code{?s} {.val {sort(v)}}.")   #> Error: length(object) == 1 is not TRUE
cli::cli_warn("column{?s} {.val {c('a','b')}}.")   #> fine — character
```

Real 2010 gridded land use has **112** unallocatable area codes across 771
`(country, crop)` pairs, so the warning written to *surface* silent data loss
instead kills the run outright.

Both sites are affected:
- `R/spatialize.R` — `.warn_unallocated_crops()`
- `R/spatialize_livestock.R` — `.warn_unallocated_livestock()`

## Why CI and the tests missed it

Both fixtures shipped with #300 use **exactly one** unallocatable area code —
the single length for which `make_quantity()` succeeds. The full suite is
green on `main` today with the bug live. A warning path that only fires on
real-world-shaped input is, by construction, not covered by the fixtures.

## Fix

Attach the plural marker to an explicit scalar count, so the quantity is never
the numeric code vector:

```r
codes <- sort(unique(leaked$area_code))
"x" = "{length(codes)} area_code{?s}: {.val {codes}}."
```

Pluralisation stays correct at both ends (`1 area_code: 7.` /
`2 area_codes: 10 and 20.`).

## Tests

Adds a plural-case regression test to each file, using **two** unallocatable
codes rather than one, and asserting the rendered count (`"2 area_codes"`) so
the message itself is pinned, not just the fact that a warning fired.

## Verification

| Check | Result |
|---|---|
| Real 2010 `build_gridded_landuse()` (type-aware, LPJmL inputs) | exits 0 — was aborting |
| Warning now renders | `771 (country, crop) pairs ... 112 area_codes` |
| National area conserved | 99.835% (unchanged by this PR) |
| `air format --check .` | clean |
| `lintr` | no lints |
| spatialize tests | 146 pass / 0 fail |
| Full suite | **FAIL 0 / PASS 4472** |

No output numbers change: this only repairs the warning's own formatting.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KS91qvnGGV5YFUrf1Lr9ya
