### PR TITLE
Give the manure chain one documented vocabulary for territory

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,19 @@
 # whep (development version)
 
+* The manure/nutrient chain now documents **one vocabulary for `territory`**: a
+  stringified `area_code`, what `redistribute_feed()` emits and what the
+  pipeline has always passed. The `@examples` of `estimate_n_excretion()`,
+  `split_manure_management()`, `apply_management_losses()`,
+  `allocate_manure_to_land()`, `allocate_manure_transport()` and
+  `build_livestock_nutrient_flows()` used ISO literals instead (`"ESP"`, and
+  `"ES"`, which the chain's own resolver rejects outright). Passing an `iso3c`
+  still resolves, as a bridge for existing fixtures, but now warns: it can only
+  answer with `polity_area_code`, a FABIO aggregation bucket, which for 62 of
+  the 257 ISO3 codes in `regions_full` is not that territory's own code (61 land
+  on 999, Rest of World; `"SSD"` lands on 206, Sudan (former), where the numeric
+  form `"277"` keeps South Sudan). No published value changes: the pipeline
+  itself never took the ISO3 branch.
+
 * Every area-keyed exported output now carries the **reporting-polity columns**
   (`polity_area_code`, `reporting_polity_code`, `reporting_polity_name`,
   `reporting_polity_has_geometry`), so a caller can tell which territory a row

--- a/R/build_livestock_nutrient_flows.R
+++ b/R/build_livestock_nutrient_flows.R
@@ -34,14 +34,14 @@
 #' intake <- tibble::tribble(
 #'   ~year, ~territory, ~sub_territory, ~livestock_category,
 #'   ~item_cbs_code, ~feed_quality, ~intake_dm_t,
-#'   2020L, "ESP", NA, "Cattle_milk", 2513L, "high_quality", 200,
-#'   2020L, "ESP", NA, "Cattle_milk", NA, "grass", 600
+#'   2020L, "203", NA, "Cattle_milk", 2513L, "high_quality", 200,
+#'   2020L, "203", NA, "Cattle_milk", NA, "grass", 600
 #' )
 #' gridded <- list(
 #'   crops = tibble::tribble(
 #'     ~year, ~territory, ~sub_territory, ~crop, ~manure_n_receptivity, ~crop_n_cap,
-#'     2020L, "ESP", NA, "barley", 6, 200,
-#'     2020L, "ESP", NA, "wheat", 4, 200
+#'     2020L, "203", NA, "barley", 6, 200,
+#'     2020L, "203", NA, "wheat", 4, 200
 #'   )
 #' )
 #' build_livestock_nutrient_flows(intake, gridded = gridded)

--- a/R/excretion.R
+++ b/R/excretion.R
@@ -11,6 +11,11 @@
 #' @param intake A tibble of realised feed intake with at least `year`,
 #'   `territory`, `sub_territory`, `livestock_category`, `item_cbs_code`,
 #'   `feed_quality` and `intake_dm_t` (the [redistribute_feed()] result).
+#'   `territory` is a stringified `area_code` (`as.character(area_code)`, what
+#'   [redistribute_feed()] emits and what the whole manure chain carries
+#'   through to the nitrogen inputs); an `iso3c` literal is still resolved
+#'   there but is deprecated, since it can only answer with an aggregation
+#'   bucket and so loses the territory for 62 of the 257 codes it knows.
 #' @param options A named list of method options:
 #'   * `method`: `"intake_minus_retention"` (default,
 #'     `n_intake * (1 - n_retention_frac)`) or `"intake_minus_product_n"`
@@ -29,8 +34,8 @@
 #' intake <- tibble::tribble(
 #'   ~year, ~territory, ~sub_territory, ~livestock_category,
 #'   ~item_cbs_code, ~feed_quality, ~intake_dm_t,
