### PR TITLE
fix(data-io): resolve FAOSTAT ISO3 codes without relying on a lazy-load side channel

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -151,6 +151,16 @@
   inflated coverage; `quality_variants = TRUE` collapses a source's several
   `quality_col` variants of a cell to its best-ranked one instead of aborting.
   Both default to the previous behaviour (#139).
+* `get_faostat_data()` no longer attaches and then unloads `FAOSTAT` to make
+  `FAOSTAT::fillCountryCode()` see its lazily loaded `FAOcountryProfile`. The
+  ISO3 lookup now loads that dataset explicitly and matches area names itself,
+  reproducing `fillCountryCode()`'s rule (exact match against the six profile
+  name columns, unresolved when several profile rows match). Verified identical
+  on all 232 FAOSTAT area names in `regions_full` and upstream's
+  `faostat_area_polity_map`: 215 resolve, 0 differences. Two side effects are
+  gone -- the user's `FAOSTAT` session state is left alone, and rows keep their
+  input order instead of being sorted by area name by an internal `merge()`
+  (#520).
 
 # whep 0.3.0
 

--- a/R/scrape_faostat.R
+++ b/R/scrape_faostat.R
@@ -26,11 +26,6 @@ get_faostat_data <- function(activity_data, ..., example = FALSE) {
   if (example) {
     return(.example_get_faostat_data())
   }
-  # Some functions from FAOSTAT pkg don't work by only using prefixed functions.
-  # It is detached again at the end of this function call.
-  # Also this is another way to write require("FAOSTAT") without triggering
-  # R CMD check warning
-  do.call(require, list("FAOSTAT"))
 
   faostat_converters <- .faostat_converter(activity_data)
 
@@ -65,9 +60,6 @@ get_faostat_data <- function(activity_data, ..., example = FALSE) {
     }
   }
 
-  # Properly detach FAOSTAT to avoid issues
-  detach("package:FAOSTAT", unload = TRUE)
-
   faostat_data |>
     tibble::as_tibble()
 }
