### PR TITLE
Stop resolving FAOSTAT areas to retired polities

### DIFF
--- a/R/polities.R
+++ b/R/polities.R
@@ -541,3 +541,92 @@ get_polity_geometries <- function(polity_codes = NULL) {
   }
   out
 }
+
+#' Find FAOSTAT areas whose polity resolution is ambiguous
+#'
+#' A FAOSTAT area maps to a sequence of polities that is meant to partition time,
+#' so `(area_code, year)` has exactly one answer. Where two live polities cover the
+#' same year the answer depends on row order rather than on the data, and
+#' [add_polity_code()] silently returns whichever the ordering surfaces.
+#'
+#' This detects that. It is separate from the upstream check that no two periods of
+#' one polity *family* overlap: two different families can both map to one FAOSTAT
+#' area, which is the case this finds and that one does not.
+#'
+#' @param crosswalk A crosswalk frame; defaults to [polity_area_crosswalk].
+#' @return A data frame with one row per ambiguous `(area_code, year)`, carrying
+#'   `area_code`, `year`, `n` and `polity_codes` (comma-separated). Zero rows when
+#'   resolution is unique, which is the intended state.
+#' @keywords internal
+#' @noRd
+.area_year_polity_conflicts <- function(crosswalk = NULL) {
+  cw <- if (is.null(crosswalk)) whep::polity_area_crosswalk else crosswalk
+  cw <- as.data.frame(cw)
+  keep <- !is.na(cw$area_code) &
+    !is.na(cw$polity_code) &
+    !is.na(cw$polity_start_year) &
+    !is.na(cw$polity_end_year)
+  cw <- unique(cw[
+    keep,
+    c("area_code", "polity_code", "polity_start_year", "polity_end_year")
+  ])
+  if (nrow(cw) == 0L) {
+    return(.empty_conflict_frame())
+  }
+
+  # One row per (area, year) a polity covers. `polity_end_year` is EXCLUSIVE, so a
+  # period [1920, 1947) covers 1920:1946 -- getting that wrong would report a
+  # spurious conflict at every boundary.
+  spans <- Map(
+    function(a, p, s, e) {
+      if (e <= s) {
+        return(NULL)
+      }
+      data.frame(
+        area_code = a,
+        year = seq.int(s, e - 1L),
+        polity_code = p,
+        stringsAsFactors = FALSE
+      )
+    },
+    cw$area_code,
+    cw$polity_code,
+    as.integer(cw$polity_start_year),
+    as.integer(cw$polity_end_year)
+  )
+  spans <- spans[!vapply(spans, is.null, logical(1))]
+  if (length(spans) == 0L) {
+    return(.empty_conflict_frame())
+  }
+  long <- do.call(rbind, spans)
+
+  key <- paste(long$area_code, long$year, sep = ":")
+  counts <- table(key)
+  dup <- names(counts)[counts > 1L]
+  if (length(dup) == 0L) {
+    return(.empty_conflict_frame())
+  }
+
+  hit <- long[key %in% dup, ]
+  hit <- hit[order(hit$area_code, hit$year, hit$polity_code), ]
+  agg <- stats::aggregate(
+    polity_code ~ area_code + year,
+    data = hit,
+    FUN = function(x) paste(sort(unique(x)), collapse = ", ")
+  )
+  names(agg)[names(agg) == "polity_code"] <- "polity_codes"
+  agg$n <- lengths(strsplit(agg$polity_codes, ", ", fixed = TRUE))
+  agg <- agg[order(-agg$n, agg$area_code, agg$year), ]
+  rownames(agg) <- NULL
+  agg[, c("area_code", "year", "n", "polity_codes")]
+}
+
+.empty_conflict_frame <- function() {
+  data.frame(
+    area_code = integer(0),
+    year = integer(0),
+    n = integer(0),
+    polity_codes = character(0),
+    stringsAsFactors = FALSE
+  )
+}

--- a/data-raw/table_mappings.R
+++ b/data-raw/table_mappings.R
@@ -55,14 +55,14 @@ known_polity_prefixes <- unique(polity_attrs$polity_prefix)
 # changes no byte -- which is why this commit carries no `data/` diff. Run against the
 # current upstream database it already excludes 27, and 22 of those are crosswalk
 # candidates, so the filter becomes load-bearing the moment the snapshot is refreshed