-#'   2020L, "ES", NA, "Cattle_milk", 2513L, "high_quality", 100,
-#'   2020L, "ES", NA, "Cattle_milk", NA, "grass", 500
+#'   2020L, "203", NA, "Cattle_milk", 2513L, "high_quality", 100,
+#'   2020L, "203", NA, "Cattle_milk", NA, "grass", 500
 #' )
 #' estimate_n_excretion(intake)
 estimate_n_excretion <- function(intake, options = list()) {

--- a/R/manure_allocation.R
+++ b/R/manure_allocation.R
@@ -12,8 +12,8 @@
 #' its post-storage bundle ratio, so mass is conserved by construction.
 #'
 #' @param applied A tibble from [apply_management_losses()] with at least `year`,
-#'   `territory`, `sub_territory`, `stream`, `applied_n`, `applied_c` and
-#'   `applied_vs`.
+#'   `territory` (a stringified `area_code`, see [estimate_n_excretion()]),
+#'   `sub_territory`, `stream`, `applied_n`, `applied_c` and `applied_vs`.
 #' @param gridded A named list describing the land surface for each polity:
 #'   * `crops`: a tibble keyed by `year`, `territory`, `sub_territory`, `crop`
 #'     with the allocation weight (`manure_n_receptivity` for
@@ -54,13 +54,13 @@
 #' applied <- tibble::tribble(
 #'   ~year, ~territory, ~sub_territory, ~stream, ~manure_type,
 #'   ~applied_n, ~applied_c, ~applied_vs,
-#'   2020L, "ESP", NA, "collected", "Solid", 80, 800, 40,
-#'   2020L, "ESP", NA, "grazing", "Excreta", 20, 380, 12
+#'   2020L, "203", NA, "collected", "Solid", 80, 800, 40,
+#'   2020L, "203", NA, "grazing", "Excreta", 20, 380, 12
 #' )
 #' crops <- tibble::tribble(
 #'   ~year, ~territory, ~sub_territory, ~crop, ~manure_n_receptivity, ~crop_n_cap,
-#'   2020L, "ESP", NA, "barley", 6, 50,
-#'   2020L, "ESP", NA, "wheat", 4, 40
+#'   2020L, "203", NA, "barley", 6, 50,
+#'   2020L, "203", NA, "wheat", 4, 40
 #' )
 #' allocate_manure_to_land(applied, list(crops = crops))
 allocate_manure_to_land <- function(

--- a/R/manure_management.R
+++ b/R/manure_management.R
@@ -8,8 +8,9 @@
 #' the per-species MMS shares sum to one.
 #'
 #' @param excretion A tibble from [estimate_n_excretion()] with `year`,
-#'   `territory`, `sub_territory`, `livestock_category`, `n_excretion`,
-#'   `c_excretion` and `vs_excretion`.
+#'   `territory` (a stringified `area_code`, see [estimate_n_excretion()]),
+#'   `sub_territory`, `livestock_category`, `n_excretion`, `c_excretion` and
+#'   `vs_excretion`.
 #' @param options A named list. `mms_source` selects the MMS-share table
 #'   (`"regional_default"`, the global IPCC/GLEAM default in
 #'   `regional_mms_distribution`).
@@ -23,8 +24,8 @@
 #' excretion <- tibble::tribble(
 #'   ~year, ~territory, ~sub_territory, ~livestock_category,
 #'   ~n_excretion, ~c_excretion, ~vs_excretion,
-#'   2020L, "ES", NA, "Cattle_milk", 100, 1900, 60,
-#'   2020L, "ES", NA, "Pigs", 30, 270, 20
+#'   2020L, "203", NA, "Cattle_milk", 100, 1900, 60,
+#'   2020L, "203", NA, "Pigs", 30, 270, 20
 #' )
 #' split_manure_management(excretion)
 split_manure_management <- function(excretion, options = list()) {
@@ -139,7 +140,7 @@ split_manure_management <- function(excretion, options = list()) {
 #' excretion <- tibble::tribble(
 #'   ~year, ~territory, ~sub_territory, ~livestock_category,
 #'   ~n_excretion, ~c_excretion, ~vs_excretion,
-#'   2020L, "ES", NA, "Cattle_milk", 100, 1900, 60
+#'   2020L, "203", NA, "Cattle_milk", 100, 1900, 60
 #' )
 #' apply_management_losses(split_manure_management(excretion))
 apply_management_losses <- function(split, options = list()) {

--- a/R/manure_transport.R
+++ b/R/manure_transport.R
@@ -13,8 +13,9 @@
 #' source cell's bundle ratio.
 #'
 #' @param source_cells A tibble of cells exporting manure, keyed by `year`,
-#'   `territory` and `sub_territory` (a `"lon_lat"` cell id), with `surplus_n`,
-#'   `surplus_c` and `surplus_vs` (t).
+#'   `territory` (a stringified `area_code`, see [estimate_n_excretion()]) and
+#'   `sub_territory` (a `"lon_lat"` cell id), with `surplus_n`, `surplus_c` and
+#'   `surplus_vs` (t).
 #' @param sink_cells A tibble of cells with spare capacity, keyed by `year`,
 #'   `territory` and `sub_territory`, with `room_n` (remaining cropland plus
 #'   grassland N capacity, t).
@@ -30,12 +31,12 @@
 #' @examples
 #' source_cells <- tibble::tribble(
 #'   ~year, ~territory, ~sub_territory, ~surplus_n, ~surplus_c, ~surplus_vs,
-#'   2020L, "ESP", "1.5_40", 10, 90, 6
+#'   2020L, "203", "1.5_40", 10, 90, 6
 #' )
 #' sink_cells <- tibble::tribble(
 #'   ~year, ~territory, ~sub_territory, ~room_n,
-#'   2020L, "ESP", "1_40", 4,
-#'   2020L, "ESP", "2_40", 6
+#'   2020L, "203", "1_40", 4,
+#'   2020L, "203", "2_40", 6
 #' )
 #' allocate_manure_transport(source_cells, sink_cells)
 allocate_manure_transport <- function(

--- a/R/n_balance_inputs.R
+++ b/R/n_balance_inputs.R
@@ -411,14 +411,14 @@ build_n_inputs <- function(
     )
 }
 
-# build_livestock_nutrient_flows()'s $applied$territory carries either a
-# stringified area_code (the real pipeline's own convention, e.g.
-# feed_intake_redistribute.R:805 territory = as.character(area_code)) or an
-# ISO3 code (the function's own roxygen @examples and test fixtures use
-# territory = "ESP"). Resolve both rather than assuming one and silently
-# NA-ing the other: try integer parsing first, then fall back to an
-# iso3c -> area_code lookup via .iso3c_to_area_code() (R/polities.R); abort on
-# anything that resolves to neither, rather than propagating NA into area_code.
+# build_livestock_nutrient_flows()'s $applied$territory carries a stringified
+# area_code -- the one vocabulary the pipeline itself produces, e.g.
+# feed_intake_redistribute.R:805 territory = as.character(area_code). An ISO3
+# literal is still resolved, but only as a compatibility bridge for fixtures
+# written before the manure chain's own @examples used area codes: try integer
+# parsing first, then fall back to an iso3c -> area_code lookup via
+# .iso3c_to_area_code() (R/polities.R); abort on anything that resolves to
+# neither, rather than propagating NA into area_code.
 #
 # That helper matches on polity_area_code and so returns exactly one row per
 # ISO3. The previous inline lookup joined on regions_full$code, where ETH and
@@ -426,11 +426,34 @@ build_n_inputs <- function(
 # the result and shifted every LATER territory onto the wrong country: given
 # c("ESP", "ETH", "DEU") it returned 203, 238, 62 -- Germany silently became
 # Ethiopia PDR -- with only a "number of items to replace" warning.
+#
+# Uniqueness is not identity, though: polity_area_code is a FABIO aggregation
+# bucket, so the bridge answers with a code that is NOT the territory's own for
+# 62 of the 257 ISO3 codes it knows (measured). 61 of those land on 999, Rest
+# of World (AND, LIE, GRL, REU, ...), and SSD lands on 206, Sudan (former) --
+# where the numeric vocabulary "277" would have kept South Sudan. The bridge
+# therefore warns: a caller passing ISO3 cannot see which of the two answers it
+# got, and a silent one-in-four chance of another territory's code is exactly
+# the identity loss the polity migration is closing.
 .manure_territory_to_area_code <- function(territory) {
   as_int <- suppressWarnings(as.integer(territory))
   still_missing <- is.na(as_int) & !is.na(territory)
   if (any(still_missing)) {
-    as_int[still_missing] <- .iso3c_to_area_code(territory[still_missing])
+    from_iso3 <- .iso3c_to_area_code(territory[still_missing])
+    as_int[still_missing] <- from_iso3
+    bridged <- unique(territory[still_missing][!is.na(from_iso3)])
+    if (length(bridged) > 0) {
+      cli::cli_warn(c(
+        "Resolving {.field territory} from an {.field iso3c} literal is
+         deprecated.",
+        i = "Bridged as {.field iso3c}: {.val {bridged}}. Pass
+             {.code as.character(area_code)} instead, the vocabulary the
+             manure pipeline itself produces.",
+        i = "An {.field iso3c} resolves to {.field polity_area_code}, a FABIO
+             aggregation bucket, which for 62 of 257 known codes is not the
+             territory's own: {.val SSD} becomes 206, Sudan (former)."
+      ))
+    }
   }
   unresolved <- unique(territory[is.na(as_int) & !is.na(territory)])
   if (length(unresolved) > 0) {

--- a/R/soil_carbon_inputs.R
+++ b/R/soil_carbon_inputs.R
@@ -31,7 +31,9 @@
 #'   `root_c_t` and `weed_npp_c_t`, tonnes C); `manure` (the `applied` tibble of
 #'   [build_livestock_nutrient_flows()], with `crop` either an existing
 #'   `item_prod_code` or an `item_prod` name from [items_prod_full] (matched
-#'   case-insensitively), and `territory` a stringified `area_code` or `iso3c`);
+#'   case-insensitively), and `territory` a stringified `area_code` -- an
+#'   `iso3c` literal is still resolved but deprecated, see
+#'   [estimate_n_excretion()]);
 #'   `country_grid` and `crop_patterns` (the spatialization inputs,
 #'   `crop_patterns` carrying per-cell `crop_area_ha`); `harvested_area` (the
 #'   FAOSTAT national harvested area per `area_code`, `item_prod_code`, `year`

--- a/man/allocate_manure_to_land.Rd
+++ b/man/allocate_manure_to_land.Rd
@@ -8,8 +8,8 @@ allocate_manure_to_land(applied, gridded = list(), options = list())
 }
 \arguments{
 \item{applied}{A tibble from \code{\link[=apply_management_losses]{apply_management_losses()}} with at least \code{year},
-\code{territory}, \code{sub_territory}, \code{stream}, \code{applied_n}, \code{applied_c} and
-\code{applied_vs}.}
+\code{territory} (a stringified \code{area_code}, see \code{\link[=estimate_n_excretion]{estimate_n_excretion()}}),
+\code{sub_territory}, \code{stream}, \code{applied_n}, \code{applied_c} and \code{applied_vs}.}
 
 \item{gridded}{A named list describing the land surface for each polity:
 \itemize{
@@ -66,13 +66,13 @@ its post-storage bundle ratio, so mass is conserved by construction.
 applied <- tibble::tribble(
   ~year, ~territory, ~sub_territory, ~stream, ~manure_type,
   ~applied_n, ~applied_c, ~applied_vs,
-  2020L, "ESP", NA, "collected", "Solid", 80, 800, 40,
-  2020L, "ESP", NA, "grazing", "Excreta", 20, 380, 12
+  2020L, "203", NA, "collected", "Solid", 80, 800, 40,
+  2020L, "203", NA, "grazing", "Excreta", 20, 380, 12
 )
 crops <- tibble::tribble(
   ~year, ~territory, ~sub_territory, ~crop, ~manure_n_receptivity, ~crop_n_cap,
-  2020L, "ESP", NA, "barley", 6, 50,
-  2020L, "ESP", NA, "wheat", 4, 40
+  2020L, "203", NA, "barley", 6, 50,
+  2020L, "203", NA, "wheat", 4, 40
 )
 allocate_manure_to_land(applied, list(crops = crops))
 }

--- a/man/allocate_manure_transport.Rd
+++ b/man/allocate_manure_transport.Rd
@@ -8,8 +8,9 @@ allocate_manure_transport(source_cells, sink_cells, options = list())
 }
 \arguments{
 \item{source_cells}{A tibble of cells exporting manure, keyed by \code{year},
-\code{territory} and \code{sub_territory} (a \code{"lon_lat"} cell id), with \code{surplus_n},
-\code{surplus_c} and \code{surplus_vs} (t).}
+\code{territory} (a stringified \code{area_code}, see \code{\link[=estimate_n_excretion]{estimate_n_excretion()}}) and
+\code{sub_territory} (a \code{"lon_lat"} cell id), with \code{surplus_n}, \code{surplus_c} and
+\code{surplus_vs} (t).}
 
 \item{sink_cells}{A tibble of cells with spare capacity, keyed by \code{year},
 \code{territory} and \code{sub_territory}, with \code{room_n} (remaining cropland plus
@@ -40,12 +41,12 @@ source cell's bundle ratio.
 \examples{
 source_cells <- tibble::tribble(
   ~year, ~territory, ~sub_territory, ~surplus_n, ~surplus_c, ~surplus_vs,
-  2020L, "ESP", "1.5_40", 10, 90, 6
+  2020L, "203", "1.5_40", 10, 90, 6
 )
 sink_cells <- tibble::tribble(
   ~year, ~territory, ~sub_territory, ~room_n,
-  2020L, "ESP", "1_40", 4,
-  2020L, "ESP", "2_40", 6
+  2020L, "203", "1_40", 4,
+  2020L, "203", "2_40", 6
 )
 allocate_manure_transport(source_cells, sink_cells)
 }

--- a/man/apply_management_losses.Rd
+++ b/man/apply_management_losses.Rd
@@ -34,7 +34,7 @@ fresh excreta; the carbon and volatile-solids storage losses follow from that.
 excretion <- tibble::tribble(
   ~year, ~territory, ~sub_territory, ~livestock_category,
   ~n_excretion, ~c_excretion, ~vs_excretion,
-  2020L, "ES", NA, "Cattle_milk", 100, 1900, 60
+  2020L, "203", NA, "Cattle_milk", 100, 1900, 60
 )
 apply_management_losses(split_manure_management(excretion))
 }

--- a/man/build_livestock_nutrient_flows.Rd
+++ b/man/build_livestock_nutrient_flows.Rd
@@ -50,14 +50,14 @@ the nitrogen balance (excreted = applied + management losses) is conserved.
 intake <- tibble::tribble(
   ~year, ~territory, ~sub_territory, ~livestock_category,
   ~item_cbs_code, ~feed_quality, ~intake_dm_t,
-  2020L, "ESP", NA, "Cattle_milk", 2513L, "high_quality", 200,
-  2020L, "ESP", NA, "Cattle_milk", NA, "grass", 600
+  2020L, "203", NA, "Cattle_milk", 2513L, "high_quality", 200,
+  2020L, "203", NA, "Cattle_milk", NA, "grass", 600
 )
 gridded <- list(
   crops = tibble::tribble(
     ~year, ~territory, ~sub_territory, ~crop, ~manure_n_receptivity, ~crop_n_cap,
-    2020L, "ESP", NA, "barley", 6, 200,
-    2020L, "ESP", NA, "wheat", 4, 200
+    2020L, "203", NA, "barley", 6, 200,
+    2020L, "203", NA, "wheat", 4, 200
   )
 )
 build_livestock_nutrient_flows(intake, gridded = gridded)

--- a/man/build_soil_carbon_inputs.Rd
+++ b/man/build_soil_carbon_inputs.Rd
@@ -21,7 +21,9 @@ per \code{area_code}, \code{item_prod_code}, \code{year}, columns \code{residue_
 \code{root_c_t} and \code{weed_npp_c_t}, tonnes C); \code{manure} (the \code{applied} tibble of
 \code{\link[=build_livestock_nutrient_flows]{build_livestock_nutrient_flows()}}, with \code{crop} either an existing
 \code{item_prod_code} or an \code{item_prod} name from \link{items_prod_full} (matched
-case-insensitively), and \code{territory} a stringified \code{area_code} or \code{iso3c});
+case-insensitively), and \code{territory} a stringified \code{area_code} -- an
+\code{iso3c} literal is still resolved but deprecated, see
+\code{\link[=estimate_n_excretion]{estimate_n_excretion()}});
 \code{country_grid} and \code{crop_patterns} (the spatialization inputs,
 \code{crop_patterns} carrying per-cell \code{crop_area_ha}); \code{harvested_area} (the
 FAOSTAT national harvested area per \code{area_code}, \code{item_prod_code}, \code{year}

--- a/man/estimate_n_excretion.Rd
+++ b/man/estimate_n_excretion.Rd
@@ -9,7 +9,12 @@ estimate_n_excretion(intake, options = list())
 \arguments{
 \item{intake}{A tibble of realised feed intake with at least \code{year},
 \code{territory}, \code{sub_territory}, \code{livestock_category}, \code{item_cbs_code},
-\code{feed_quality} and \code{intake_dm_t} (the \code{\link[=redistribute_feed]{redistribute_feed()}} result).}
+\code{feed_quality} and \code{intake_dm_t} (the \code{\link[=redistribute_feed]{redistribute_feed()}} result).
+\code{territory} is a stringified \code{area_code} (\code{as.character(area_code)}, what
+\code{\link[=redistribute_feed]{redistribute_feed()}} emits and what the whole manure chain carries
+through to the nitrogen inputs); an \code{iso3c} literal is still resolved
+there but is deprecated, since it can only answer with an aggregation
+bucket and so loses the territory for 62 of the 257 codes it knows.}
 
 \item{options}{A named list of method options:
 \itemize{
@@ -40,8 +45,8 @@ comparable.
 intake <- tibble::tribble(
   ~year, ~territory, ~sub_territory, ~livestock_category,
   ~item_cbs_code, ~feed_quality, ~intake_dm_t,
-  2020L, "ES", NA, "Cattle_milk", 2513L, "high_quality", 100,
-  2020L, "ES", NA, "Cattle_milk", NA, "grass", 500
+  2020L, "203", NA, "Cattle_milk", 2513L, "high_quality", 100,
+  2020L, "203", NA, "Cattle_milk", NA, "grass", 500
 )
 estimate_n_excretion(intake)
 }

--- a/man/split_manure_management.Rd
+++ b/man/split_manure_management.Rd
@@ -8,8 +8,9 @@ split_manure_management(excretion, options = list())
 }
 \arguments{
 \item{excretion}{A tibble from \code{\link[=estimate_n_excretion]{estimate_n_excretion()}} with \code{year},
-\code{territory}, \code{sub_territory}, \code{livestock_category}, \code{n_excretion},
-\code{c_excretion} and \code{vs_excretion}.}
+\code{territory} (a stringified \code{area_code}, see \code{\link[=estimate_n_excretion]{estimate_n_excretion()}}),
+\code{sub_territory}, \code{livestock_category}, \code{n_excretion}, \code{c_excretion} and
+\code{vs_excretion}.}
 
 \item{options}{A named list. \code{mms_source} selects the MMS-share table
 (\code{"regional_default"}, the global IPCC/GLEAM default in
@@ -32,8 +33,8 @@ the per-species MMS shares sum to one.
 excretion <- tibble::tribble(
   ~year, ~territory, ~sub_territory, ~livestock_category,
   ~n_excretion, ~c_excretion, ~vs_excretion,
-  2020L, "ES", NA, "Cattle_milk", 100, 1900, 60,
-  2020L, "ES", NA, "Pigs", 30, 270, 20
+  2020L, "203", NA, "Cattle_milk", 100, 1900, 60,
+  2020L, "203", NA, "Pigs", 30, 270, 20
 )
 split_manure_management(excretion)
 }

--- a/tests/testthat/test_grass_natural_carbon_inputs.R
+++ b/tests/testthat/test_grass_natural_carbon_inputs.R
@@ -253,9 +253,14 @@ testthat::test_that("ISO3 excreta territory resolves to area_code, not NA", {
     ~year, ~territory, ~sub_territory, ~land_use, ~crop, ~applied_c,
     2000L, "ESP", NA, "Grassland", NA, 80
   )
-  with_ex <- whep::build_grass_natural_carbon_inputs(
-    resolution = "grid",
-    data = d
+  # The ISO3 form is a deprecated bridge (#463), so resolving it warns; this
+  # test is about it still resolving rather than dropping the excreta carbon.
+  testthat::expect_warning(
+    with_ex <- whep::build_grass_natural_carbon_inputs(
+      resolution = "grid",
+      data = d
+    ),
+    "deprecated"
   )
   without_ex <- whep::build_grass_natural_carbon_inputs(
     resolution = "grid",

--- a/tests/testthat/test_n_balance_inputs.R
+++ b/tests/testthat/test_n_balance_inputs.R
@@ -459,7 +459,9 @@ testthat::test_that("urban ISO3 area codes resolve instead of becoming NA", {
   data$cell_polity$area_code <- "ESP"
   data$cropland_ha$area_code <- "ESP"
 
-  out <- whep:::.n_inputs_urban(data)
+  # The iso3c form is a deprecated bridge (#463), so resolving it warns; what
+  # this test is about is that it still resolves rather than becoming NA.
+  testthat::expect_warning(out <- whep:::.n_inputs_urban(data), "deprecated")
 
   testthat::expect_equal(out$area_code, 203L)
   testthat::expect_false(anyNA(out$area_code))
@@ -507,9 +509,12 @@ testthat::test_that("manure_type maps to manure_solid/manure_liquid/excreta", {
 })
 
 testthat::test_that("manure territory resolves an iso3c code, not just a stringified area_code", {
-  # build_livestock_nutrient_flows()'s own @examples/tests use an iso3c
-  # territory ("ESP"); the real pipeline (redistribute_feed()) instead
-  # casts area_code to character. Both must resolve, not just one.
+  # The real pipeline (redistribute_feed()) casts area_code to character; an
+  # iso3c territory is a deprecated bridge for fixtures written before the
+  # manure chain's @examples used area codes (#463). It must still resolve
+  # rather than silently NA out, but it now warns, and the warning has to reach
+  # the exported boundary rather than dying inside the helper -- that is what
+  # tells a caller their fixture is on the lossy vocabulary.
   intake <- .nbi_livestock_intake()
   intake$territory <- "ESP"
   gridded <- .nbi_gridded()
@@ -519,7 +524,10 @@ testthat::test_that("manure territory resolves an iso3c code, not just a stringi
   data$livestock_intake <- intake
   data$gridded <- gridded
 
-  out <- whep::build_n_inputs(data = data)
+  testthat::expect_warning(
+    out <- whep::build_n_inputs(data = data),
+    "deprecated"
+  )
   manure <- out[
     out$fert_type %in% c("manure_solid", "manure_liquid", "excreta"),
   ]
@@ -811,24 +819,132 @@ testthat::test_that("a duplicate-ISO3 territory no longer shifts later ones", {
   # ETH and SDN each carry a second historical row. The join grew the result and
   # shifted every LATER territory onto the wrong country -- c("ESP","ETH","DEU")
   # returned 203, 238, 62, silently turning Germany into Ethiopia PDR.
+  #
+  # The ISO3 form is now a deprecated bridge that warns, and these assertions
+  # are about the resolved codes rather than the warning, so silence it here;
+  # the warning itself is asserted in the test below.
+  territory_codes <- function(x) {
+    suppressWarnings(whep:::.manure_territory_to_area_code(x))
+  }
   testthat::expect_equal(
-    whep:::.manure_territory_to_area_code(c("ESP", "ETH", "DEU")),
+    territory_codes(c("ESP", "ETH", "DEU")),
     c(203L, 238L, 79L)
   )
-  testthat::expect_equal(
-    whep:::.manure_territory_to_area_code(c("SDN", "DEU")),
-    c(206L, 79L)
-  )
+  testthat::expect_equal(territory_codes(c("SDN", "DEU")), c(206L, 79L))
   # Stringified area codes still pass straight through, mixed with ISO3.
+  testthat::expect_equal(territory_codes(c("203", "ETH")), c(203L, 238L))
+})
+
+testthat::test_that("the ISO3 territory bridge warns and area codes do not", {
+  # #463: territory carried two undocumented vocabularies. The pipeline emits
+  # only stringified area codes (feed_intake_redistribute.R:805), while the
+  # manure chain's own @examples used ISO3 literals, and the two disagree about
+  # what the resolved code means: an ISO3 resolves through polity_area_code, a
+  # FABIO aggregation bucket, which for 62 of the 257 ISO3 codes in
+  # whep::regions_full is not that territory's own code (measured). 61 land on
+  # 999, Rest of World; "SSD" lands on 206, Sudan (former), where the numeric
+  # form "277" keeps South Sudan. So the bridge must be audible.
+  testthat::expect_warning(
+    testthat::expect_equal(
+      whep:::.manure_territory_to_area_code(c("ESP", "203")),
+      c(203L, 203L)
+    ),
+    "deprecated"
+  )
+  # The warning names the offending value, so a caller can find the fixture.
+  testthat::expect_warning(
+    whep:::.manure_territory_to_area_code("SSD"),
+    "SSD"
+  )
+  # The measured collapse itself: the two vocabularies for South Sudan resolve
+  # to different area codes, hence different polities downstream (206 is
+  # SDN-2011-2025, 277 is SSD-2011-2025).
   testthat::expect_equal(
-    whep:::.manure_territory_to_area_code(c("203", "ETH")),
-    c(203L, 238L)
+    suppressWarnings(whep:::.manure_territory_to_area_code("SSD")),
+    206L
+  )
+  testthat::expect_equal(whep:::.manure_territory_to_area_code("277"), 277L)
+  # The pipeline's own vocabulary stays silent: no warning for anyone who
+  # follows the (now area-code) documented examples.
+  testthat::expect_silent(
+    whep:::.manure_territory_to_area_code(c("203", "79", NA))
   )
 })
 
 testthat::test_that("an unresolvable territory still aborts", {
   testthat::expect_error(
-    whep:::.manure_territory_to_area_code(c("ESP", "NOTACODE")),
+    whep:::.manure_territory_to_area_code(c("203", "NOTACODE")),
     "NOTACODE"
+  )
+})
+
+testthat::test_that("the manure chain's examples use the pipeline vocabulary", {
+  # #463: every @examples block in the manure chain identified a territory with
+  # an ISO literal -- "ESP" in the allocation, transport and driver examples,
+  # "ES" in the excretion and management ones -- while the pipeline itself
+  # passes as.character(area_code). "ES" is not resolvable at all: pasting the
+  # documented split_manure_management() fixture into build_n_inputs() aborted
+  # with "Could not resolve territory to an area_code", and "ESP" resolved only
+  # through the lossy iso3c bridge. The defect lives in the documentation, so
+  # this scans the roxygen @examples blocks themselves; asserting on one
+  # function's output would let the next ISO literal back in.
+  #
+  # R/ holds compiled objects rather than sources in an installed package, so
+  # the scan skips wherever the five files are not readable and is load-bearing
+  # under devtools::test() and in a source checkout.
+  files <- c(
+    "excretion.R",
+    "manure_management.R",
+    "manure_allocation.R",
+    "manure_transport.R",
+    "build_livestock_nutrient_flows.R"
+  )
+  roots <- c(testthat::test_path("..", "..", "R"), "../../00_pkg_src/whep/R")
+  found <- lapply(roots, function(r) file.path(r, files))
+  found <- Filter(function(p) all(file.exists(p)), found)
+  testthat::skip_if(
+    length(found) == 0L,
+    "the manure chain's R sources are not available next to the tests"
+  )
+  paths <- found[[1]]
+
+  # Every #' line below an @examples tag, up to the end of that roxygen block.
+  example_lines <- function(path) {
+    lines <- readLines(path, warn = FALSE)
+    rox <- grepl("^#'", lines)
+    starts <- which(rox & grepl("@examples", lines))
+    unlist(lapply(starts, function(i) {
+      j <- i + 1L
+      while (j <= length(lines) && rox[[j]]) {
+        j <- j + 1L
+      }
+      if (j > i + 1L) lines[seq(i + 1L, j - 1L)] else character()
+    }))
+  }
+  lits <- unlist(lapply(paths, function(p) {
+    ex <- example_lines(p)
+    gsub('"', "", unlist(regmatches(ex, gregexpr('"[^"]*"', ex))))
+  }))
+  testthat::expect_gt(length(lits), 0L)
+
+  iso_like <- unique(lits[grepl("^[A-Za-z]{2,3}$", lits)])
+  testthat::expect_equal(
+    iso_like,
+    character(),
+    info = paste0(
+      "ISO-shaped literals in the manure chain's examples: ",
+      paste(iso_like, collapse = ", ")
+    )
+  )
+  # In these blocks the quoted all-digit literals ARE the territory values:
+  # years and item codes are unquoted integers and cell ids carry a "_". Each
+  # must resolve through the chain's terminal step, and resolve silently, since
+  # a warning here would mean the examples still teach the bridge.
+  codes <- unique(lits[grepl("^[0-9]+$", lits)])
+  testthat::expect_gt(length(codes), 0L)
+  testthat::expect_silent(whep:::.manure_territory_to_area_code(codes))
+  testthat::expect_equal(
+    whep:::.manure_territory_to_area_code(codes),
+    as.integer(codes)
   )
 })

--- a/tests/testthat/test_n_urban.R
+++ b/tests/testthat/test_n_urban.R
@@ -1,8 +1,12 @@
+# These fixtures carry numeric area codes (203 Spain, 68 France) where they
+# used to carry ISO3 literals. build_urban_n() routes them through
+# .manure_territory_to_area_code(), whose ISO3 form is a deprecated bridge
+# (#463); the resolved codes, and so every assertion below, are unchanged.
 .example_cell_polity_urban <- function() {
   tibble::tribble(
     ~lon, ~lat, ~area_code,
-    -0.25, -0.25, "ESP",
-    0.25, -0.25, "ESP"
+    -0.25, -0.25, 203L,
+    0.25, -0.25, 203L
   )
 }
 
@@ -13,7 +17,7 @@ testthat::test_that("build_urban_n converts population to a nitrogen load", {
   )
   cropland_ha <- tibble::tribble(
     ~lon, ~lat, ~area_code, ~year, ~cropland_ha,
-    -0.25, -0.25, "ESP", 2000L, 1000
+    -0.25, -0.25, 203L, 2000L, 1000
   )
   out <- whep::build_urban_n(
     data = list(
@@ -56,8 +60,8 @@ testthat::test_that("build_urban_n spills surplus to a neighbouring cell with cr
   )
   cropland_ha <- tibble::tribble(
     ~lon, ~lat, ~area_code, ~year, ~cropland_ha,
-    -0.25, -0.25, "ESP", 2000L, 0,
-    0.25, -0.25, "ESP", 2000L, 1000
+    -0.25, -0.25, 203L, 2000L, 0,
+    0.25, -0.25, 203L, 2000L, 1000
   )
   out <- whep::build_urban_n(
     data = list(
@@ -88,13 +92,13 @@ testthat::test_that("build_urban_n splits a border cell by polity_frac", {
   )
   cell_polity <- tibble::tribble(
     ~lon, ~lat, ~area_code, ~polity_frac,
-    -0.25, -0.25, "ESP", 0.7,
-    -0.25, -0.25, "FRA", 0.3
+    -0.25, -0.25, 203L, 0.7,
+    -0.25, -0.25, 68L, 0.3
   )
   cropland_ha <- tibble::tribble(
     ~lon, ~lat, ~area_code, ~year, ~cropland_ha,
-    -0.25, -0.25, "ESP", 2000L, 1000,
-    -0.25, -0.25, "FRA", 2000L, 1000
+    -0.25, -0.25, 203L, 2000L, 1000,
+    -0.25, -0.25, 68L, 2000L, 1000
   )
   out <- whep::build_urban_n(
     data = list(
@@ -124,8 +128,8 @@ testthat::test_that("build_urban_n filters preloaded inputs by years", {
   )
   cropland_ha <- tibble::tribble(
     ~lon, ~lat, ~area_code, ~year, ~cropland_ha,
-    -0.25, -0.25, "ESP", 2000L, 1000,
-    -0.25, -0.25, "ESP", 2001L, 1000
+    -0.25, -0.25, 203L, 2000L, 1000,
+    -0.25, -0.25, 203L, 2001L, 1000
   )
 
   out <- whep::build_urban_n(
@@ -151,7 +155,7 @@ testthat::test_that("build_urban_n interpolates the per-capita rate between benc
   )
   cropland_ha <- tibble::tribble(
     ~lon, ~lat, ~area_code, ~year, ~cropland_ha,
-    -0.25, -0.25, "ESP", 2004L, 1000
+    -0.25, -0.25, 203L, 2004L, 1000
   )
   out <- whep::build_urban_n(
     data = list(
@@ -174,7 +178,7 @@ testthat::test_that("build_urban_n holds the rate constant outside the benchmark
   )
   cropland_ha <- tibble::tribble(
     ~lon, ~lat, ~area_code, ~year, ~cropland_ha,
-    -0.25, -0.25, "ESP", 1800L, 1000
+    -0.25, -0.25, 203L, 1800L, 1000
   )
   out <- whep::build_urban_n(
     data = list(

--- a/tests/testthat/test_soil_carbon_inputs.R
+++ b/tests/testthat/test_soil_carbon_inputs.R
@@ -236,7 +236,12 @@ test_that("manure territory as an iso3c resolves instead of dropping to NA", {
     crop_patterns = crop_patterns,
     residue_humification = whep::residue_humification
   )
-  out <- whep::build_soil_carbon_inputs(resolution = "polity", data = data)
+  # The iso3c form is a deprecated bridge (#463), so resolving it warns; this
+  # test is about it still resolving rather than dropping to NA.
+  testthat::expect_warning(
+    out <- whep::build_soil_carbon_inputs(resolution = "polity", data = data),
+    "deprecated"
+  )
   # 20 t manure C over 40 ha = 0.5, not 0 (which a silent as.integer NA drop
   # would give).
   testthat::expect_equal(out$manure_c_mgc_ha_yr, 20 / 40)


### PR DESCRIPTION
## What was wrong

The manure/nutrient chain keys territory on an opaque `territory` string, and that string
carried **two vocabularies**. The pipeline only ever produces one of them -- a stringified
`area_code` (`R/feed_intake_redistribute.R:805`, `R/n_urban.R:137`) -- while every `@examples`
block in the chain taught the other: `"ESP"` in `allocate_manure_to_land()`,
`allocate_manure_transport()` and `build_livestock_nutrient_flows()`, and `"ES"` (not even an
ISO3) in `estimate_n_excretion()` and `split_manure_management()`.

## Evidence it reproduced BEFORE the change

Documented fixture, run through the chain into its terminal step
(`.manure_to_n_inputs()`), on `origin/main`:

```
territory "ES":  ABORT: Could not resolve territory to an area_code.
territory "ESP": area_code = 203      # resolved only via the iso3c bridge
territory "203": area_code = 203      # the pipeline's own vocabulary
```

So the fixture printed in `?estimate_n_excretion` and `?split_manure_management` cannot reach
`build_n_inputs()` at all, and the `"ESP"` form resolves through a lossy path:
`.iso3c_to_area_code()` answers with `polity_area_code`, a FABIO aggregation bucket, not an
identity. Measured against the shipped `whep::regions_full`:

| | |
|---|---|
| iso3c the bridge knows | 257 |
| whose answer is **not** that territory's own code | **62** |
| of those, landing on 999 Rest of World | 61 (`AND`, `LIE`, `GRL`, `REU`, ...) |
| the remaining one | `SSD` -> 206, Sudan (former) |

`"SSD"` -> 206 resolves to `SDN-2011-2025` (Sudan) downstream, where the numeric form `"277"`
keeps `SSD-2011-2025` (South Sudan). Nothing tells the caller which of the two answers it got.

**The fan-out half of the issue does not reproduce.** `1d317d81` (already on main) routes the
lookup through `.iso3c_to_area_code()`, and the issue's own measured call now returns

```r
whep:::.manure_territory_to_area_code(c("ETH", "SDN", "ESP", "123"))
#> [1] 238 206 203 123      # 4 values for 4 inputs, no warning
```

All three acceptance criteria therefore already hold on main: length is preserved, the ETH/SDN
case is locked (`test_polities.R`, `test_n_balance_inputs.R`), and the output is
`polity_area_code` rather than the raw code. What was left of #463 is the vocabulary.

## What I changed

- `@examples` in `estimate_n_excretion()`, `split_manure_management()`,
  `apply_management_losses()`, `allocate_manure_to_land()`, `allocate_manure_transport()` and
  `build_livestock_nutrient_flows()` now use `"203"`, Spain's area code. The roxygen states the
  vocabulary; `build_soil_carbon_inputs()`, the one place that documented `iso3c` as an accepted
  form, now says it is deprecated.
- `.manure_territory_to_area_code()` still resolves an `iso3c`, as a bridge for fixtures written
  before this, but **warns** and names the value it bridged. The comment records why (the 62/257
  measurement above).
- `tests/testthat/test_n_urban.R` fixtures move from `area_code = "ESP"/"FRA"` to `203L`/`68L`,
  the codes they already resolved to -- an ISO3 in an `area_code` column is the same defect.

### Deviation from the issue title, deliberately

The title asks to *drop* the ISO3 branch. I deprecated it instead: acceptance criterion 1 ("for
any input, **including ambiguous ISO3**") and the regression test landed two commits ago in
`1d317d81` both require ISO3 to keep resolving, and `build_soil_carbon_inputs()` documented it as
supported. Flipping the warning to an abort is a one-line follow-up once you decide.
`territory` still carries no polity metadata -- moving it to a polity code string, and the
`year`-threading the spec flags as a decision, are untouched here (and the `year` question is
moot for the bridge as written: `polity_area_code` is unique per iso3c by construction).

## How I verified

- All six changed examples run (extracted from the regenerated `.Rd` files); none warns.
- New tests fail **6 assertions** with the `R/` changes stashed and pass with them:
  the bridge-warns test, the examples census scan, and the two call sites that now expect the
  warning.
- `testthat::test_file("tests/testthat/test_n_balance_inputs.R")`: 85 pass, 0 fail, 0 warn, 0 skip.
  `test_n_urban.R`: 16 pass, 0 warn (6 warnings before the fixture swap).
  `test_excretion.R`, `test_manure_management.R`, `test_manure_allocation.R`,
  `test_manure_transport.R`, `test_build_livestock_nutrient_flows.R`, `test_livestock_manure.R`,
  `test_polities.R`: all clean. `test_soil_carbon_inputs.R` and
  `test_grass_natural_carbon_inputs.R` each keep a test whose point is that an iso3c territory
  resolves rather than dropping to NA; those now assert the warning too (run by `desc`, 2 and 2
  passing, 0 warnings -- the rest of those two files reads remote data, so I did not run them
  whole).
- `air format` on every changed file; `lintr::lint_package()` with the CI linter config: **no
  lints**. `devtools::document()` run, `man/` committed. No non-ASCII in R code.
- **Value-neutral on the example paths, measured**: per-column sums of
  `build_n_inputs(example = TRUE)`, `build_urban_n(example = TRUE)` and
  `build_grass_natural_carbon_inputs(example = TRUE)` are identical to `origin/main` (diff is
  empty). The warning sits inside a branch the pipeline never takes -- it needs a non-numeric
  `territory`, which only a hand-built fixture produces. I did **not** run a full-range build, so
  this is an example-path measurement, not a whole-pipeline one.

The census test scans the roxygen `@examples` of the five chain files, so the next ISO literal
cannot slip back in; it skips where the R sources are not readable next to the tests (an
installed-package check), as `test_cow_to_lpjml_area_identity.R` does for its external header.

Closes #463. Part of the polity migration epic #458.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JAxP2LSXPx67DDTWKERXiQ
