### PR TITLE
fix(check): clear both R CMD check NOTEs and run the script-sourced tests under check

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -40,7 +40,6 @@ Imports:
     vctrs,
     withr,
     yaml,
-    readxl,
     stringi,
     zoo
 Encoding: UTF-8
@@ -59,6 +58,7 @@ Suggests:
     ncdf4,
     patchwork,
     pointblank,
+    readxl,
     rmarkdown,
     RSQLite,
     sf,

--- a/R/utils.R
+++ b/R/utils.R
@@ -1350,7 +1350,14 @@ utils::globalVariables(
     "residue_c_mg",
     "root_c_mg",
     "manure_c_mg",
+    "weed_c_mg",
     "total_c_mg",
+    # .sci_sum_components() pre-masks c_mass_mg by input_type into these four
+    # dot-prefixed data.table columns, then sums them per cell.
+    ".residue",
+    ".root",
+    ".weed",
+    ".manure",
     "residue_c_mgc_ha_yr",
     "root_c_mgc_ha_yr",
     "manure_c_mgc_ha_yr",

--- a/tests/testthat/helper_prepare_spatialize.R
+++ b/tests/testthat/helper_prepare_spatialize.R
@@ -1,0 +1,46 @@
+# The helpers exercised by test_prepare_nitrogen.R and
+# test_prepare_spatialize_irrigation.R live at script scope in
+# inst/scripts/prepare_spatialize_all.R rather than in R/, so those tests have
+# to source the script before they can see them.
+#
+# The script's path depends on the layout. A source checkout keeps
+# `inst/scripts/`; an installed package flattens `inst/` onto the package root,
+# so `inst/scripts/` does not exist under `R CMD check`, on CRAN or on
+# r-universe. Both test files used to resolve the source-checkout path only,
+# which meant that under `R CMD check` `file.exists()` was FALSE, nothing was
+# sourced, and all 11 tests fell through their `exists(<helper>)` guards as
+# skips -- reported as passes, never actually run on any check platform.
+# `system.file()` resolves both layouts (pkgload shims it for a source
+# checkout), so the tests now run everywhere.
+#
+# Sourcing is wrapped rather than left to abort because the script attaches
+# ncdf4 at top level and ncdf4 is Suggests-only: where it is missing the script
+# genuinely cannot load, and the callers' `exists()` guards should skip instead
+# of erroring the whole file. That is why those guards stay.
+.source_prepare_spatialize <- function() {
+  path <- system.file(
+    "scripts",
+    "prepare_spatialize_all.R",
+    package = "whep"
+  )
+  if (!nzchar(path)) {
+    path <- testthat::test_path(
+      "..",
+      "..",
+      "inst",
+      "scripts",
+      "prepare_spatialize_all.R"
+    )
+  }
+  if (!file.exists(path)) {
+    return(invisible(FALSE))
+  }
+  ok <- tryCatch(
+    {
+      sys.source(path, envir = topenv())
+      TRUE
+    },
+    error = function(e) FALSE
+  )
+  invisible(ok)
+}

--- a/tests/testthat/test_prepare_nitrogen.R
+++ b/tests/testthat/test_prepare_nitrogen.R
@@ -5,18 +5,7 @@
 # (`.faostat_synth_country_total`, `.faostat_manure_country_long`) need
 # whep_read_file() over the network and are not covered here.
 
-local({
-  pkg_root <- testthat::test_path("..", "..")
-  script_path <- file.path(
-    pkg_root,
-    "inst",
-    "scripts",
-    "prepare_spatialize_all.R"
-  )
-  if (file.exists(script_path)) {
-    sys.source(script_path, envir = topenv())
-  }
-})
+.source_prepare_spatialize()
 
 
 test_that(".smil_global_yearly interpolates linearly between anchors", {

--- a/tests/testthat/test_prepare_spatialize_irrigation.R
+++ b/tests/testthat/test_prepare_spatialize_irrigation.R
@@ -2,18 +2,7 @@
 # inst/scripts/prepare_spatialize_all.R. The helper lives at script scope
 # (not package R/) so we source the script once and exercise it offline.
 
-local({
-  pkg_root <- testthat::test_path("..", "..")
-  script_path <- file.path(
-    pkg_root,
-    "inst",
-    "scripts",
-    "prepare_spatialize_all.R"
-  )
-  if (file.exists(script_path)) {
-    sys.source(script_path, envir = topenv())
-  }
-})
+.source_prepare_spatialize()
 
 
 test_that(".cap_national_irrigation caps summed irrigation at the total", {


### PR DESCRIPTION
Three leftovers found while triaging why r-universe's check had been ERRORing
since 2026-07-27 (that root cause was fixed in #521; these are separate). None
of them changes package output.

## 1. `readxl` in Imports but unused from `R/`

`R CMD check`: *Namespace in Imports field not imported from: 'readxl'.*

It is a real dependency — `inst/scripts/prepare_upload.R` calls
`readxl::read_excel()` and `data-raw/cropgrids_land.R` attaches it — just not
one used from `R/`. Moved to `Suggests` rather than deleted.

## 2. Five undeclared NSE symbols in `.sci_sum_components()`

`R CMD check`: *no visible binding for global variable* `.residue`, `.root`,
`.weed`, `.manure`, `weed_c_mg`.

The first four are the dot-prefixed data.table columns the function builds with
`:=` to pre-mask `c_mass_mg` by `input_type`. `weed_c_mg` was simply missed —
`residue_c_mg`, `root_c_mg` and `manure_c_mg` were already declared beside it.
All five added to `utils::globalVariables()` per CLAUDE.md.

## 3. Twelve tests never ran under `R CMD check`

`test_prepare_nitrogen.R` and `test_prepare_spatialize_irrigation.R` exercise
helpers that live at script scope in `inst/scripts/prepare_spatialize_all.R`
rather than in `R/`, so they source that script first. Both resolved **only**
the source-checkout path:

```r
pkg_root <- testthat::test_path("..", "..")
script_path <- file.path(pkg_root, "inst", "scripts", "prepare_spatialize_all.R")
if (file.exists(script_path)) sys.source(script_path, envir = topenv())
```

An installed package flattens `inst/` onto the package root, so `inst/scripts/`
does not exist under `R CMD check`, on CRAN, or on r-universe. `file.exists()`
returned `FALSE`, the `if` did nothing **in silence**, and all 12 tests fell
through their `skip_if_not(exists(<helper>))` guards — reported as skips,
counted as passes, never actually run on any check platform. r-universe's own
skip summary shows them as `exists(".smil_global_yearly", mode = "function") is
not TRUE` and friends.

Verified directly against an installed build:

```
system.file("scripts", "prepare_spatialize_all.R", package = "whep")
  -> <lib>/whep/scripts/prepare_spatialize_all.R    ✓
file.exists(<pkg>/inst/scripts/prepare_spatialize_all.R)
  -> FALSE                                          ✗
```

The duplicated block collapses into one helper
(`tests/testthat/helper_prepare_spatialize.R`) that resolves the script with
`system.file()`, which works in both layouts (pkgload shims it for a source
checkout).

Sourcing is wrapped in `tryCatch` because the script attaches `ncdf4` at top
level and `ncdf4` is `Suggests`-only: where it is genuinely absent these tests
*should* skip rather than error the whole file. That is why the `exists()`
guards are kept as the safety net rather than removed.

## Verification

- **`R CMD check` with tests** (`_R_CHECK_FORCE_SUGGESTS_=false`, matching
  r-universe): `Status: OK` — 0 errors, 0 warnings, **0 notes**. Both NOTEs gone.
- **Installed package**, real `system.file()` with no pkgload shim — the exact
  check condition: the two files run **12 tests, 0 skipped, 31 expectations**.
- **Full suite offline** (`CI=false`, dead proxy, empty pin cache):
  `FAIL 0 | WARN 7 | SKIP 13 | PASS 5402`.
- `air format .` no changes; `lintr` clean; `devtools::document()` no `man/` diff.

## Note for reviewers

Your CI would not have caught either NOTE: `r-lib/actions/check-r-package@v2`
defaults to `error-on: "warning"`, so NOTEs pass silently even though CLAUDE.md
requires none. Worth considering `error-on: "note"` separately — not changed here.