-# (#485). Measured, not assumed: the regeneration reports
-# "Excluded 27 retired/superseded polities from resolution candidates; 713 remain."
+# (#485). Measured rather than assumed: regenerating against the current upstream
+# database reports excluding 27 dead polities and retaining 713.
 #
 # It does NOT fix every ambiguity. Two polities can be live and still overlap --
-# Montenegro's `MNE-1913-1915` and `MNE-1913-1918` both cover 1913-1914 and are both
-# `draft` upstream. No downstream filter can resolve that; it is
-# lbm364dl/whep-polities#62. `.area_year_polity_conflicts()` detects the class and
-# `test_polity_resolution_uniqueness.R` pins the known instance.
+# Montenegro's MNE-1913-1915 and MNE-1913-1918 both cover 1913-1914 and are both
+# marked draft upstream. No downstream filter can resolve that; it is filed upstream
+# as whep-polities issue 62. The conflict detector added alongside this finds the
+# class, and test_polity_resolution_uniqueness.R pins the known instance.
 live_polity_attrs <- polity_attrs |>
   dplyr::filter(
     is.na(.data$wiki_status) |

--- a/data-raw/table_mappings.R
+++ b/data-raw/table_mappings.R
@@ -32,6 +32,50 @@ polity_attrs <- polities |>
   )
 known_polity_prefixes <- unique(polity_attrs$polity_prefix)
 
+# A DEAD POLITY MUST NOT BE A RESOLUTION CANDIDATE.
+#
+# Upstream retires a polity when a finer split supersedes it -- `F248-1920-1991`
+# was retired once `F248-1920-1947` and `F248-1947-1991` replaced it -- and marks
+# that in `wiki_status`. We carried the column through and never filtered on it, so
+# a retired polity stayed a candidate and `(area, year)` resolution had two answers
+# for the same year. Which one `add_polity_code()` returned depended on row order.
+#
+# Upstream already draws this line and publishes it both ways: the manifest carries
+# `counts = {total, live, dead}`, and whep-polities' own matcher reports "excluded
+# from matching: 26 dead polities (retired/superseded)". We were the only consumer
+# ignoring it.
+#
+# The filter belongs HERE and not on `polities`. The published `polities` table keeps
+# every row, because looking up a retired code is legitimate -- a consumer holding
+# historical output needs to resolve the code it already has. What must not happen is
+# resolving TO one.
+#
+# Inert for the COMMITTED snapshot and not for long. The committed `polities.rda` holds
+# one `superseded` polity and it is not in the crosswalk, so regenerating against it
+# changes no byte -- which is why this commit carries no `data/` diff. Run against the
+# current upstream database it already excludes 27, and 22 of those are crosswalk
+# candidates, so the filter becomes load-bearing the moment the snapshot is refreshed
+# (#485). Measured, not assumed: the regeneration reports
+# "Excluded 27 retired/superseded polities from resolution candidates; 713 remain."
+#
+# It does NOT fix every ambiguity. Two polities can be live and still overlap --
+# Montenegro's `MNE-1913-1915` and `MNE-1913-1918` both cover 1913-1914 and are both
+# `draft` upstream. No downstream filter can resolve that; it is
+# lbm364dl/whep-polities#62. `.area_year_polity_conflicts()` detects the class and
+# `test_polity_resolution_uniqueness.R` pins the known instance.
+live_polity_attrs <- polity_attrs |>
+  dplyr::filter(
+    is.na(.data$wiki_status) |
+      !.data$wiki_status %in% c("retired", "superseded")
+  )
+dropped_dead <- nrow(polity_attrs) - nrow(live_polity_attrs)
+if (dropped_dead > 0L) {
+  cli::cli_inform(
+    "Excluded {dropped_dead} retired/superseded polities from resolution
+     candidates; {nrow(live_polity_attrs)} remain."
+  )
+}
+
 excel_na <- c("", "NA", "#N/A", "#DIV/0!", "#REF!")
 
 # repair_table_labels(): shared with harmonization_tables.R, which reads the same
