### PR TITLE
warn when GLEAM cannot classify a live reporting area

### DIFF
--- a/R/energy_co2_extension.R
+++ b/R/energy_co2_extension.R
@@ -151,9 +151,68 @@ build_energy_co2_extension <- function(
   )
 }
 
+# Say which reporting areas the GLEAM schemes cannot classify, because the
+# alternative is nothing at all.
+#
+# `gleam_geographic_hierarchy` defines the country universe for the whole energy
+# extension: all three schemes below are derived from it, so an area absent from
+# that table gets no row -- not a wrong group, no group -- and the intensity join
+# in `.energy_co2e_by_group()` then drops its production in silence.
+#
+# Only areas WHEP treats as a polity in their own right are worth naming.
+# Dissolved entities such as SUN and YUG are absent from a present-day table by
+# construction, the regional buckets RAFR to ROW are aggregates a country table
+# should not carry, and territories folded into a FABIO bucket are represented by
+# that bucket rather than by themselves. What remains on the current crosswalk is
+# Nauru and Tuvalu: they exist today, report under their own area codes, and are
+# unclassifiable. Tuvalu is the sharpest case -- `.energy_ldc_iso3()` lists TUV
+# as least-developed, so this file asserts a classification for a country the
+# table it joins against cannot represent.
+#
+# whep#415 lists Bermuda, Guam and Palau alongside those two. They are no longer
+# named here because the crosswalk now folds all three into FABIO bucket 999, so
+# they are no longer self-reporting; their raw area codes 17, 88 and 180 still
+# carry an iso3 GLEAM has no row for.
+#
+# This WARNS rather than assigning a group. Which GLEAM region an area belongs to
+# is a modelling decision tracked in whep#415, and the source table is not
+# edited either: it is parsed from the GLEAM Excel workbook, so adding rows would
+# make this package's copy diverge from the published source with nothing
+# recording it.
+.warn_areas_gleam_cannot_group <- function() {
+  # `area_code == polity_area_code` keeps the areas that report as themselves,
+  # dropping those aggregated into a FABIO bucket under another code.
+  gaps <- polity_area_crosswalk |>
+    tibble::as_tibble() |>
+    dplyr::filter(
+      !is.na(.data$area_code),
+      !is.na(.data$area_iso3c),
+      .data$area_code == .data$polity_area_code,
+      .data$polity_type != "aggregate",
+      !is.na(.data$polity_end_year),
+      .data$polity_end_year >= 2020,
+      !.data$area_iso3c %in% gleam_geographic_hierarchy$iso3
+    ) |>
+    dplyr::distinct(.data$area_code, .data$area_name)
+  if (nrow(gaps) == 0L) {
+    return(invisible(NULL))
+  }
+  n_gaps <- nrow(gaps)
+  areas <- sort(gaps$area_name)
+  cli::cli_warn(c(
+    "!" = "GLEAM cannot classify {n_gaps} live reporting area{?s}: no row in
+       {.field gleam_geographic_hierarchy}, so the energy extension drops their
+       production.",
+    "i" = "Areas: {.val {areas}}.",
+    "i" = "Assigning them a GLEAM region is a modelling decision; see whep#415."
+  ))
+  invisible(NULL)
+}
+
 # Map each country to its grouping under each of the three GLEAM schemes.
 .energy_country_grouping <- function() {
   ldc <- .energy_ldc_iso3()
+  .warn_areas_gleam_cannot_group()
   gleam_geographic_hierarchy |>
     dplyr::transmute(
       iso3 = .data$iso3,
@@ -327,12 +386,15 @@ build_energy_co2_extension <- function(
   )
 }
 
+# Reporting area -> iso3 for the GLEAM joins. `area_iso3c` is a property of the
+# reporting area, constant across the polity periods sharing an `area_code`
+# (checked: one distinct value for each of the 265 mapped codes), so this needs
+# no tie-breaking between those periods.
 .energy_area_iso3 <- function() {
-  .current_area_lookup(include_unmapped = FALSE) |>
+  polity_area_crosswalk |>
     tibble::as_tibble() |>
-    dplyr::select("area_code", iso3 = "area_iso3c") |>
-    dplyr::filter(!is.na(.data$iso3)) |>
-    dplyr::distinct(.data$area_code, .keep_all = TRUE)
+    dplyr::filter(!is.na(.data$area_code), !is.na(.data$area_iso3c)) |>
+    dplyr::distinct(area_code = .data$area_code, iso3 = .data$area_iso3c)
 }
 
 # ---- attribution to live-animal sectors -----------------------------------

--- a/tests/testthat/test_energy_co2_extension.R
+++ b/tests/testthat/test_energy_co2_extension.R
@@ -95,6 +95,56 @@ testthat::test_that("a group is split across its sectors by slaughtered heads", 
   testthat::expect_equal(cattle / buffalo, 30)
 })
 
