### PR TITLE
Let origin_area accept polity codes in footprint path tracing

### DIFF
--- a/R/footprint_paths.R
+++ b/R/footprint_paths.R
@@ -18,7 +18,14 @@
 #' @param extensions Numeric vector of environmental extensions per sector.
 #' @param labels Tibble with `area_code` and `item_cbs_code` mapping sectors.
 #' @param fd_labels Tibble labelling Y columns, from [build_io_model()].
-#' @param origin_area Optional area code vector limiting origin sectors.
+#' @param origin_area Optional vector limiting origin sectors. Each value is
+#'   matched against `labels$area_code` -- the LEGACY numeric area code -- and a
+#'   value that matches no `area_code` is then resolved through the polity
+#'   vocabulary of [polity_area_crosswalk], so a `polity_area_code` (`206`, the
+#'   Sudan aggregation bucket) or a `polity_code` (`"SDN-2011-2025"`) selects
+#'   the area codes it covers. Legacy codes keep their legacy meaning. Values
+#'   that resolve to no sector are dropped with a warning, and a call in which
+#'   nothing resolves aborts instead of returning an empty table.
 #' @param origin_item Optional item code vector limiting origin sectors.
 #' @param output_tol Minimum output considered valid when computing extension
 #'   intensities.
@@ -176,12 +183,63 @@ compute_footprint_paths <- function(
 ) {
   keep <- extensions > 0 & x_vec > output_tol
   if (!is.null(origin_area)) {
-    keep <- keep & labels$area_code %in% origin_area
+    keep <- keep & .origin_area_selection(labels, origin_area)
   }
   if (!is.null(origin_item)) {
     keep <- keep & labels$item_cbs_code %in% origin_item
   }
   which(keep)
+}
+
+# `origin_area` filters on `labels$area_code`, the legacy numeric area code.
+# A caller holding the polity vocabulary instead -- a `polity_area_code` such as
+# 206, the aggregation bucket covering Sudan 276 and South Sudan 277, or a
+# `polity_code` such as "SDN-2011-2025" -- used to get a silent, valid-looking
+# empty table, because those values are absent from `area_code` for the 64 areas
+# whose aggregation key differs from their own code. Accept either vocabulary,
+# resolved through the same reporting-polity lookup that labels the output, so
+# what you filter on is what the output reports. A value that matches a legacy
+# `area_code` keeps its legacy meaning, so anything that worked before is
+# unchanged; only values matching no `area_code` reach the polity vocabulary.
+.origin_area_selection <- function(labels, origin_area) {
+  lookup <- .label_reporting_polity_lookup(labels)
+  resolved <- purrr::map(origin_area, ~ .resolve_one_origin_area(lookup, .x))
+  unmatched <- origin_area[purrr::map_int(resolved, length) == 0L]
+
+  if (length(unmatched) == length(origin_area)) {
+    cli::cli_abort(c(
+      "{.arg origin_area} matches no sector in {.arg labels}.",
+      "x" = "Unresolved: {.val {origin_area}}.",
+      "i" = paste(
+        "Values are matched against {.field area_code}, then against",
+        "{.field polity_area_code} and {.field polity_code}."
+      )
+    ))
+  }
+  if (length(unmatched) > 0L) {
+    cli::cli_warn(
+      "Ignoring {.arg origin_area} values with no sector: {.val {unmatched}}."
+    )
+  }
+
+  labels$area_code %in% unlist(resolved)
+}
+
+.resolve_one_origin_area <- function(lookup, value) {
+  if (is.na(value)) {
+    return(lookup$area_code[0])
+  }
+  legacy <- .area_column_hits(lookup$area_code, value)
+  if (any(legacy)) {
+    return(lookup$area_code[legacy])
+  }
+  polity <- .area_column_hits(lookup$polity_area_code, value) |
+    .area_column_hits(lookup$reporting_polity_code, value)
+  lookup$area_code[polity]
+}
+
+.area_column_hits <- function(column, value) {
+  !is.na(column) & as.character(column) == as.character(value)
 }
 
 .footprint_paths_one_fd_col <- function(

--- a/man/compute_footprint_paths.Rd
+++ b/man/compute_footprint_paths.Rd
@@ -33,7 +33,14 @@ compute_footprint_paths(
 
 \item{fd_labels}{Tibble labelling Y columns, from \code{\link[=build_io_model]{build_io_model()}}.}
 
-\item{origin_area}{Optional area code vector limiting origin sectors.}
+\item{origin_area}{Optional vector limiting origin sectors. Each value is
+matched against \code{labels$area_code} -- the LEGACY numeric area code -- and a
+value that matches no \code{area_code} is then resolved through the polity
+vocabulary of \link{polity_area_crosswalk}, so a \code{polity_area_code} (\code{206}, the
+Sudan aggregation bucket) or a \code{polity_code} (\code{"SDN-2011-2025"}) selects
+the area codes it covers. Legacy codes keep their legacy meaning. Values
+that resolve to no sector are dropped with a warning, and a call in which
+nothing resolves aborts instead of returning an empty table.}
 
 \item{origin_item}{Optional item code vector limiting origin sectors.}
 

--- a/man/compute_fp_product_paths.Rd
+++ b/man/compute_fp_product_paths.Rd
@@ -33,7 +33,14 @@ compute_fp_product_paths(
 
 \item{fd_labels}{Tibble labelling Y columns, from \code{\link[=build_io_model]{build_io_model()}}.}
 
-\item{origin_area}{Optional area code vector limiting origin sectors.}
+\item{origin_area}{Optional vector limiting origin sectors. Each value is
+matched against \code{labels$area_code} -- the LEGACY numeric area code -- and a
+value that matches no \code{area_code} is then resolved through the polity
+vocabulary of \link{polity_area_crosswalk}, so a \code{polity_area_code} (\code{206}, the
+Sudan aggregation bucket) or a \code{polity_code} (\code{"SDN-2011-2025"}) selects
+the area codes it covers. Legacy codes keep their legacy meaning. Values
+that resolve to no sector are dropped with a warning, and a call in which
+nothing resolves aborts instead of returning an empty table.}
 
 \item{origin_item}{Optional item code vector limiting origin sectors.}
 

--- a/tests/testthat/test_footprint_paths.R
+++ b/tests/testthat/test_footprint_paths.R
@@ -103,15 +103,19 @@ testthat::test_that("compute_footprint_paths validates max_column_sum", {
   )
 })
 
-testthat::test_that("compute_footprint_paths returns empty output for absent origin", {
+testthat::test_that("compute_footprint_paths returns empty output for extension-free origin", {
+  # This used to select an area absent from `labels` (`origin_area = 2L`), which
+  # is now an error rather than a silent empty table. The empty-output schema
+  # still has to hold, so reach it the legitimate way: a selected origin area
+  # that carries no extension at all.
   paths <- compute_footprint_paths(
-    z_mat = matrix(0, nrow = 1, ncol = 1),
-    x_vec = 1,
-    y_mat = matrix(1, nrow = 1),
-    extensions = 1,
-    labels = tibble::tibble(area_code = 1L, item_cbs_code = 1L),
+    z_mat = matrix(0, nrow = 2, ncol = 2),
+    x_vec = c(1, 1),
+    y_mat = matrix(c(1, 1), nrow = 2),
+    extensions = c(0, 1),
+    labels = tibble::tibble(area_code = c(1L, 2L), item_cbs_code = c(1L, 2L)),
     fd_labels = tibble::tibble(area_code = 1L, fd_col = "food"),
-    origin_area = 2L
+    origin_area = 1L
   )
 
   testthat::expect_equal(nrow(paths), 0)
@@ -138,6 +142,138 @@ testthat::test_that("compute_footprint_paths returns empty output for absent ori
       "value"
     )
   )
+})
+
+testthat::test_that("origin_area accepts a polity_area_code for a folded area", {
+  # `origin_area` filters on `labels$area_code`, the legacy numeric area code.
+  # For the 64 areas whose FABIO aggregation key differs from their own code,
+  # `polity_area_code` is a different number: Sudan 276 and South Sudan 277 both
+  # sit in bucket 206. Passing 206 used to return 0 rows and no message at all,
+  # so a caller working in the polity vocabulary got a silent, valid-looking
+  # empty footprint. It must now resolve to the areas the bucket covers.
+  z_mat <- matrix(c(0, 50, 0, 0), nrow = 2, byrow = TRUE)
+  x_vec <- c(100, 200)
+  y_mat <- matrix(c(10, 100), nrow = 2)
+  extensions <- c(200, 0)
+  labels <- tibble::tibble(
+    area_code = c(276L, 277L),
+    item_cbs_code = c(10L, 20L)
+  )
+  fd_labels <- tibble::tibble(area_code = 277L, fd_col = "food")
+
+  legacy <- compute_footprint_paths(
+    z_mat = z_mat,
+    x_vec = x_vec,
+    y_mat = y_mat,
+    extensions = extensions,
+    labels = labels,
+    fd_labels = fd_labels,
+    origin_area = 276L,
+    conserve_extensions = FALSE
+  )
+  bucket <- compute_footprint_paths(
+    z_mat = z_mat,
+    x_vec = x_vec,
+    y_mat = y_mat,
+    extensions = extensions,
+    labels = labels,
+    fd_labels = fd_labels,
+    origin_area = 206L,
+    conserve_extensions = FALSE
+  )
+  polity <- compute_footprint_paths(
+    z_mat = z_mat,
+    x_vec = x_vec,
+    y_mat = y_mat,
+    extensions = extensions,
+    labels = labels,
+    fd_labels = fd_labels,
+    origin_area = "SDN-2011-2025",
+    conserve_extensions = FALSE
+  )
+
+  testthat::expect_equal(nrow(legacy), 2)
+  testthat::expect_equal(bucket, legacy)
+  testthat::expect_equal(polity, legacy)
+  testthat::expect_equal(unique(bucket$origin_polity_code), "SDN-2011-2025")
+})
+
+testthat::test_that("origin_area keeps the legacy meaning of an area code", {
+  # American Samoa (5) is folded into rest-of-world, so its `polity_area_code`
+  # is 999 -- which is also a legacy `area_code` in its own right. Resolving the
+  # polity vocabulary must not widen an existing legacy selection: 999 keeps
+  # meaning the single rest-of-world sector, while the polity code shared by
+  # both label rows selects both.
+  z_mat <- matrix(0, nrow = 2, ncol = 2)
+  x_vec <- c(100, 200)
+  y_mat <- matrix(c(10, 20), nrow = 2)
+  extensions <- c(100, 200)
+  labels <- tibble::tibble(
+    area_code = c(5L, 999L),
+    item_cbs_code = c(10L, 20L)
+  )
+  fd_labels <- tibble::tibble(area_code = 999L, fd_col = "food")
+
+  row_only <- compute_footprint_paths(
+    z_mat = z_mat,
+    x_vec = x_vec,
+    y_mat = y_mat,
+    extensions = extensions,
+    labels = labels,
+    fd_labels = fd_labels,
+    origin_area = 999L,
+    conserve_extensions = FALSE
+  )
+  both <- compute_footprint_paths(
+    z_mat = z_mat,
+    x_vec = x_vec,
+    y_mat = y_mat,
+    extensions = extensions,
+    labels = labels,
+    fd_labels = fd_labels,
+    origin_area = "ROW-1850-2023",
+    conserve_extensions = FALSE
+  )
+
+  testthat::expect_equal(row_only$origin_area, 999L)
+  testthat::expect_setequal(both$origin_area, c(5L, 999L))
+})
+
+testthat::test_that("origin_area rejects values that resolve to no sector", {
+  # An unresolvable value is a caller mistake, and used to produce an empty
+  # table indistinguishable from a genuine zero footprint. A partly resolvable
+  # vector stays backward compatible -- the resolvable areas are still traced --
+  # but the dropped values are reported instead of vanishing.
+  args <- list(
+    z_mat = matrix(0, nrow = 2, ncol = 2),
+    x_vec = c(100, 200),
+    y_mat = matrix(c(10, 20), nrow = 2),
+    extensions = c(100, 200),
+    labels = tibble::tibble(
+      area_code = c(276L, 277L),
+      item_cbs_code = c(10L, 20L)
+    ),
+    fd_labels = tibble::tibble(area_code = 277L, fd_col = "food"),
+    conserve_extensions = FALSE
+  )
+
+  testthat::expect_error(
+    do.call(compute_footprint_paths, c(args, list(origin_area = 424242L))),
+    "matches no sector"
+  )
+  testthat::expect_error(
+    do.call(compute_fp_product_paths, c(args, list(origin_area = 424242L))),
+    "matches no sector"
+  )
+
+  testthat::expect_warning(
+    partial <- do.call(
+      compute_footprint_paths,
+      c(args, list(origin_area = c(276L, 424242L)))
+    ),
+    "no sector"
+  )
+  testthat::expect_equal(unique(partial$origin_area), 276L)
 })
 
 testthat::test_that("compute_fp_product_paths keeps supplied product area and item", {


### PR DESCRIPTION
## What was wrong

`compute_footprint_paths()` and `compute_fp_product_paths()` restricted traced origin sectors with
`labels$area_code %in% origin_area` (`R/footprint_paths.R:179`). `labels$area_code` is the LEGACY
numeric FAOSTAT/FABIO area code, not the polity vocabulary. For the **64** areas whose aggregation
key differs from their own code, `polity_area_code` is a different number:

| area_code | area_name | polity_area_code |
|---|---|---|
| 276 | Sudan | 206 |
| 277 | South Sudan | 206 |
| 62 | Ethiopia PDR | 238 |
| 5, 6, 17, 22, ... (61 areas) | small territories | 999 |

A caller working in polity terms (`206`, or the polity code `"SDN-2011-2025"`) therefore got 0 rows,
no message, and a schema-complete tibble indistinguishable from a genuine zero footprint. So did a
caller passing an outright typo.

## Evidence it reproduced before the change

Two-sector Sudan/South Sudan model (labels `area_code = c(276, 277)`, extension on 276 only),
run on this branch before the fix:

```
--- legacy area code 276 (works today) ---
rows: 2  value: 70
--- polity_area_code 206 (Sudan bucket) ---
SILENT rows: 0  value: 0
--- polity_code string 'SDN-2011-2025' ---
SILENT rows: 0  value: 0
--- compute_fp_product_paths with 206 ---
SILENT rows: 0  value: 0
--- nonsense code 424242 ---
SILENT rows: 0
```

## What changed

`.origin_area_selection()` resolves each `origin_area` value through
`.label_reporting_polity_lookup()` -- the *same* lookup that stamps `origin_polity_code` onto the
output, so what you filter on is what the output reports.

Decision taken: **accept either vocabulary (backward compatible)**, not deprecation. Reasons:

1. Resolution is by **precedence**, not union: a value matching a legacy `area_code` keeps its legacy
   meaning, and only values matching no `area_code` fall through to `polity_area_code` and
   `polity_code`. So any input that produced a non-empty result before produces the byte-identical
   result now. This matters concretely: `999` is *both* a legacy `area_code` (rest of world) and the
   `polity_area_code` of 61 folded areas -- a union would have silently widened an existing caller's
   selection. There is a regression test for exactly that.
2. `polity_area_code` is an aggregation key, not an identity (per the epic's project rule), so it
   cannot be the required input vocabulary; and no code in the package passes `origin_area`, so
   deprecating the raw form would only break external/notebook callers for no gain.
3. Values that resolve to nothing are dropped with a `cli_warn()`; a call in which **nothing**
   resolves now `cli_abort()`s instead of returning an empty table. Partial vectors keep working
   (backward compatible) but no longer lose values silently. `NA` counts as unresolved.

Roxygen `@param origin_area` now documents the mismatch and the resolution order (port of the
doc-only change from #382, reworded to ASCII and to describe the implemented behaviour).

## How I verified

```
--- legacy area code 276 --- rows: 2  value: 70
--- polity_area_code 206  --- rows: 2  value: 70
--- polity_code 'SDN-2011-2025' --- rows: 2  value: 70
--- compute_fp_product_paths with 206 --- rows: 2  value: 70
--- nonsense code 424242 ---
ERRORED: `origin_area` matches no sector in `labels`.
x Unresolved: 424242.
i Values are matched against area_code, then against polity_area_code and polity_code.
```

- `tests/testthat/test_footprint_paths.R`: **FAIL 0 | PASS 48** with the fix; stashing only
  `R/footprint_paths.R` and re-running the same file gives **FAIL 7**, i.e. the new tests do not pass
  without the code change.
- Unchanged and still green: `test_footprint.R` (42), `test_footprint_balance.R` (27),
  `test_build_footprint.R` (8), `test_footprint_sankey.R` (25), `test_polity_output_coverage.R` (82).
- `air format`, `lintr::lint_package()` with the CI linter config: **No lints found**,
  `devtools::document()` (man/ committed). No non-ASCII anywhere in the changed R or Rd files.

**Published values:** unchanged, and this is structural rather than measured -- no function in the
package passes `origin_area`, so no build path reaches the modified branch. The only behaviour
changes are for inputs that previously produced an empty result.

One existing test (`"returns empty output for absent origin"`, `origin_area = 2L` against labels
holding only area 1) asserted the silent-empty behaviour this issue asks to remove. It is rewritten
to reach the empty-output schema legitimately -- a selected origin area carrying no extension -- so
`.empty_footprint_paths()` column coverage is retained.

Closes #471
Part of the polity migration epic #458.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JAxP2LSXPx67DDTWKERXiQ