@@ -82,11 +74,7 @@ get_faostat_data <- function(activity_data, ..., example = FALSE) {
 #' @returns data.frame
 .populate_iso3_code <- function(df) {
   # create new column "ISO3_CODE" and fill it
-  df <- FAOSTAT::fillCountryCode(
-    country = "area",
-    data = df,
-    outCode = "ISO3_CODE"
-  )
+  df[["ISO3_CODE"]] <- .match_fao_area_to_iso3(df[["area"]])
 
   # manually fix some crazy countries/ISO3_CODE
   df[df$area == "China, mainland", "ISO3_CODE"] <- "CHN"
@@ -96,6 +84,8 @@ get_faostat_data <- function(activity_data, ..., example = FALSE) {
   df[df$area == "South Sudan", "ISO3_CODE"] <- "SSD"
   df[df$area == "Czechia", "ISO3_CODE"] <- "CZE"
   df[df$area == "Lao People's Democratic Republic", "ISO3_CODE"] <- "LAO"
+
+  .warn_unmatched_fao_areas(unique(df$area[is.na(df$ISO3_CODE)]))
 
   df
 }
@@ -139,6 +129,98 @@ get_faostat_data <- function(activity_data, ..., example = FALSE) {
     FAOSTAT_code = fao_cat_converter[[activity_data]],
     FAOSTAT_param = fao_param_converter[[activity_data]]
   )
+}
+
+.match_fao_area_to_iso3 <- function(areas) {
+  lookup <- .fao_area_iso3_lookup()
+
+  lookup[["iso3_code"]][match(areas, lookup[["fao_area_name"]])]
+}
+
+.warn_unmatched_fao_areas <- function(unmatched) {
+  if (length(unmatched) == 0) {
+    return(invisible())
+  }
+
+  shown <- utils::head(unmatched, 5)
+  cli::cli_warn(c(
+    "Could not match {length(unmatched)} FAOSTAT area name{?s} to an
+     {.field ISO3_CODE}.",
+    i = "First unmatched: {.val {shown}}.",
+    i = "Regional aggregates and multi-territory areas have no ISO3 code."
+  ))
+}
+
+# Builds the FAOSTAT area name -> ISO3 code lookup. Reproduces the matching
+# rule of FAOSTAT::fillCountryCode(): an area name is compared for exact
+# equality against the six name columns of `FAOcountryProfile`, and only
+# resolves when all its matches fall in a single profile row. Names matching
+# several rows (e.g. the "China" aggregate) stay unmatched.
+.fao_area_iso3_lookup <- function() {
+  name_cols <- .fao_profile_name_cols()
+
+  .fao_country_profile(c("ISO3_CODE", name_cols)) |>
+    dplyr::mutate(
+      profile_row = dplyr::row_number(),
+      iso3_code = as.character(ISO3_CODE)
+    ) |>
+    tidyr::pivot_longer(
+      cols = dplyr::all_of(name_cols),
+      values_to = "fao_area_name",
+      values_transform = as.character
+    ) |>
+    dplyr::filter(!is.na(fao_area_name)) |>
+    dplyr::distinct(fao_area_name, profile_row, iso3_code) |>
+    dplyr::summarise(
+      iso3_code = dplyr::if_else(
+        dplyr::n() == 1L,
+        iso3_code[1],
+        NA_character_
+      ),
+      .by = fao_area_name
+    )
+}
+
+.fao_profile_name_cols <- function() {
+  c(
+    "OFFICIAL_FAO_NAME",
+    "SHORT_NAME",
+    "FAO_TABLE_NAME",
+    "UNOFFICIAL1_NAME",
+    "UNOFFICIAL2_NAME",
+    "UNOFFICIAL3_NAME"
+  )
+}
+
+# FAOSTAT::fillCountryCode() reads `FAOcountryProfile` as a free variable and
+# so only works while the package is attached; prefixed calls fail with
+# "object 'FAOcountryProfile' not found" (#520). Load the dataset explicitly
+# instead, which does not depend on that lazy-load behaviour.
+.fao_country_profile <- function(required_cols) {
+  profile_env <- new.env(parent = emptyenv())
+  utils::data("FAOcountryProfile", package = "FAOSTAT", envir = profile_env)
+
+  if (!rlang::env_has(profile_env, "FAOcountryProfile")) {
+    faostat_version <- as.character(utils::packageVersion("FAOSTAT"))
+    cli::cli_abort(
+      "Dataset {.val FAOcountryProfile} is not available in
+       {.pkg FAOSTAT} {faostat_version}."
+    )
+  }
+
+  profile <- rlang::env_get(profile_env, "FAOcountryProfile") |>
+    tibble::as_tibble()
+
+  missing_cols <- setdiff(required_cols, names(profile))
+  if (length(missing_cols) > 0) {
+    cli::cli_abort(
+      "Column{?s} {.field {missing_cols}} missing from
+       {.val FAOcountryProfile}."
+    )
+  }
+
+  profile |>
+    dplyr::select(dplyr::all_of(required_cols))
 }
 
 .activity_data_choices <- function() {

--- a/R/utils.R
+++ b/R/utils.R
@@ -1769,7 +1769,12 @@ utils::globalVariables(
     "sjos_class",
     # n_exceedance_extension.R (SJOS-N Module 4, Task 4.2) — footprint extension
     # category provenance stamp
-    "method_n_exceedance"
+    "method_n_exceedance",
+    # scrape_faostat.R — FAOSTAT country profile name/ISO3 lookup NSE columns
+    "ISO3_CODE",
+    "fao_area_name",
+    "iso3_code",
+    "profile_row"
   )
 )
 

--- a/tests/testthat/helper_scrape_faostat.R
+++ b/tests/testthat/helper_scrape_faostat.R
@@ -1,0 +1,14 @@
+# Helpers for FAOSTAT scraping tests -------------------------------------------
+
+#' Skip when package:FAOSTAT is attached.
+#'
+#' The ISO3 tests assert that `.populate_iso3_code()` works with prefixed
+#' access only (#520). An attached FAOSTAT would put its lazily loaded
+#' `FAOcountryProfile` on the search path and hide the very failure the tests
+#' guard against, so probe the search path instead of the CI environment.
+skip_if_faostat_attached <- function() {
+  if ("package:FAOSTAT" %in% search()) {
+    testthat::skip("package:FAOSTAT is attached; unattached path not testable")
+  }
+  invisible()
+}

--- a/tests/testthat/test_scrape_faostat.R
+++ b/tests/testthat/test_scrape_faostat.R
@@ -36,6 +36,104 @@ testthat::test_that(".activity_data_choices returns expected values", {
   testthat::expect_true("crop_production" %in% choices)
 })
 
+testthat::test_that(".fao_country_profile reads the dataset when unattached", {
+  testthat::skip_if_not_installed("FAOSTAT")
+  skip_if_faostat_attached()
+
+  profile <- whep:::.fao_country_profile(c("ISO3_CODE", "SHORT_NAME"))
+
+  testthat::expect_s3_class(profile, "tbl_df")
+  testthat::expect_named(profile, c("ISO3_CODE", "SHORT_NAME"))
+  testthat::expect_gt(nrow(profile), 200)
+  testthat::expect_true("PRT" %in% profile$ISO3_CODE)
+})
+
+testthat::test_that(".fao_country_profile aborts on a missing column", {
+  testthat::skip_if_not_installed("FAOSTAT")
+
+  testthat::expect_error(
+    whep:::.fao_country_profile("NOT_A_PROFILE_COLUMN"),
+    "NOT_A_PROFILE_COLUMN"
+  )
+})
+
+# Regression test for #520: `.populate_iso3_code()` used to delegate to
+# FAOSTAT::fillCountryCode(), which reads `FAOcountryProfile` as a free
+# variable and therefore only worked while package:FAOSTAT was attached. Every
+# assertion below fails with "object 'FAOcountryProfile' not found" before the
+# fix. No network is needed; the country profile ships inside FAOSTAT.
+testthat::test_that(".populate_iso3_code resolves ISO3 codes unattached", {
+  testthat::skip_if_not_installed("FAOSTAT")
+  skip_if_faostat_attached()
+
+  df <- tibble::tribble(
+    ~area, ~value,
+    "Portugal", 1,
+    "Spain", 2,
+    "T\u00FCrkiye", 3
+  ) |>
+    as.data.frame()
+
+  search_before <- search()
+  result <- whep:::.populate_iso3_code(df)
+
+  testthat::expect_equal(result$ISO3_CODE, c("PRT", "ESP", "TUR"))
+  # Resolving codes must not attach (nor later unload) FAOSTAT.
+  testthat::expect_identical(search(), search_before)
+})
+
+testthat::test_that(".populate_iso3_code keeps input rows and their order", {
+  testthat::skip_if_not_installed("FAOSTAT")
+
+  # fillCountryCode() merged on the area name, which sorted the rows.
+  df <- data.frame(
+    area = c("Spain", "Portugal", "Spain"),
+    value = 1:3,
+    stringsAsFactors = FALSE
+  )
+
+  result <- whep:::.populate_iso3_code(df)
+
+  testthat::expect_equal(result$area, df$area)
+  testthat::expect_equal(result$value, df$value)
+  testthat::expect_equal(result$ISO3_CODE, c("ESP", "PRT", "ESP"))
+})
+
+testthat::test_that(".populate_iso3_code warns and returns NA if unmatched", {
+  testthat::skip_if_not_installed("FAOSTAT")
+
+  df <- data.frame(
+    area = c("Portugal", "World", "Not A Country"),
+    stringsAsFactors = FALSE
+  )
+
+  testthat::expect_warning(
+    result <- whep:::.populate_iso3_code(df),
+    "Could not match"
+  )
+  testthat::expect_equal(result$ISO3_CODE, c("PRT", NA, NA))
+  testthat::expect_type(result$ISO3_CODE, "character")
+})
+
+testthat::test_that(".fao_area_iso3_lookup leaves ambiguous names unmatched", {
+  testthat::skip_if_not_installed("FAOSTAT")
+
+  lookup <- whep:::.fao_area_iso3_lookup()
+
+  testthat::expect_named(lookup, c("fao_area_name", "iso3_code"))
+  testthat::expect_false(any(duplicated(lookup$fao_area_name)))
+
+  # "China" names three profile rows (the aggregate 351, mainland 41 and
+  # mainland + Taiwan 357), so it must not resolve to a single ISO3 code.
+  china <- lookup$iso3_code[lookup$fao_area_name == "China"]
+  testthat::expect_length(china, 1)
+  testthat::expect_true(is.na(china))
+
+  # An unambiguous name still resolves.
+  mainland <- lookup$iso3_code[lookup$fao_area_name == "China mainland"]
+  testthat::expect_equal(mainland, "CHN")
+})
+
 testthat::test_that("get_faostat_data(example = TRUE) returns offline fixture", {
   result <- whep::get_faostat_data(example = TRUE)
 


### PR DESCRIPTION
## What was wrong

`FAOSTAT::fillCountryCode()` reads `FAOcountryProfile` as a **free variable**, expecting it to be
lazy-loaded into its own namespace. FAOSTAT 2.4.0 ships the dataset but does not make it visible
that way, so a prefixed call dies:

```
Error in FAOSTAT::fillCountryCode(country = "area", data = df, outCode = "ISO3_CODE"):
  object 'FAOcountryProfile' not found
```

**The issue's headline claim is partly wrong, and I am saying so.** `.populate_iso3_code()` does
fail exactly as reported, but the *live* path of `get_faostat_data()` did **not** fail outright: it
ran `do.call(require, list("FAOSTAT"))` first, which put the attached package on the search path
where the namespace's free-variable lookup could reach the lazily loaded dataset, and detached it at
the end. The comment above that line ("Some functions from FAOSTAT pkg don't work by only using
prefixed functions") is a description of this exact bug. So the defect is real but narrower than
filed: **the lookup only works as a side effect of attaching a package**, which breaks any prefixed
or direct call, is invisible to the test suite, mutates the caller's session (`detach(unload =
TRUE)` unloads `FAOSTAT` even if the user had it loaded), and never runs its cleanup when the
download upstream of it fails.

## Evidence it reproduced BEFORE the change

At base commit `60fc6610`, unmodified:

```r
devtools::load_all()
whep:::.populate_iso3_code(data.frame(area = c("Portugal", "Spain"), value = 1:2))
#> Error in FAOSTAT::fillCountryCode(...): object 'FAOcountryProfile' not found
```

Quantified over a real corpus — every FAOSTAT area name obtainable offline: the 272-row
`regions_full$FAOSTAT_name` plus upstream's `faostat_area_polity_map.csv$source_label`, **232
unique names**:

| state | area names resolved to an ISO3 code |
|---|---|
| `FAOSTAT::fillCountryCode()`, package **attached** (the accidental live path) | **215 / 232** |
| `FAOSTAT::fillCountryCode()`, prefixed only (any other caller, and the test suite) | **hard error, 0 / 232** |

And the new tests, run against the parent commit's `R/scrape_faostat.R`: **FAIL 6 | PASS 25**. Five
of the six die on `object 'FAOcountryProfile' not found`.

Root cause confirmed by static analysis rather than assumed — `codetools::findGlobals()` over the
whole call graph of what we call in `FAOSTAT`:

| function | free variables |
|---|---|
| `fillCountryCode` | **`FAOcountryProfile`** |
| `get_faostat_bulk`, `download_faostat_bulk`, `read_faostat_bulk`, `read_bulk_metadata`, `get_fao`, `to_snake` | none (`as.data.table` resolves through `imports:FAOSTAT`) |

`fillCountryCode()` is the only reason the package had to be attached.

## What I changed

`.populate_iso3_code()` no longer delegates to `fillCountryCode()`. Three new private helpers in
`R/scrape_faostat.R`:

- `.fao_country_profile()` — loads `FAOcountryProfile` explicitly into a private environment with
  `utils::data(..., envir = ...)`, and `cli::cli_abort()`s with the FAOSTAT version if the dataset
  or a required column is absent. No dependence on anyone's lazy-load behaviour.
- `.fao_area_iso3_lookup()` — builds the name→ISO3 table, **reproducing `fillCountryCode()`'s rule
  exactly**: exact equality against the six profile name columns, resolved only when all matches
  fall in a single profile row. Ambiguous names stay `NA`.
- `.match_fao_area_to_iso3()` / `.warn_unmatched_fao_areas()` — the vectorised match, and one
  `cli::cli_warn()` listing unmatched areas, raised *after* the manual fix block so a name the
  manual fixes do resolve (e.g. `Türkiye`) no longer warns spuriously.

`get_faostat_data()` loses `do.call(require, list("FAOSTAT"))` and `detach("package:FAOSTAT",
unload = TRUE)`, per the table above: nothing left in that path needs the attach.

## How I verified

**Equivalence, not just "it runs".** Same 232-name corpus, new implementation with FAOSTAT *not*
attached vs. `fillCountryCode()` with it attached:

```
baseline matched: 215 / 232
new matched:      215 / 232
differing area names: 0
row count preserved: TRUE
row order preserved: TRUE
```

Zero differences. Two incidental improvements fall out: rows keep their input order (the old
`merge()` inside `fillCountryCode()` sorted them by area name), and the caller's search path is
untouched.

Gates, all run, none predicted:

- `air format --check .` → exit 0 (`air 0.10.0`)
- `devtools::document()` → no `man/` change (only private helpers added)
- `lintr::lint_package()` with the four repo-disabled linters → **0 lints**
- `devtools::test()` (whole suite) → **FAIL 0 | WARN 7 | SKIP 8 | PASS 5440**; the 7 warnings and 8
  skips are pre-existing and none is in this file
- `test_scrape_faostat.R` alone → **FAIL 0 | WARN 0 | SKIP 0 | PASS 43** (was 25 before)
- pkgdown `comm` check → empty; `utils::globalVariables()` appended for the 4 new NSE symbols
- `rcmdcheck` deliberately left to CI (5 platforms, shared machine); no undeclared globals in the
  new functions per `codetools::findGlobals()`

**The test that would have caught it.** Six new tests exercise the ISO3 step itself instead of the
`example = TRUE` fixture: the profile loads unattached, the abort branch fires on a bad column,
`.populate_iso3_code()` returns `PRT`/`ESP`/`TUR` **and leaves `search()` identical**, row order and
row count survive, unmatched names give `NA` plus the warning, and the ambiguous "China" stays `NA`
while "China mainland" resolves. **No network** — the country profile ships inside `FAOSTAT`, which
is in **Imports**, so it is present wherever the package is checked. Per the r-universe surface
where `skip_on_ci()` does not fire, the guard is a **capability probe**
(`skip_if_faostat_attached()` in a new `tests/testthat/helper_scrape_faostat.R`, plus
`skip_if_not_installed()`), never an environment check.

## Moves published values

**No.** `get_faostat_data()` has no caller anywhere in `R/`, `data-raw/` or the vignettes — it is a
user-facing convenience wrapper. Nothing in the pipeline consumes it, and the mapping it produces is
byte-identical on all 232 names measured above, so no published number can move. That is why this
is not a draft.

## What I deliberately did not do

- **I did not switch the ISO3 source to the polity crosswalk** (option 2 in the issue), because that
  changes which authority resolves a territorial identity and would move output. See the open
  decision below.
- **I did not add missing name mappings.** 8 of the 211 real FAOSTAT area labels in `regions_full`
  still resolve to `NA`, because FAOSTAT 2.4.0's own name table is stale — including three current
  reporters: `Eswatini`, `North Macedonia` and `China, Taiwan Province of`. That is a pre-existing
  gap this PR neither creates nor widens, and patching it is a behaviour change, so it is filed
  separately as #541 with the measurement.
- **I did not touch the manual-fix block or the "China" handling**, which #313 owns. That PR's hunk
  applies unchanged on top of this one, and its test now passes: the aggregate `"China"` matches
  three profile rows (351, 41, 357) and so stays `NA` under the reproduced matching rule.
- **I did not rewrite the FAOSTAT download to direct API calls** (#45's broader ask), or reformat the
  surrounding `for`-loop filter code. Out of scope.

## The open decision

Whether whep should resolve FAOSTAT area names through **upstream's polity crosswalk** instead of
FAOSTAT's vendored `FAOcountryProfile` (#520 option 2, and the natural end state under #458). The
evidence, on the same 232-name corpus:

| source | resolved | disagreements where both resolve |
|---|---|---|
| FAOSTAT profile + whep's manual fixes (this PR) | 222 / 232 | — |
| upstream `faostat_area_polity_map.csv$iso3` | 228 / 232 | **0** |

Upstream resolves 7 names this PR leaves `NA` (`Belgium-Luxembourg`→BLX, `China, Taiwan Province
of`→TWN, `Ethiopia PDR`→ETH, `North Macedonia`→MKD, `Sudan (former)`→SDN, `USSR`→SUN,
`Netherlands Antilles (former)`→ANT) and contradicts it nowhere; `Eswatini` resolves too, through
`label_alias_map.csv` rather than the area map. That looks like a strict improvement, but it is a
territorial-attribution change with a real output effect, so I have not made it here — it is yours
to call.

Closes #520
Part of the polity migration epic #458.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