@@ -133,7 +177,7 @@ polity_area_crosswalk <- regions_for_crosswalk |>
     )
   ) |>
   dplyr::left_join(
-    polity_attrs,
+    live_polity_attrs,
     by = c("mapping_prefix" = "polity_prefix"),
     relationship = "many-to-many"
   ) |>

--- a/tests/testthat/test_polity_resolution_uniqueness.R
+++ b/tests/testthat/test_polity_resolution_uniqueness.R
@@ -1,0 +1,87 @@
+# A FAOSTAT area maps to a sequence of polities that is meant to partition time, so
+# `(area_code, year)` has exactly one answer. Nothing checked that, and two separate
+# routes break it.
+#
+# ROUTE 1 -- DEAD POLITIES WERE CANDIDATES. Upstream retires a polity when a finer
+# split supersedes it (`F248-1920-1991` was retired once `F248-1920-1947` and
+# `F248-1947-1991` replaced it) and records that in `wiki_status`. The crosswalk build
+# carried the column and never filtered on it, so the retired period stayed a
+# candidate and competed with its own replacements. `add_polity_code()` returned
+# whichever row order surfaced. Fixed in `data-raw/table_mappings.R` by joining
+# `live_polity_attrs` rather than `polity_attrs`.
+#
+# Currently that filter removes nothing: this vintage of the database holds one
+# `superseded` polity and it is not in the crosswalk. It becomes load-bearing when the
+# snapshot is refreshed (#485), where 22 of 27 dead polities are candidates. So the
+# first test below would pass today even without the fix -- which is why the second
+# test exercises the DETECTOR against a fixture instead of against shipped data.
+#
+# ROUTE 2 -- GENUINELY OVERLAPPING LIVE PERIODS, which no downstream filter can fix.
+# Montenegro has `MNE-1913-1915` and `MNE-1913-1918`, both `draft` upstream, both
+# covering 1913 and 1914. One is presumably a legacy duplicate that was never retired,
+# but deciding which is an upstream question. Filed as lbm364dl/whep-polities#62.
+#
+# So the third test PINS the known conflict rather than asserting zero. Asserting zero
+# would fail today and teach nobody which route regressed; pinning means a new conflict
+# fails the test and the pin shrinks when upstream fixes Montenegro.
+
+testthat::test_that("no dead polity is a resolution candidate", {
+  cw <- as.data.frame(whep::polity_area_crosswalk)
+  p <- as.data.frame(whep::polities)
+
+  dead <- p$polity_code[
+    !is.na(p$wiki_status) & p$wiki_status %in% c("retired", "superseded")
+  ]
+  candidates <- unique(cw$polity_code[!is.na(cw$polity_code)])
+
+  testthat::expect_equal(intersect(candidates, dead), character(0))
+})
+
+testthat::test_that("the conflict detector finds an overlap the filter cannot", {
+  # Against a fixture, so this is not hostage to which polities the shipped vintage
+  # happens to contain. Two periods of one area covering 1930: a real conflict.
+  overlapping <- data.frame(
+    area_code = c(15L, 15L, 99L),
+    polity_code = c("XXX-1900-1950", "XXX-1925-1950", "YYY-1900-1950"),
+    polity_start_year = c(1900L, 1925L, 1900L),
+    polity_end_year = c(1950L, 1950L, 1950L),
+    stringsAsFactors = FALSE
+  )
+  out <- whep:::.area_year_polity_conflicts(overlapping)
+
+  testthat::expect_gt(nrow(out), 0L)
+  testthat::expect_setequal(unique(out$area_code), 15L)
+  testthat::expect_setequal(unique(out$n), 2L)
+  # 1925..1949 inclusive -- 25 years, and NOT 26, because `polity_end_year` is
+  # exclusive. An off-by-one here would report a phantom conflict at every boundary.
+  testthat::expect_equal(nrow(out), 25L)
+  testthat::expect_equal(min(out$year), 1925L)
+  testthat::expect_equal(max(out$year), 1949L)
+})
+
+testthat::test_that("adjacent periods are not a conflict", {
+  # The complement, and the case an exclusive-end off-by-one would break: periods that
+  # meet exactly must not overlap.
+  adjacent <- data.frame(
+    area_code = c(1L, 1L),
+    polity_code = c("AAA-1900-1950", "AAA-1950-2000"),
+    polity_start_year = c(1900L, 1950L),
+    polity_end_year = c(1950L, 2000L),
+    stringsAsFactors = FALSE
+  )
+  testthat::expect_equal(nrow(whep:::.area_year_polity_conflicts(adjacent)), 0L)
+})
+
+testthat::test_that("the shipped crosswalk's conflicts are the known ones", {
+  # PINNED, not asserted to zero -- see the header. Montenegro 1913-1914 is an upstream
+  # data question (lbm364dl/whep-polities#62), not something this package can resolve.
+  out <- whep:::.area_year_polity_conflicts()
+
+  testthat::expect_setequal(
+    paste0(out$area_code, ":", out$year, " ", out$polity_codes),
+    c(
+      "273:1913 MNE-1913-1915, MNE-1913-1918",
+      "273:1914 MNE-1913-1915, MNE-1913-1918"
+    )
+  )
+})