+testthat::test_that("areas GLEAM cannot classify are named, not dropped mutely", {
+  # `gleam_geographic_hierarchy` is the country universe of the whole extension,
+  # so an area with no row there gets no grouping, hence no `ef_total`, and the
+  # intensity join in `.energy_co2e_by_group()` used to discard its production
+  # without a word: a Tuvalu-only (area 227) build returned zero rows and raised
+  # nothing. Tuvalu is the sharpest case because `.energy_ldc_iso3()` asserts TUV
+  # is least-developed, i.e. the file claims a GLEAM grouping for a country the
+  # table it joins against cannot represent. The two names are asserted rather
+  # than only the count: whep#415 needs to know WHICH areas to resolve, and the
+  # list moves with the crosswalk (Bermuda, Guam and Palau were in it until they
+  # were folded into FABIO bucket 999, so they no longer report as themselves).
+  testthat::expect_warning(
+    grouping <- .energy_country_grouping(),
+    "GLEAM cannot classify"
+  )
+  # The warning is a statement about the crosswalk, not about any one build, so
+  # it must not change what the grouping itself contains.
+  testthat::expect_setequal(grouping$iso3, gleam_geographic_hierarchy$iso3)
+
+  areas <- testthat::capture_warnings(.energy_country_grouping())
+  testthat::expect_match(areas, "Nauru", all = FALSE)
+  testthat::expect_match(areas, "Tuvalu", all = FALSE)
+})
+
+testthat::test_that("area -> iso3 needs no tie-break across polity periods", {
+  # `.energy_area_iso3()` used to reuse `.current_area_lookup()`, which exists to
+  # pick one "best current" polity per area_code for a different purpose, purely
+  # to read `area_iso3c` off the winning row -- riding on an unstated invariant.
+  # The invariant is real (checked below), so the projection can be taken off the
+  # crosswalk directly; this test pins the invariant so the simpler projection
+  # cannot start silently picking an arbitrary iso3 if it ever breaks.
+  per_area <- whep::polity_area_crosswalk |>
+    tibble::as_tibble() |>
+    dplyr::filter(!is.na(.data$area_code)) |>
+    dplyr::summarise(
+      n_iso3 = dplyr::n_distinct(.data$area_iso3c),
+      .by = "area_code"
+    )
+  testthat::expect_equal(max(per_area$n_iso3), 1L)
+
+  area2iso <- .energy_area_iso3()
+  testthat::expect_named(area2iso, c("area_code", "iso3"))
+  testthat::expect_equal(anyDuplicated(area2iso$area_code), 0L)
+  testthat::expect_false(any(is.na(area2iso$iso3)))
+  testthat::expect_equal(area2iso$iso3[area2iso$area_code == 231L], "USA")
+  # Statistical aggregates with no iso3 (351 "China", which double-counts its
+  # components) stay out, as they did under the old lookup's unmapped filter.
+  testthat::expect_false(351L %in% area2iso$area_code)
+})
+
 testthat::test_that("only the gleam method is available", {
   testthat::expect_error(
     whep::build_energy_co2_extension(method = "fao"),


### PR DESCRIPTION
Part of the polity migration epic #458. Closes #207.

## What was wrong

`gleam_geographic_hierarchy` is the country universe of the entire energy extension: all three
grouping schemes in `.energy_country_grouping()` are `transmute()`d off it. An area with no row
there therefore gets *no* grouping row -- not a wrong group, no group -- so it picks up no
`ef_total`, and the `left_join(intensity)` in `.energy_co2e_by_group()` leaves `co2e_kg = NA`,
which `.energy_finalise_extension()`'s `filter(impact_u > 0)` then silently discards.

Tuvalu is the contradiction that makes this worth surfacing: `.energy_ldc_iso3()` asserts `TUV`
is a least-developed country (`R/energy_co2_extension.R:146`), i.e. the file claims a GLEAM
grouping for a country the table it joins against has no row for.

Separately, `.energy_area_iso3()` called `.current_area_lookup()` -- a helper built to pick one
"best current" polity per `area_code` for a different purpose -- purely to read `area_iso3c` off
whichever row won the tie-break, riding on an unstated invariant.

## Evidence it reproduced before the change

On `polity/207` at its base commit, a build with Tuvalu (area 227) and the USA:

```
> res <- build_energy_co2_extension(data = list(primary_prod = prod))   # 227 + 231
  year area_code item_cbs_code   impact_u         method_energy
1 2000       231          1049 1472279070 GLEAM_3.0_energy_meat

Tuvalu rows in output: 0
TUV in gleam hierarchy: FALSE
TUV asserted LDC:      TRUE
```

No warning, no message: Tuvalu's production simply is not there.

## What changed

- Ported `.warn_areas_gleam_cannot_group()` from #382 plus its call site in
  `.energy_country_grouping()`. It derives the "live, self-reporting, non-aggregate present-day
  polity" set from `polity_area_crosswalk` (`polity_type`, `polity_end_year`,
  `area_code == polity_area_code`) -- polity-routed, no hand-maintained region list -- and warns
  naming the areas GLEAM has no row for.
- `.energy_area_iso3()` now projects `distinct(area_code, area_iso3c)` straight off the crosswalk,
  with the invariant it relies on stated in a comment and pinned by a test.

Expressed in dplyr rather than #382's base-R subsetting, to match this file's idiom; the logic is
the branch's. Deliberately **not** ported: the `.energy_slaughter_shares()` NaN fix in the same
diff hunk (out of scope per the issue), and none of the ~58 bare ISO3 literals in this file.

## One place the port had to diverge from #382

#382, and whep#415, list **five** unclassifiable areas: Bermuda, Guam, Nauru, Palau, Tuvalu.
On current `main` the same filter names **two** -- Nauru and Tuvalu -- and that is correct, not a
regression of the port. The crosswalk has moved since #382:

```
 area_code area_name area_iso3c reporting_polity_code fabio_code polity_area_code   polity_code polity_type
        17   Bermuda        BMU                  RLAM        999              999 ROW-1850-2023   aggregate
        88      Guam        GUM                  ROCE        999              999 ROW-1850-2023   aggregate
       180     Palau        PLW                  ROCE        999              999 ROW-1850-2023   aggregate
       148     Nauru        NRU                   NRU        148              148 NRU-1888-2025    national
       227    Tuvalu        TUV                   TUV        227              227 TUV-1800-2025    national
```

Bermuda, Guam and Palau are now folded into FABIO bucket 999 with aggregate reporting polities, so
they no longer report as themselves and are indistinguishable from ~40 other bucketed territories
(Aruba, Andorra, Greenland, ...) that GLEAM also lacks and that nobody wants named. Nauru and
Tuvalu are the two areas where WHEP asserts a national polity of its own and GLEAM cannot classify
it. I did not widen the filter to force the count back to five: no principled filter on today's
crosswalk selects exactly those three out of the forty. Their raw area codes 17/88/180 do still
carry an iso3 GLEAM has no row for, and `.energy_area_iso3()` still maps them, so their production
still drops -- noted in the code comment, and whep#415 is the place to decide it.

Also left alone, honestly out of scope: the regional buckets themselves (`ROW`, `RAFR`, ...) have
no GLEAM row either, so area 999's meat production drops silently too. #382 excluded aggregates on
purpose ("a country table should not carry" them); widening the warning to aggregate buckets is a
separate decision.

## Verification

After the change, the same reproduction:

```
! GLEAM cannot classify 2 live reporting areas: no row in gleam_geographic_hierarchy,
  so the energy extension drops their production.
i Areas: "Nauru" and "Tuvalu".
i Assigning them a GLEAM region is a modelling decision; see whep#415.
```

**Published values: unchanged, measured.** Same fixture spanning USA 231, Tuvalu 227, area 100 and
RoW 999, built on the base commit and on this branch, written to CSV and `diff`ed: identical 8
rows, `sum(impact_u) = 18512676472.925266` both times. Separately, the new `.energy_area_iso3()` is
row-identical to the old lookup's output -- 265 rows each, zero rows from an anti-join in either
direction on `(area_code, iso3)`, and `max(n_distinct(area_iso3c))` per `area_code` is 1, so the
tie-break it used to depend on never had a tie to break.

**Tests.** Two new blocks in `tests/testthat/test_energy_co2_extension.R`. Reverting only
`R/energy_co2_extension.R` and re-running gives `FAIL 5` in the warning test (lines 109/118/119);
with the change, `FAIL 0 | PASS 22`. `tests/testthat/test_polities.R` and
`test_livestock_energy.R` also pass unchanged.

**Gates.** `air format` on both files; `lintr::lint_package()` with the exact CI linter config
reports `No lints found`; both changed files are pure ASCII.

One thing a reviewer will notice: the four pre-existing tests that build the extension from a
fixture now surface this warning, so the file reports `WARN 5`. That is the warning doing its job
on a real crosswalk gap and it fails nothing; I left those tests untouched rather than wrapping
them in `suppressWarnings()`, which would also hide future genuine warnings there. Say the word if
you would rather they were muted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JAxP2LSXPx67DDTWKERXiQ
