### PR TITLE
fix(polities): stop resolve_polity_label() resolving to retired polities

### DIFF
--- a/R/polities.R
+++ b/R/polities.R
@@ -845,15 +845,34 @@ resolve_polity_label <- function(label, source = NULL, year = NULL) {
 
   # Identity fallbacks, tried only after the alias route misses.
   #
+  # A DEAD POLITY MUST NOT BE A RESOLUTION CANDIDATE, for the same reason
+  # `data-raw/table_mappings.R` filters them out of the crosswalk build: upstream
+  # retires a polity when a finer or corrected split supersedes it, and both rows
+  # stay in the published `polities` table because looking up a code you already
+  # hold is legitimate. What must not happen is resolving TO one.
+  #
+  # Only the INFERENCE routes below are filtered. The alias route is not: an alias
+  # names a code explicitly, and a curator who decided a label means a particular
+  # polity has made that decision whatever its status.
+  #
+  # Unfiltered, a corrected period and the row it corrected both cover the same
+  # year, the ambiguity guard cannot separate them, and the label resolves to
+  # nothing. Measured after the #530 re-sync: `CAN-1948-2025` (retired) sat beside
+  # `CAN-1949-2025`, and the same shape held for BRA, ARG, AGO, GRC and IRQ --
+  # 234 of `mueller_synthetic_n`'s 5,043 rows unresolvable, every one of them with
+  # exactly one LIVE candidate.
+  #
   # `polities` is an sf data frame and sf is only suggested, so the attribute
   # columns are taken by name rather than through `sf::st_drop_geometry()`.
+  alive <- is.na(polities$wiki_status) |
+    !polities$wiki_status %in% c("retired", "superseded")
   pol <- data.frame(
-    polity_code = polities$polity_code,
-    start_year = polities$start_year,
-    end_year = polities$end_year,
+    polity_code = polities$polity_code[alive],
+    start_year = polities$start_year[alive],
+    end_year = polities$end_year[alive],
     stringsAsFactors = FALSE
   )
-  name_key <- .norm_polity_label(polities$polity_name)
+  name_key <- .norm_polity_label(polities$polity_name[alive])
   # The ISO3 index is what makes this usable for the datasets that motivated it.
   # The alias map is keyed on the labels curators had to decide about, so a label
   # that is simply a current ISO3 code is not in it: without this route,
@@ -861,7 +880,7 @@ resolve_polity_label <- function(label, source = NULL, year = NULL) {
   # 10 FAO-style legacy codes the map does carry -- and `crops_manure_n`'s `ISO`
   # 860 of 31,648. Upstream's matcher resolves "by alias, then ISO/name family +
   # year containment", so this is the second half of that rule, not a new one.
-  iso_key <- toupper(trimws(polities$iso3_code))
+  iso_key <- toupper(trimws(polities$iso3_code[alive]))
   refuse_names <- .refused_polity_label_names()
 
   family <- function(code) sub("-.*", "", code)

--- a/tests/testthat/test_resolve_polity_label.R
+++ b/tests/testthat/test_resolve_polity_label.R
@@ -94,11 +94,25 @@ test_that("a year-scoped alias is silent outside its span, not contradicted", {
 })
 
 test_that("ambiguous identifiers return NA instead of picking by row order", {
-  # Four polities are named "Montenegro" once parenthesised qualifiers are
-  # dropped, and MNE-1913-1915 overlaps MNE-1913-1918. Resolving 1914 by row
-  # order would invent an answer; NA says the label needs an alias.
-  expect_true(is.na(resolve_polity_label("Montenegro", year = 1914L)))
-  # The same label is unambiguous in 2010, where exactly one is live.
+  # Panama in 1970 is the live case: `PAN-1903-1979` and `CZN-1903-1979`, the
+  # Canal Zone, both carry ISO3 `PAN` and both cover that year. They are a real
+  # territorial overlap rather than a data defect -- the Zone was administered
+  # separately inside Panama's borders -- so no re-sync will remove it, which is
+  # what makes it the right case to pin the guard on. Resolving by row order
+  # would invent an answer; NA says the label needs an alias.
+  expect_true(is.na(resolve_polity_label("PAN", year = 1970L)))
+  # And unambiguous once the Zone ends: exactly one live polity carries `PAN`.
+  expect_equal(resolve_polity_label("PAN", year = 2000L), "PAN-1979-2025")
+
+  # Montenegro USED to be this test's case, on `MNE-1913-1915` overlapping
+  # `MNE-1913-1918` while both were draft upstream. That was a data defect, filed
+  # as whep-polities#62, and upstream has retired `MNE-1913-1915`. So 1914 now has
+  # one live answer, and the guard needed a case that is not a bug waiting to be
+  # fixed -- hence Panama above.
+  expect_equal(
+    resolve_polity_label("Montenegro", year = 1914L),
+    "MNE-1913-1918"
+  )
   expect_equal(
     resolve_polity_label("Montenegro", year = 2010L),
     "MNE-2006-2025"
@@ -110,7 +124,6 @@ test_that("ambiguous identifiers return NA instead of picking by row order", {
   # no answer and NA was the honest one. `SUD-1956-2011` now carries `SDN` as its
   # ISO3 too, so a 2000 row resolves to the unified Sudan that actually existed
   # then -- which is the outcome #387 wanted, reached upstream instead of here.
-  # The guard itself is unchanged and still tested by Montenegro above.
   expect_equal(resolve_polity_label("SDN", year = 2000L), "SUD-1956-2011")
   expect_equal(resolve_polity_label("SDN", year = 2015L), "SDN-2011-2025")
 })
@@ -152,33 +165,28 @@ test_that("resolve_polity_label recovers the coverage whep#389 measured", {
   # refresh that resolves MORE labels does not fail the test, while a regression
   # that resolves fewer does.
   #
-  # mueller_synthetic_n$iso3c: 328 rows carried a legacy code matching no
-  # polity, and the other 4,715 carried an ISO3 the package had no label route
-  # for at all.
+  # mueller_synthetic_n$iso3c: 328 rows carried a legacy code matching no polity,
+  # and the other 4,715 carried an ISO3 the package had no label route for at all.
+  # All 5,043 now resolve.
   #
-  # 4,832 of 5,043 resolve against the polities vintage this package currently
-  # embeds. The bound was 4,999 when this was written, and the 167-row difference
-  # is NOT a regression in the resolver -- it is the ambiguity guard firing on an
-  # upstream defect that upstream has since fixed. Five ISO3 families ship a
-  # spanning row alongside the finer split of the same family, so two live
-  # polities cover 2000 and the resolver refuses to pick by row order:
+  # This bound has moved twice and the history is worth keeping, because both
+  # moves were the guard working rather than the resolver regressing. It was 4,999
+  # when written. The #530 re-sync then dropped it to 4,809, because a corrected
+  # polity period and the row it superseded both stayed in the published `polities`
+  # table and both covered 2000, so the ambiguity guard refused to choose --
+  # `CAN-1948-2025` beside `CAN-1949-2025`, and the same shape for BRA, ARG, AGO,
+  # GRC and IRQ. That exposed a real defect: the inference routes were reading
+  # every row of `polities`, including retired and superseded ones, where the
+  # crosswalk build has always filtered them. With that fixed, every one of the
+  # 234 rows resolves, because each had exactly one LIVE candidate all along.
   #
-  #   BRA (54 rows)  BRA-1800-2025 alongside BRA-1909-2025
-  #   ARG (44)       ARG-1800-2025 alongside ARG-1902-2025
-  #   AGO (41)       AGO-1816-2025 alongside AGO-1975-2025
-  #   GRC (39)       GRC-1919-2025 alongside GRC-1947-2025
-  #   IRQ (33)       IRQ-1921-2025 alongside IRQ-1932-2025
-  #
-  # Measured against upstream `main`: every one of the five spanning rows is now
-  # retired or superseded, leaving exactly one live polity covering 2000 in each
-  # family. So the re-sync in #530 lifts this back above 4,999 without touching
-  # the resolver. It stays a lower bound for exactly that reason.
+  # Asserted as a lower bound, so a future vintage that resolves more still passes.
   mueller <- resolve_polity_label(
     whep::mueller_synthetic_n$iso3c,
     source = "mueller-synthetic-n",
     year = 2000L
   )
-  expect_gte(sum(!is.na(mueller)), 4832)
+  expect_gte(sum(!is.na(mueller)), 5043)
 
   # lassaletta_grassland_share$Country was matched by exact string against
   # regions$area_name, which covered 6,370 of 6,909 rows (92.2%). Resolution


### PR DESCRIPTION
**`main` is red and this fixes it.** `test_resolve_polity_label.R` asserts `mueller_synthetic_n` resolves at least 4,999 of its 5,043 rows; it resolves 4,809.

**The broken bound is mine.** #479 landed with a coverage bound measured before #551 changed the polities vintage, and I merged it without re-running its suite against the merged result. But the bound was the symptom — the cause is a real defect the re-sync exposed, and this PR fixes that rather than adjusting the number.

## What was wrong

`resolve_polity_label()`'s inference routes (name and ISO3) indexed **every** row of `polities`, including retired and superseded ones.

`data-raw/table_mappings.R` has always filtered those out of the crosswalk build, and spells out why:

> A DEAD POLITY MUST NOT BE A RESOLUTION CANDIDATE. […] The filter belongs HERE and not on `polities`. The published `polities` table keeps every row, because looking up a retired code is legitimate — a consumer holding historical output needs to resolve the code it already has. What must not happen is resolving TO one.

The label resolver never got the same filter.

## Why it only fired now

Harmless while no corrected period overlapped the row it corrected. #551 made it live: upstream retires the old row and adds the fixed one, and **both stay in `polities`**, so both cover the same year, the ambiguity guard cannot separate them, and the label resolves to nothing.

Measured on `main`, every case having exactly one **live** candidate:

| ISO3 | rows lost | covering 2000 |
|---|---|---|
| BRA | 54 | `BRA-1800-2025`/superseded + `BRA-1909-2025` |
| ARG | 44 | `ARG-1800-2025`/retired + `ARG-1902-2025` |
| AGO | 41 | `AGO-1816-2025`/retired + `AGO-1975-2025` |
| GRC | 39 | `GRC-1919-2025`/superseded + `GRC-1947-2025` |
| IRQ | 33 | `IRQ-1921-2025`/superseded + `IRQ-1932-2025` |
| CAN | 23 | `CAN-1948-2025`/retired + `CAN-1949-2025` |

**234 rows**, all recoverable.

## What changed

One filter, on the inference index only:

```r
alive <- is.na(polities$wiki_status) |
  !polities$wiki_status %in% c("retired", "superseded")
```

**The alias route is deliberately not filtered.** An alias names a code explicitly, and a curator who decided a label means a particular polity has made that decision whatever the code's status.

## Verified

- `mueller_synthetic_n`: 4,809 → **5,043 of 5,043**, above the 4,999 #389 originally targeted.
- `lassaletta_grassland_share`: holds at 6,781.
- Full suite **5602 pass, 0 fail, 8 skip**; `lintr` and `air` clean.

## Two test consequences, recorded rather than papered over

The mueller bound moves to 5,043, carrying the full history of why it went 4,999 → 4,809 → 5,043.

And the ambiguity guard needed a new case. It was pinned on Montenegro's `MNE-1913-1915`/`MNE-1913-1918` overlap — but that was a **data defect** (lbm364dl/whep-polities#62) and upstream has retired the duplicate, so 1914 now has one live answer. Pinning a guard on a bug waiting to be fixed makes the guard evaporate when it is. It now pins **Panama in 1970**, where `PAN-1903-1979` and the Canal Zone `CZN-1903-1979` both carry ISO3 `PAN`: a genuine territorial overlap that no re-sync will remove.

Part of the polity migration epic #458.

🤖 Generated with [Claude Code](https://claude.com/claude-code)