### PR TITLE
Attach polity columns to read_population(), fixing main

### DIFF
--- a/R/population.R
+++ b/R/population.R
@@ -38,7 +38,9 @@
 #'   data. Defaults to `FALSE`.
 #'
 #' @return A tibble with `year`, `area_code` and `population` (persons), one row
-#'   per country-year, sorted by year then area code.
+#'   per country-year, sorted by year then area code, plus the polity columns
+#'   below.
+#' @inheritSection whep_polity_columns Polity columns
 #' @export
 #' @examples
 #' read_population(example = TRUE)
@@ -56,7 +58,8 @@ read_population <- function(years = NULL, data = list(), example = FALSE) {
       population = sum(.data$population),
       .by = c("year", "area_code")
     ) |>
-    dplyr::arrange(.data$year, .data$area_code)
+    dplyr::arrange(.data$year, .data$area_code) |>
+    .add_reporting_polity_columns()
 }
 
 # ---- Private helpers -------------------------------------------------------
@@ -123,5 +126,6 @@ read_population <- function(years = NULL, data = list(), example = FALSE) {
     2010L,
     21L,
     196353500
-  )
+  ) |>
+    .add_reporting_polity_columns()
 }

--- a/man/read_population.Rd
+++ b/man/read_population.Rd
@@ -19,7 +19,8 @@ data. Defaults to \code{FALSE}.}
 }
 \value{
 A tibble with \code{year}, \code{area_code} and \code{population} (persons), one row
-per country-year, sorted by year then area code.
+per country-year, sorted by year then area code, plus the polity columns
+below.
 }
 \description{
 Reads the \code{gdp-population} pin and returns population per country and year on
@@ -34,6 +35,33 @@ Regional residual aggregates in the pin (\code{RAFR}, \code{RASI}, \code{REUR}, 
 reported rather than silently discarded, since their omission is what makes
 the result a countries-only total rather than a world total.
 }
+\section{Polity columns}{
+
+Every area-keyed output carries the polity its \code{area_code} resolves to in
+that row's year:
+\itemize{
+\item \code{polity_area_code}: The numeric key rows are AGGREGATED on, for the matrix
+workflows. It is a bucket, not an identity: use \code{reporting_polity_code} to
+say which territory a row belongs to.
+\item \code{reporting_polity_code}: The polity itself, e.g. \code{ESP-1846-1914}. It is
+year-aware, so the same \code{area_code} resolves to different polities in
+different years, which is the point of the crosswalk.
+\item \code{reporting_polity_name}: Its name. It can differ from the area's own name
+where the area folds into an aggregate.
+\item \code{reporting_polity_has_geometry}: Whether the polity has a polygon in the
+WHEP polity database, for callers that need to map or intersect it. \code{FALSE}
+is a documented gap upstream, not an error.
+}
+
+Rows whose \code{area_code} resolves to no polity keep the columns with \code{NA}
+rather than being dropped, so a gap is visible instead of silent.
+
+Rows before the back-cast anchor year resolve to the polity live in that
+anchor year rather than to the polity live in the row's own year, because
+WHEP's pre-anchor series are back-cast onto the anchor-year territory. See
+\code{\link[=add_polity_code]{add_polity_code()}} for the reasoning.
+}
+
 \examples{
 read_population(example = TRUE)
 }

--- a/tests/testthat/test_population.R
+++ b/tests/testthat/test_population.R
@@ -36,9 +36,27 @@
 testthat::test_that("the example fixture matches the documented contract", {
   out <- whep::read_population(example = TRUE)
   testthat::expect_s3_class(out, "tbl_df")
-  testthat::expect_named(out, c("year", "area_code", "population"))
+  # The polity columns are part of the contract now, not an extra: `read_population()`
+  # resolves ISO3 to a numeric `area_code` and carries a `year`, so it is an area-keyed
+  # export with a year and #424 requires it to say which polity each row belongs to.
+  # `expect_named()` is exact, so it has to name them -- and asserting the exact set is
+  # the point: a silently dropped polity column should fail here.
+  testthat::expect_named(
+    out,
+    c(
+      "year",
+      "area_code",
+      "polity_area_code",
+      "reporting_polity_code",
+      "reporting_polity_name",
+      "reporting_polity_has_geometry",
+      "population"
+    )
+  )
   testthat::expect_true(all(out$population > 0))
   testthat::expect_type(out$area_code, "integer")
+  # Populated, not merely present.
+  testthat::expect_false(anyNA(out$reporting_polity_code))
 })
 
 testthat::test_that("ISO3 becomes a numeric area code and thousands persons", {


### PR DESCRIPTION
**`main` is currently red.** This fixes it.

## What happened

#487 pinned the set of area-keyed exports carrying **no** reporting-polity columns at exactly three. `read_population()` makes four:

```
Actual:   build_grazing_feed_footprint, build_land_balance_footprint, get_faostat_data, read_population
Expected: get_faostat_data, build_grazing_feed_footprint, build_land_balance_footprint
Needs:    read_population
```

Neither PR could have seen it. #487 censused the exports; `read_population()` arrived afterwards in `8fdd3e0b` (the SJOS-N nourishment work) while #487 was in flight. Both were green on their own branches — CI judges the merge ref, so the disagreement only appeared once #487 landed.

## The fix, and why this direction

**Attach the columns**, not widen the exception list. `read_population()` meets #424's own criterion: it resolves the pin's ISO3 to the numeric `area_code` the rest of the package uses, and it carries a `year` — so a polity *is* resolvable.

That is what separates it from the three real exceptions: `get_faostat_data()` returns FAOSTAT's own area **name** because resolving is the caller's job, and the two footprints aggregate over time with **no `year`**, so attaching a polity there means *choosing* one.

Applied to the real path and the example fixture both, so the documented example matches a real call.

## Verification

- census test passes — exception list back to three
- `test_population.R`, `test_food_supply.R`, `test_n_percapita.R` pass
- **0 lints** under the exact CI config
- `devtools::document()` regenerated `man/read_population.Rd`
- `test_population.R`'s contract test used `expect_named()`, which is exact — it now names all seven columns and asserts `reporting_polity_code` is *populated*, not merely present

Moves no published values: adds columns, changes no number.

Refs #424, #458.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JAxP2LSXPx67DDTWKERXiQ