### PR TITLE
docs: fix Salvagiotti citation spelling

### DIFF
--- a/inst/extdata/coefs/bnf.csv
+++ b/inst/extdata/coefs/bnf.csv
@@ -9,7 +9,7 @@ Lentils,0.66,0.75,1.3,,1,"Anglade et al., 2015"
 Other pulses,0.68,0.75,1.3,,1,"Lassaletta et al., 2014, based on Anglade et al., 2015"
 Pea,0.71,0.75,1.3,,1,"Anglade et al., 2015"
 Rice,,,,33,0,"Lassaletta et al., 2014, based on Herridge et al., 2008"
-Soyabeans,0.57,0.73,1.4,,1,"Lassaletta et al., 2014, based on Salvagliotti et al., 2008"
+Soyabeans,0.57,0.73,1.4,,1,"Lassaletta et al., 2014, based on Salvagiotti et al., 2008"
 Sugarcane,,,,25,0,"Lassaletta et al., 2014, based on Herridge et al., 2008"
 "Fodder, other",0.68,0.5,1.3,,0.5,Based on share of green leguminous
 Mixed swards,0.68,0.45,1.4,,0.25,Luscher et al. 2014; Suter et al. 2015; Nyfeler et al. 2011


### PR DESCRIPTION
## Summary
- correct the soybean BNF source spelling from `Salvagliotti` to `Salvagiotti` in `inst/extdata/coefs/bnf.csv`
- align the CSV source text with the existing test ledger spelling

Closes #498.

## Validation
- Verified DOI `10.1016/j.fcr.2008.03.001` via Crossref metadata: first author family name is `Salvagiotti`
- Parsed `inst/extdata/coefs/bnf.csv` with Python `csv.DictReader` and asserted the `Soyabeans` source contains `Salvagiotti et al., 2008` and no `Salvagliotti`
- `rg -n "Salvagliotti|Salvagiotti" inst/extdata/coefs/bnf.csv tests/testthat/test_bnf_coef_sources.R`
- `git diff --check`

I could not run the R package checks locally because this container does not have `Rscript` installed. This PR is a one-line CSV citation spelling fix and should be covered by the repository CI.