### PR TITLE
fix(n_prov_destiny): drop empty-alias default and stale roxygen

### DIFF
--- a/R/n_prov_destiny.R
+++ b/R/n_prov_destiny.R
@@ -1176,7 +1176,7 @@ create_n_nat_destiny <- function(example = FALSE) {
 #' @keywords internal
 #' @noRd
 .convert_to_items_n <- function(
-  grafs_prod_item_combined = whep_read_file(""),
+  grafs_prod_item_combined,
   codes_coefs_items_full = whep_read_file("codes_coefs_items_full"),
   biomass_coefs = whep_read_file("biomass_coefs")
 ) {
@@ -1240,13 +1240,9 @@ create_n_nat_destiny <- function(example = FALSE) {
 
 #' @title Consumption and Trade
 #' @description Calculation of consumption by destiny and trade
-#' (export, import). National scaling can be activated, for analysis for whole
-#' Spain. It should be deactivated for provincial analysis
+#' (export, import).
 #'
 #' @param grafs_prod_item_n A dataframe with N values (MgN) by destiny.
-#' @param pie_full_destinies_fm A data frame with destiny data.
-#' @param biomass_coefs A data frame with biomass coefficients.
-#' @param codes_coefs_items_full A lookup table with coefficients.
 #'
 #' @return A dataframe with consumption, exports, and imports in MgN.
 #' @keywords internal


### PR DESCRIPTION
Fixes #525

Two small leftovers from the refactor in `6e98f4fd` (#521), both verified against current main on 2026-08-04.

## 1. Placeholder default `whep_read_file("")`

`.convert_to_items_n()` defaulted `grafs_prod_item_combined` to `whep_read_file("")`, which always aborts with "There is no file entry". Harmless in practice because the sole caller pipes the argument in, but any direct caller or reader gets a default that looks meaningful and is not. The default is dropped; the argument is now required.

## 2. Stale roxygen on `.calculate_trade()`

The roxygen block documented three parameters (`pie_full_destinies_fm`, `biomass_coefs`, `codes_coefs_items_full`) that the function does not take, and the `@description` promised a national-scaling toggle that does not exist. Both corrected.

## Verification

- `Rscript -e 'parse(file="R/n_prov_destiny.R")'` — syntax OK.
- Signature-vs-roxygen consistency verified: `.calculate_trade` documents only its real argument; `.convert_to_items_n` has no empty-alias default.
- No output change; no other file touched.