### PR TITLE
Resolve historical trade to the polity of its own reported year

### DIFF
--- a/R/build_cbs.R
+++ b/R/build_cbs.R
@@ -734,16 +734,39 @@ build_processing_coefs <- function(
   dt
 }
 
+# Resolve an iso3c + year table from a genuine historical trade source to the
+# polity active in its own reported year, adding `area`, `area_code` -- the
+# polity aggregation bucket -- and `polity_code`. Unlike WHEP's pre-1962 FAOSTAT
+# series, which are back-cast onto ~1961 territory, these sources are reported
+# under their own year's borders, so the back-cast floor documented in
+# .add_polity_columns_dt must be switched off. Rows whose iso3c is unknown, or
+# whose reported year predates every period of its area, keep NA and are dropped
+# by the caller.
+.resolve_hist_trade_polities <- function(dt) {
+  area_bridge <- .current_area_lookup(include_unmapped = FALSE)[
+    !is.na(area_iso3c),
+    .(iso3c = area_iso3c, area = area_name, area_code)
+  ]
+  area_bridge <- unique(area_bridge, by = "iso3c")
+
+  out <- merge(dt, area_bridge, by = "iso3c", all.x = TRUE, sort = FALSE)
+  out <- .add_polity_columns_dt(
+    out,
+    code_col = "area_code",
+    year_col = "year",
+    include_unmapped = FALSE,
+    backcast_anchor = -Inf
+  )
+  out[, area_code := polity_area_code]
+  keep <- unique(c(names(dt), "area", "area_code", "polity_code"))
+  out[, keep, with = FALSE]
+}
+
 .read_historical_trade <- function(years = NULL) {
   items <- data.table::as.data.table(whep::items_full)[,
     .(item_cbs, item_cbs_code)
   ]
   cbs_trade <- data.table::as.data.table(whep::cbs_trade_codes)
-  area_bridge <- .current_area_lookup(include_unmapped = FALSE)[
-    !is.na(area_iso3c),
-    .(iso3c = area_iso3c, area = area_name, area_code = polity_area_code)
-  ]
-  area_bridge <- unique(area_bridge, by = "iso3c")
 
   exports <- .read_input(
     "historical-trade-exports",
@@ -777,16 +800,24 @@ build_processing_coefs <- function(
     c("iso3c", "item_code_trade")
   )
 
-  dt <- merge(dt, area_bridge, by = "iso3c", all.x = TRUE, sort = FALSE)
+  dt <- .resolve_hist_trade_polities(dt)
   dt <- merge(dt, cbs_trade, by = "item_code_trade", all.x = TRUE, sort = FALSE)
   dt <- merge(dt, items, by = "item_cbs", all.x = TRUE, sort = FALSE)
 
   dt <- dt[,
     .(value = sum(value, na.rm = TRUE)),
-    by = c("year", "area", "area_code", "item_cbs", "item_cbs_code", "element")
+    by = c(
+      "year",
+      "area",
+      "area_code",
+      "polity_code",
+      "item_cbs",
+      "item_cbs_code",
+      "element"
+    )
   ]
   dt[, unit := "tonnes"]
-  dt[!is.na(area)]
+  dt[!is.na(polity_code)]
 }
 
 # Enrich codes-only primary output with names needed by the CBS pipeline.

--- a/tests/testthat/test_build_cbs.R
+++ b/tests/testthat/test_build_cbs.R
@@ -605,3 +605,70 @@ test_that(".format_cbs_output removes duplicate rows", {
   expect_equal(nrow(prod_rows), 1L)
   expect_equal(prod_rows$value, 100)
 })
+
+
+# -- .resolve_hist_trade_polities ----------------------------------------------
+
+test_that(".resolve_hist_trade_polities keys on the reported year, not today", {
+  # The historical trade pins are a genuine historical source: 1746-1961 figures
+  # reported under the borders in force at the time, unlike WHEP's pre-1962
+  # FAOSTAT series which are back-cast onto ~1961 territory. Resolution used to
+  # go through .current_area_lookup, which is deliberately year-insensitive, so
+  # every row of an ISO3 got that ISO3's *present-day* polity: all 1,093 India
+  # rows landed on IND-1949-2025 and all 9,522 UK rows on GBR-1921-2025.
+  resolved <- whep:::.resolve_hist_trade_polities(data.table::data.table(
+    iso3c = c("IND", "IND", "IND", "GBR", "GBR"),
+    year = c(1885L, 1920L, 1961L, 1850L, 1961L),
+    value = 1
+  ))
+
+  expect_equal(
+    resolved$polity_code,
+    c(
+      "IND-1800-1893",
+      "IND-1914-1937",
+      "IND-1949-2025",
+      "GBR-1800-1921",
+      "GBR-1921-2025"
+    )
+  )
+
+  # The FABIO aggregation bucket is period-invariant for both ISO3s, which is
+  # why making the lookup year-aware moved no tonnage for them: over the full
+  # pin the totals went 18,455,438,816 t -> 18,453,716,816 t (-0.0093%), and all
+  # of that was the pre-1850 aggregate rows exercised in the next test.
+  expect_equal(resolved$area_code, c(100L, 100L, 100L, 229L, 229L))
+})
+
+test_that(".resolve_hist_trade_polities drops pre-range aggregate rows", {
+  # Guadeloupe and Martinique are folded into the ROW bucket, whose only polity
+  # ROW-1850-2023 is of type "aggregate". .add_polity_columns_dt refuses to
+  # extend aggregate reporting areas outside their range, so an 1830 figure has
+  # no polity and must be dropped rather than back-filled into ROW. That is the
+  # 64 rows / 1,722,000 t the year-aware lookup removes from the feed.
+  resolved <- whep:::.resolve_hist_trade_polities(data.table::data.table(
+    iso3c = c("GLP", "GLP"),
+    year = c(1830L, 1900L),
+    value = 1
+  ))
+
+  expect_true(is.na(resolved$polity_code[1]))
+  expect_true(is.na(resolved$area_code[1]))
+  expect_equal(resolved$polity_code[2], "ROW-1850-2023")
+  expect_equal(resolved$area_code[2], 999L)
+})
+
+test_that(".resolve_hist_trade_polities leaves unknown iso3 labels unresolved", {
+  # The pins carry a handful of labels that are not ISO3 codes in the crosswalk
+  # (a placeholder for unknown origin, "BEL-LUX", "CZH"). They stay NA so the
+  # caller drops them instead of silently attaching them to a wrong polity;
+  # resolving them needs new crosswalk aliases, not a change here.
+  resolved <- whep:::.resolve_hist_trade_polities(data.table::data.table(
+    iso3c = c("BEL-LUX", "ESP"),
+    year = c(1900L, 1900L),
+    value = 1
+  ))
+
+  expect_true(is.na(resolved$polity_code[1]))
+  expect_false(is.na(resolved$polity_code[2]))
+})


### PR DESCRIPTION
Part of the polity migration epic #458.

## What was wrong

`.read_historical_trade()` reads two genuine historical trade pins
(`historical-trade-exports` / `historical-trade-imports`, 1746-1961 quantities
reported under the borders in force at the time) and resolved their `iso3`
labels through `.current_area_lookup()`. That lookup is **deliberately
year-insensitive**: it collapses the crosswalk to one row per `area_code`,
preferring the entity still active in 2025. So every row of an ISO3 inherited
that ISO3's present-day polity, which directly contradicts the contract already
documented in `.add_polity_columns_dt()`:

> Genuine historical-source data (reported under real historical borders) is
> handled separately, keyed directly to its polity, not via this lookup.

## Evidence it reproduced (on this branch, before the change)

Reading both pins in full (249,267 rows after the unit filter) and applying the
pre-change resolution:

| ISO3 | rows | year span in the data | polity the old code assigned |
|---|---|---|---|
| `IND` | 1,093 | 1849-1961 | `IND-1949-2025` for **all** of them |
| `GBR` | 9,522 | 1840-1961 | `GBR-1921-2025` for **all** of them |

The data actually spans `IND-1800-1893`, `IND-1893-1914`, `IND-1914-1937` and
`GBR-1800-1921`. Pre-change output carried no `polity_code` column at all, and
1830 Guadeloupe was folded into `ROW-1850-2023` -- an `aggregate` polity that
did not exist in 1830.

## What I changed

`R/build_cbs.R`: extracted the resolution into `.resolve_hist_trade_polities()`,
which bridges `iso3c` to the raw FAOSTAT `area_code` and then resolves the
polity with `.add_polity_columns_dt(year_col = "year", backcast_anchor = -Inf)`.
The back-cast floor exists for FAOSTAT series projected onto ~1961 territory;
these pins are precisely what it is *not* for, so it is disabled as the issue
asks. The output now carries `polity_code` next to the `polity_area_code`
aggregation bucket, and unresolved rows are dropped on `polity_code` instead of
on the area label.

## How I verified

`.read_historical_trade()` after the change, both pins in full:

```
rows: 173699   total tonnes: 18,453,716,816
cols: year, area, area_code, polity_code, item_cbs, item_cbs_code, element, value, unit
any NA polity_code? FALSE
all area_code are polity_area_codes? TRUE

India (area_code 100)          UK (area_code 229)
IND-1800-1893  174  1849-1892  GBR-1800-1921  5335  1840-1920
IND-1893-1914  150  1893-1913  GBR-1921-2025  4187  1921-1961
IND-1914-1937  574  1914-1933
IND-1949-2025  195  1961-1961
```

Feed-level magnitude diff, old vs new over the same input:

* 173,763 -> 173,699 rows
* 18,455,438,816 t -> 18,453,716,816 t (**-0.0093%**)
* Every surviving row keeps the same `area_code`, because each ISO3 in the
  crosswalk maps to exactly one `polity_area_code` across all of its periods
  (verified: zero ISO3s with more than one `polity_area_code`).
* The entire delta is 64 pre-1850 Guadeloupe/Martinique rows (1,722,000 t). Both
  fold into the ROW bucket, whose only polity `ROW-1850-2023` is of type
  `aggregate`, and aggregate reporting areas are not extended outside their
  range -- so those rows now drop instead of being back-filled.

Tests: three new cases in `tests/testthat/test_build_cbs.R`. Against unmodified
`R/build_cbs.R` they fail (`FAIL 3`, `object '.resolve_hist_trade_polities' not
found`); with the change `test_build_cbs.R` is `FAIL 0 | PASS 80`.
`test_polities.R` and `test_polity_output_coverage.R` also pass. `air format`
clean; `lintr::lint_package()` with the exact CI linter config reports
**No lints found**. No non-ASCII characters added.

## Draft, because the value question is not fully settled

The feed's own totals move (-0.0093%, above), so per the epic's rule this is a
draft: **no full-build magnitude comparison against `main` has been run and one
is required before merge.**

That said, I could not find a path by which this reaches a published number:
`inputs$trade_hist` is produced at `R/build_cbs.R:621` and stored in the inputs
list at `:644`, but **no consumer reads it**. `.cbs_combine_sources()`,
`.assemble_cbs_sources()` and `.cbs_extend_historical()` never touch it; the only
other occurrence of the name in the package is the string comparison
`source != "trade_hist"` at `:1571`, and no source is ever labelled
`"trade_hist"`. So the historical trade pins are downloaded, parsed and
discarded on current `main`. If that is intended, this PR is value-neutral; if
it is an oversight, wiring the feed in is a separate change and should be
measured then. Flagging for an owner decision rather than guessing.

## Part (a) of the issue is stale -- deliberately not changed

The issue also asks to route `.read_fao_trade()` through
`.aggregate_to_polities()`. It already is: `.read_fao_trade()` delegates to
`.extract_fao()`, which has ended in `.aggregate_to_polities(dt, item_cbs,
item_cbs_code)` since the reader was first written (`89c400ca`, 2026-04-01).
Checked on 2019-2020 (215,341 rows): none of the 64 divergent raw area codes
appear in its output, and every `area_code` it emits is a valid
`polity_area_code`. `all_trade` is already `polity_area_code`-keyed end to end,
so the first acceptance criterion holds on `main` without any change and I made
none.

## Known gap reported, not fixed

Four `iso3` labels in the pins are not ISO3 codes in the crosswalk and are
dropped (unchanged by this PR): a non-ASCII unknown-origin placeholder (3,292
rows), `BEL-LUX` (2,741 rows), `CZH` (269 rows) and `CAM` (1 row) -- together
6,303 of 249,267 rows and 0.99% of the tonnage. `BEL-LUX` and `CZH` plainly
correspond to FAOSTAT areas 15 (Belgium-Luxembourg) and 51 (Czechoslovakia),
which do carry polities (`BLX-1850-1999`, `F51-1947-1993`). Adding those aliases
is a crosswalk change with a methodological choice attached, so it belongs in its
own issue rather than here.

Closes #469

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JAxP2LSXPx67DDTWKERXiQ