### PR DESCRIPTION
Part of the polity migration epic #458. Closes #486. **Unblocks #485.**

## What was wrong

A FAOSTAT area maps to a sequence of polities meant to partition time, so `(area_code, year)` should have exactly one answer. Two separate routes broke that, and nothing checked either.

**Route 1 — dead polities were resolution candidates.** Upstream retires a polity when a finer split supersedes it (`F248-1920-1991` was retired once `F248-1920-1947` and `F248-1947-1991` replaced it) and records it in `wiki_status`. The crosswalk build carried that column through and **never filtered on it**, so a retired period competed with its own replacements and `add_polity_code()` returned whichever row order surfaced.

Upstream already draws this line and publishes it twice over — the manifest carries `counts = {total: 740, live: 713, dead: 27}`, and whep-polities' own matcher reports *"excluded from matching: 26 dead polities (retired/superseded)"*. We were the only consumer ignoring it.

## The fix

The join at `data-raw/table_mappings.R` now uses `live_polity_attrs`, which drops `wiki_status %in% c("retired", "superseded")`.

Deliberately **not** applied to `polities`, which keeps every row. Resolving a retired code a consumer already holds is legitimate; resolving *to* one is not. The exclusion belongs to resolution, not to the published reference table.

## No `data/` diff, and that is the point

The committed snapshot holds one `superseded` polity and it is not in the crosswalk, so regenerating against it is byte-identical. Run against the **current upstream** database the filter already fires:

```
Excluded 27 retired/superseded polities from resolution candidates; 713 remain.
```

22 of those 27 are crosswalk candidates, so this becomes load-bearing the moment the snapshot is refreshed — which is #485, and why that PR's eight test failures should resolve once this lands.

## Route 2 — live periods can still overlap, and no filter fixes that

`.area_year_polity_conflicts()` is added to detect the general class, and it found one on **current main**:

```
area 273  1913  MNE-1913-1915, MNE-1913-1918
area 273  1914  MNE-1913-1915, MNE-1913-1918
```

Both `draft` upstream, so both live. Montenegrin data for 1913-1914 is attributed non-deterministically today. That is an upstream data question — filed as lbm364dl/whep-polities#62 — and it is the **only** conflict the shipped crosswalk has; every other overlap traced to a retired polity, which route 1 now handles.

## Why the test pins rather than asserts zero

Asserting zero conflicts fails today and names no route. The test **pins the Montenegro pair by identity**, so a new conflict fails it and the pin shrinks when upstream resolves that one.

The detector is unit-tested against **fixtures, not shipped data**, so it is not hostage to which polities this vintage happens to contain — including a case asserting that exactly-adjacent periods are *not* a conflict, which an exclusive-`end_year` off-by-one would break.

## Verification

- 9 tests pass in `test_polity_resolution_uniqueness.R`
- `lintr::lint_package()` under the exact CI config: **0 lints**
- `data-raw/table_mappings.R` parses; regeneration against the committed snapshot produces no diff
- **Moves no published values** — no dataset changes at all

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JAxP2LSXPx67DDTWKERXiQ
