### PR TITLE
test(validation): guard the LPJmL-derived pins so a swap cannot pass silently

### DIFF
--- a/validation/README.md
+++ b/validation/README.md
@@ -47,6 +47,8 @@ a hardcoded grid.
 | `nass_sum.R` | Deterministic USA extractor: sums STATE rows from the local USDA NASS bulk CSV → national tonnes, writes `cache/findings/USA.json`. No web, no PDF. |
 | `lpjml_faostat_crops.R` | Checks a finished **LPJmL run's** crop output against FAOSTAT per CFT and country. See below. |
 | `lpjml_globalflux.R` | Checks a finished **LPJmL run's** global fluxes for spinup equilibration and against published observational estimates. See below. |
+| `lpjml_pins.R` | Guards the four **LPJmL-derived input pins** against their recorded contract, physical invariants and magnitudes, so a pin swap cannot pass silently. See below. |
+| `gt_lpjml_pins.json` | Recorded magnitudes for those pins. **Committed** — it is the tripwire, and it is meant to fail when the pins change. |
 
 ## Validating an LPJmL run (different target)
 
@@ -69,6 +71,47 @@ Rscript validation/lpjml_globalflux.R <run_dir> [baseline_run_dir] 2000,2010
 ```
 
 `<run_dir>` is a run's `output/scenario_1`.
+
+### Guarding the LPJmL-derived pins
+
+Separate from the two above, which check a *run*. This one checks the four
+**pins** WHEP actually feeds on:
+
+```bash
+Rscript validation/lpjml_pins.R            # check against the recorded baseline
+Rscript validation/lpjml_pins.R --record   # rewrite the baseline, deliberately
+```
+
+It exists because repointing those pins from LPJmL 5.9.7 to 6.1.1 raised
+natural-land carbon input ~31% — moving every downstream SOC number — and
+`validate_all.R` ran clean straight through it. It had to: every variable that
+sweep covers reads FAOSTAT/GAEZ/MapSPAM/PSD and none reads an LPJmL pin (#559).
+
+Three tiers, and they mean different things when they fail:
+
+- **Contract** — required columns, row count, year span. A mismatch means the pin
+  is not the layer its consumers expect.
+- **Invariant** — physical impossibility, not expectation: a fractional
+  saturation outside `[0, 1]`, a negative carbon density, a monthly rainfall
+  above any observed value. These hold for any model version, so they never need
+  updating, and a violation is corruption rather than a model difference.
+- **Baseline** — recorded magnitudes in `gt_lpjml_pins.json`. **This tier is
+  designed to fail when the pins change.** The tolerance is `1e-5`, not a few
+  percent, because these are deterministic model outputs rather than
+  measurements — at 2% the real 5.9.7→6.1.1 hydrology shift (1.7%) slipped
+  through while the larger carbon shifts were caught, which is the silent pass
+  the script exists to prevent.
+
+So a baseline failure is a prompt, not a verdict: find out what moved, then
+re-record with `--record` and say in the commit message why.
+
+**Still not covered:** how a pin change propagates into `build_carbon_balance()`
+output. That needs local raster paths which are unset in a fresh checkout —
+`WHEP_HWSD_DIR`, `WHEP_CRU_DIR`, `WHEP_LUH2_DIR`, `WHEP_POLITY_FRACTION_PATH`,
+`WHEP_TYPE_CROPLAND_PATH`, `WHEP_GRIDDED_PASTURE_PATH`,
+`WHEP_CROP_PATTERNS_PATH` — and the repo's tracked `.Renviron` shadows
+`~/.Renviron` (#456), so they cannot come from a home file either. Tracked in
+#559.
 
 **What these can and cannot establish.** LPJmL only matches FAO yields once its
 maximum LAI has been calibrated per country ([Fader et al.

--- a/validation/gt_lpjml_pins.json
+++ b/validation/gt_lpjml_pins.json
@@ -1,0 +1,34 @@
+{
+  "note": "Recorded magnitudes for the LPJmL-derived pins. A mismatch is not automatically a fault: it is the intended alarm when the pins are repointed at a different LPJmL run. Re-record deliberately and say in the commit message why the numbers moved.",
+  "compare_years": [2000, 2010],
+  "pins": {
+    "lpjml-grass-availability": {
+      "n_rows": 5239855,
+      "first_year": 1901,
+      "last_year": 2023,
+      "mean": 1.497867262552,
+      "median": 0.8131793171264
+    },
+    "lpjml-grass-productivity": {
+      "n_rows": 6809325,
+      "first_year": 1901,
+      "last_year": 2023,
+      "mean": 183.282239534719,
+      "median": 102.713092803955
+    },
+    "lpjml-grass-natural-net-c": {
+      "n_rows": 12577999,
+      "first_year": 1901,
+      "last_year": 2023,
+      "mean": 6.212994850758,
+      "median": 5.025367842573
+    },
+    "lpjml-soc-hydrology": {
+      "n_rows": 86781420,
+      "first_year": 1901,
+      "last_year": 2023,
+      "mean": 0.4661382837461,
+      "median": 0.4954651743174
+    }
+  }
+}

--- a/validation/lpjml_pins.R
+++ b/validation/lpjml_pins.R
@@ -1,0 +1,341 @@
+# Guards the four WHEP input pins that carry LPJmL model output, so a pin swap
+# cannot change published numbers silently.
+#
+# WHY THIS EXISTS
+#
+# Repointing these pins from LPJmL 5.9.7 to 6.1.1 raised natural-land carbon
+# input ~31% -- a change that moves every downstream SOC number -- and
+# `validate_all.R` ran clean straight through it. It had to: every variable it
+# sweeps reads FAOSTAT, GAEZ, MapSPAM or USDA PSD, and none reads an LPJmL pin
+# (see the note at the top of `variables.R`). So the largest input change of the
+# migration was invisible to the harness. See #559.
+#
+# WHAT THIS IS, AND IS NOT
+#
+# It is NOT an external validation: there is no independent observational
+# product for "LPJmL's grass NPP", so nothing here can say the model is right.
+# It is a CONTRACT and REGRESSION check, in three tiers, cheapest first:
+#
+#   1. CONTRACT   required columns, row count and year span -- the cheapest
+#                 signal that a pin is not the layer its consumers expect.
+#   2. INVARIANT  physical impossibility, not expectation: a fractional
+#                 saturation outside [0, 1], a negative carbon density, a
+#                 monthly rainfall above any observed value. These hold for any
+#                 model version, so they never need updating and they catch the
+#                 corruptions that a row count cannot.
+#   3. BASELINE   recorded magnitudes in `gt_lpjml_pins.json`, compared with a
+#                 tolerance. This is the tier that makes a pin swap loud: it
+#                 fails by design when the pins change, and the failure is the
+#                 signal to look at what moved and then re-record.
+#
+# Tier 3 is deliberately a tripwire rather than a truth claim. Re-record it with
+# `--record` when a pin change is intended and understood, and say in the commit
+# why the numbers moved.
+#
+# Usage:
+#   Rscript validation/lpjml_pins.R            # check against the baseline
+#   Rscript validation/lpjml_pins.R --record   # rewrite the baseline
+#
+# Magnitudes use a fixed year window (see COMPARE_YEARS) so the check is fast
+# and deterministic; row counts and schema cover the whole pin.
+
+suppressPackageStartupMessages({
+  devtools::load_all(".", quiet = TRUE)
+  library(dplyr)
+})
+
+BASELINE_PATH <- "validation/gt_lpjml_pins.json"
+
+# One decade is enough to detect a magnitude shift, and reading the full span of
+# the hydrology pin would mean 86.8e6 rows for no extra information.
+COMPARE_YEARS <- 2000:2010
+
+# Fractional tolerance on a recorded mean before it is flagged.
+#
+# Tiny on purpose. These are deterministic model outputs, not measurements:
+# re-reading the same pin gives the same number, so the tolerance has to absorb
+# only floating-point summation order, not sampling noise. A loose tolerance
+# defeats the whole tier -- at 2% the real 5.9.7 -> 6.1.1 hydrology shift (1.7%)
+# slipped through undetected while the larger carbon shifts were caught, which
+# is exactly the silent pass this script exists to prevent.
+MAGNITUDE_TOL <- 1e-5
+
+# The four pins, their required columns, and the value column each is judged on.
+#
+# `bounds` are IMPOSSIBILITY limits, not expected ranges. swc_topsoil is a
+# fractional saturation so it cannot leave [0, 1]. The carbon densities cannot
+# be negative, and their ceilings sit far above any real value (tropical forest
+# NPP is ~15-25 Mg C/ha/yr, so 100 is absurd rather than merely high). Monthly
+# precipitation has been observed near 2500 mm, so 10000 is unreachable. A
+# violation is corruption, not a model difference.
+PIN_SPECS <- list(
+  list(
+    alias = "lpjml-grass-availability",
+    columns = c("lon", "lat", "year", "grass_npp_gc_m2", "grass_avail_dm_t_ha"),
+    value = "grass_avail_dm_t_ha",
+    bounds = list(grass_avail_dm_t_ha = c(0, 100), grass_npp_gc_m2 = c(0, 5000))
+  ),
+  list(
+    alias = "lpjml-grass-productivity",
+    columns = c("lon", "lat", "year", "grass_npp"),
+    value = "grass_npp",
+    bounds = list(grass_npp = c(0, 5000))
+  ),
+  list(
+    alias = "lpjml-grass-natural-net-c",
+    columns = c("lon", "lat", "year", "land_use", "npp_c_mgc_ha_yr"),
+    value = "npp_c_mgc_ha_yr",
+    bounds = list(npp_c_mgc_ha_yr = c(0, 100))
+  ),
+  list(
+    alias = "lpjml-soc-hydrology",
+    columns = c(
+      "lon",
+      "lat",
+      "year",
+      "month",
+      "swc_topsoil",
+      "prec_mm",
+      "irrig_mm"
+    ),
+    value = "swc_topsoil",
+    bounds = list(
+      swc_topsoil = c(0, 1),
+      prec_mm = c(0, 10000),
+      irrig_mm = c(0, 10000)
+    )
+  )
+)
+
+main <- function() {
+  record <- "--record" %in% commandArgs(trailingOnly = TRUE)
+  observed <- lapply(PIN_SPECS, measure_pin)
+  names(observed) <- vapply(PIN_SPECS, function(s) s$alias, character(1))
+
+  if (record) {
+    write_baseline(observed)
+    return(invisible(NULL))
+  }
+  report(observed, read_baseline())
+}
+
+# ---- Measuring -------------------------------------------------------------
+
+# Everything this check needs from one pin.
+#
+# Read through whep_read_file() rather than off a path, because the point is to
+# check what WHEP would actually load -- the registry version included -- not a
+# file that happens to be on disk. That costs a full read of the 86.8e6-row
+# hydrology pin, which is the price of using the supported interface instead of
+# reaching into the pins cache layout.
+measure_pin <- function(spec) {
+  data <- whep::whep_read_file(spec$alias, type = "parquet") |>
+    tibble::as_tibble()
+
+  missing <- setdiff(spec$columns, names(data))
+  if (length(missing) > 0L) {
+    return(list(
+      alias = spec$alias,
+      fatal = sprintf("missing columns: %s", paste(missing, collapse = ", ")),
+      n_rows = nrow(data)
+    ))
+  }
+
+  info <- list(num_rows = nrow(data))
+  window <- dplyr::filter(data, .data$year %in% COMPARE_YEARS)
+  values <- window[[spec$value]]
+  values <- values[is.finite(values)]
+
+  list(
+    alias = spec$alias,
+    fatal = NULL,
+    n_rows = info$num_rows,
+    first_year = min(data$year),
+    last_year = max(data$year),
+    n_window = length(values),
+    mean = mean(values),
+    median = stats::median(values),
+    violations = bound_violations(window, spec$bounds)
+  )
+}
+
+# Rows outside the impossibility limits, per column. Counted rather than
+# stopped at the first one: how many and in which column is what tells you
+# whether it is one bad cell or a broken layer.
+bound_violations <- function(data, bounds) {
+  out <- lapply(names(bounds), function(column) {
+    limit <- bounds[[column]]
+    values <- data[[column]]
+    finite <- values[is.finite(values)]
+    tibble::tibble(
+      column = column,
+      below = sum(finite < limit[[1L]]),
+      above = sum(finite > limit[[2L]]),
+      n_missing = sum(!is.finite(values))
+    )
+  })
+  dplyr::bind_rows(out)
+}
+
+# ---- Baseline --------------------------------------------------------------
+
+read_baseline <- function() {
+  if (!file.exists(BASELINE_PATH)) {
+    cli::cli_abort(c(
+      "No baseline at {.path {BASELINE_PATH}}.",
+      i = "Record one with {.code Rscript validation/lpjml_pins.R --record}."
+    ))
+  }
+  jsonlite::fromJSON(BASELINE_PATH, simplifyVector = FALSE)
+}
+
+write_baseline <- function(observed) {
+  payload <- list(
+    note = paste(
+      "Recorded magnitudes for the LPJmL-derived pins. A mismatch is not",
+      "automatically a fault: it is the intended alarm when the pins are",
+      "repointed at a different LPJmL run. Re-record deliberately and say in",
+      "the commit message why the numbers moved."
+    ),
+    compare_years = range(COMPARE_YEARS),
+    pins = lapply(observed, function(o) {
+      list(
+        n_rows = o$n_rows,
+        first_year = o$first_year,
+        last_year = o$last_year,
+        mean = o$mean,
+        median = o$median
+      )
+    })
+  )
+  # digits = 12, because the default rounds to 4 decimals and that alone would
+  # cap detectable change at ~1e-4 regardless of the tolerance above.
+  jsonlite::write_json(
+    payload,
+    BASELINE_PATH,
+    auto_unbox = TRUE,
+    pretty = TRUE,
+    digits = 12
+  )
+  cli::cli_alert_success(
+    "Recorded {length(observed)} pins to {.path {BASELINE_PATH}}."
+  )
+}
+
+# ---- Reporting -------------------------------------------------------------
+
+report <- function(observed, baseline) {
+  cli::cli_h1("LPJmL-derived pin checks")
+  rows <- lapply(observed, function(o) check_one(o, baseline$pins[[o$alias]]))
+  table <- dplyr::bind_rows(rows)
+  print(as.data.frame(table), row.names = FALSE)
+
+  failed <- dplyr::filter(table, .data$verdict != "ok")
+  cat("\n")
+  if (nrow(failed) == 0L) {
+    cli::cli_alert_success(
+      "All {nrow(table)} pins match contract, invariants and baseline."
+    )
+    return(invisible(NULL))
+  }
+  cli::cli_alert_danger("{nrow(failed)} of {nrow(table)} pins deviate:")
+  for (i in seq_len(nrow(failed))) {
+    cli::cli_alert_warning("{failed$pin[[i]]}: {failed$detail[[i]]}")
+  }
+  cli::cli_alert_info(
+    "If the pins were repointed on purpose, re-record with
+     {.code Rscript validation/lpjml_pins.R --record}."
+  )
+  invisible(NULL)
+}
+
+check_one <- function(observed, expected) {
+  base <- tibble::tibble(pin = observed$alias, n_rows = observed$n_rows)
+
+  if (!is.null(observed$fatal)) {
+    return(dplyr::mutate(base, verdict = "SCHEMA", detail = observed$fatal))
+  }
+  if (is.null(expected)) {
+    return(dplyr::mutate(
+      base,
+      verdict = "NEW",
+      detail = "not in the baseline; record it"
+    ))
+  }
+
+  problems <- c(
+    row_problem(observed, expected),
+    span_problem(observed, expected),
+    invariant_problem(observed),
+    magnitude_problem(observed, expected)
+  )
+  dplyr::mutate(
+    base,
+    verdict = if (length(problems) == 0L) "ok" else "DEVIATES",
+    detail = if (length(problems) == 0L) {
+      sprintf("mean %.4g", observed$mean)
+    } else {
+      paste(problems, collapse = "; ")
+    }
+  )
+}
+
+row_problem <- function(observed, expected) {
+  if (identical(as.numeric(observed$n_rows), as.numeric(expected$n_rows))) {
+    return(character())
+  }
+  sprintf("rows %d vs recorded %d", observed$n_rows, expected$n_rows)
+}
+
+span_problem <- function(observed, expected) {
+  if (
+    identical(
+      as.numeric(observed$first_year),
+      as.numeric(expected$first_year)
+    ) &&
+      identical(as.numeric(observed$last_year), as.numeric(expected$last_year))
+  ) {
+    return(character())
+  }
+  sprintf(
+    "span %d-%d vs recorded %d-%d",
+    observed$first_year,
+    observed$last_year,
+    expected$first_year,
+    expected$last_year
+  )
+}
+
+# Impossibility violations are reported separately from baseline drift, because
+# they mean something different: drift is a changed model, a violation is a
+# broken layer.
+invariant_problem <- function(observed) {
+  bad <- dplyr::filter(observed$violations, .data$below > 0 | .data$above > 0)
+  if (nrow(bad) == 0L) {
+    return(character())
+  }
+  sprintf(
+    "IMPOSSIBLE VALUES: %s",
+    paste(
+      sprintf("%s %d below/%d above", bad$column, bad$below, bad$above),
+      collapse = ", "
+    )
+  )
+}
+
+magnitude_problem <- function(observed, expected) {
+  ratio <- observed$mean / expected$mean
+  if (abs(ratio - 1) <= MAGNITUDE_TOL) {
+    return(character())
+  }
+  sprintf(
+    "mean %.4g vs recorded %.4g (%.3fx)",
+    observed$mean,
+    expected$mean,
+    ratio
+  )
+}
+
+if (sys.nframe() == 0L) {
+  main()
+}

--- a/validation/validate_all.R
+++ b/validation/validate_all.R
@@ -17,9 +17,25 @@ source("validation/variables.R")
 year_min <- as.integer(Sys.getenv("VAL_YEAR_MIN", "1970"))
 year_max <- as.integer(Sys.getenv("VAL_YEAR_MAX", "2010"))
 bench_years <- c(1990L, 2000L, 2010L)
-production <- readRDS(
-  sprintf(".whep_cache/primary_prod_%d_%d.rds", year_min, year_max)
+# The production build is NOT triggered here on purpose: it takes minutes to
+# hours and reads pins, which is not something a validation sweep should start
+# without being asked. But a bare readRDS() on a missing cache dies inside
+# gzfile() naming only a path, which reads as corruption rather than as setup
+# not done -- so say which it is.
+production_cache <- sprintf(
+  ".whep_cache/primary_prod_%d_%d.rds",
+  year_min,
+  year_max
 )
+if (!file.exists(production_cache)) {
+  cli::cli_abort(c(
+    "No cached WHEP production at {.path {production_cache}}.",
+    i = "{.path .whep_cache/} is gitignored, so a fresh checkout has none.",
+    i = "Build it once with {.code Rscript validation/rank_countries.R}, or set
+         {.envvar VAL_YEAR_MIN}/{.envvar VAL_YEAR_MAX} to a window you have."
+  ))
+}
+production <- readRDS(production_cache)
 lookups <- whep_validation_lookups()
 scorecard <- list()
 add <- function(variable, archetype, n, ok, flag, note) {
@@ -146,33 +162,42 @@ if (file.exists(psd_path)) {
 }
 
 # 3. occupation + land_per_tonne (external, vs LCA literature) -----------------
-occ_gt <- jsonlite::fromJSON("validation/cache/ground_truth/occupation.json") |>
-  tibble::as_tibble() |>
-  dplyr::transmute(
-    item_cbs_code = as.integer(.data$item_cbs_code),
-    lit = .data$gt_value,
-    lo = .data$gt_low,
-    hi = .data$gt_high
-  )
-score_occ <- function(extractor, label) {
-  w <- extractor(production, bench_years) |>
-    dplyr::inner_join(occ_gt, by = "item_cbs_code") |>
-    dplyr::mutate(
-      m2 = .data$whep_value * 10,
-      in_range = .data$m2 >= .data$lo & .data$m2 <= .data$hi
+occ_path <- "validation/cache/ground_truth/occupation.json"
+if (!file.exists(occ_path)) {
+  cli::cli_warn(c(
+    "Skipping occupation and land_per_tonne: no ground truth at
+     {.path {occ_path}}.",
+    i = "{.path validation/cache/} is gitignored, so a fresh clone has none;
+         see {.file validation/README.md}."
+  ))
+} else {
+  occ_gt <- jsonlite::fromJSON(occ_path) |>
+    tibble::as_tibble() |>
+    dplyr::transmute(
+      item_cbs_code = as.integer(.data$item_cbs_code),
+      lit = .data$gt_value,
+      lo = .data$gt_low,
+      hi = .data$gt_high
     )
-  add(
-    label,
-    "external",
-    nrow(w),
-    sum(w$in_range),
-    sum(!w$in_range),
-    "ha-yr/t vs Poore & Nemecek 2018 range (m2*yr/kg)"
-  )
+  score_occ <- function(extractor, label) {
+    w <- extractor(production, bench_years) |>
+      dplyr::inner_join(occ_gt, by = "item_cbs_code") |>
+      dplyr::mutate(
+        m2 = .data$whep_value * 10,
+        in_range = .data$m2 >= .data$lo & .data$m2 <= .data$hi
+      )
+    add(
+      label,
+      "external",
+      nrow(w),
+      sum(w$in_range),
+      sum(!w$in_range),
+      "ha-yr/t vs Poore & Nemecek 2018 range (m2*yr/kg)"
+    )
+  }
+  score_occ(extract_occupation_intensity, "occupation")
+  score_occ(extract_land_per_tonne, "land_per_tonne")
 }
-score_occ(extract_occupation_intensity, "occupation")
-score_occ(extract_land_per_tonne, "land_per_tonne")
-
 # 4. cropping_intensity (bound, vs GAEZ potential) -----------------------------
 gaez_path <- "validation/cache/ground_truth/cropping_intensity.json"
 if (file.exists(gaez_path)) {


### PR DESCRIPTION
Closes the gap recorded in #559.

Repointing the four LPJmL-output pins from 5.9.7 to 6.1.1 (#558) raised
natural-land carbon input **~31%** — moving every downstream SOC number — and
`validate_all.R` ran clean straight through it. It had to: every variable that
sweep covers reads FAOSTAT/GAEZ/MapSPAM/PSD, and **none reads an LPJmL pin**.

## What this adds

`validation/lpjml_pins.R` checks the pins WHEP actually loads — via
`whep_read_file()`, so the registry version is part of what is checked rather
than a file left on disk. Three tiers, failing for different reasons:

| tier | what a failure means |
|---|---|
| **contract** — columns, row count, year span | the pin is not the layer its consumers expect |
| **invariant** — physical impossibility | corruption, not a model difference |
| **baseline** — recorded magnitudes | the pins changed |

Invariants are impossibility limits, not expected ranges: a fractional
saturation outside `[0, 1]`, a negative carbon density, a monthly rainfall above
any observed value. They hold for any model version, so they never need updating.

The baseline tier is explicitly a **tripwire, not a truth claim** — there is no
independent observational product for "LPJmL's grass NPP", so nothing here can
say the model is right. It is designed to fail when the pins change, and a
failure is a prompt to find out what moved and re-record with `--record`.

## Two details that decide whether it works at all

Both found by testing that the tripwire actually *trips*, rather than assuming it:

- **Tolerance is `1e-5`, not a few percent.** These are deterministic model
  outputs, not measurements, so the tolerance absorbs only floating-point
  summation order. My first attempt used 2% — and the real 5.9.7→6.1.1 hydrology
  shift (1.7%) passed undetected while the larger carbon shifts were caught. That
  is precisely the silent pass this script exists to prevent.
- **The baseline is written with `digits = 12`.** `jsonlite`'s default rounds to 4
  decimals, which alone caps detectable change at ~1e-4 regardless of tolerance.

Verified both directions: clean against the live pins, and correctly flagging a
perturbed row count plus all three perturbed magnitudes including the 1.7% one.

## Also fixes two misleading failures met on the way

Both cost a diagnosis, and neither was the fault they appeared to be:

- `validate_all.R` did a bare `readRDS()` on the gitignored `.whep_cache`
  production build, dying inside `gzfile()` naming only a path — which reads as
  corruption rather than setup-not-done. Now aborts saying which, and how to
  build it. The build is deliberately **not** triggered here: it takes minutes to
  hours and reads pins, which a validation sweep should not start unasked.
- The occupation ground-truth read was the one section **not** guarded by
  `file.exists()`, so a fresh checkout died inside `jsonlite` parsing the missing
  *path* as JSON content. Now skipped with a warning, like its neighbours.

## Still uncovered

How a pin change propagates into `build_carbon_balance()` output. That needs
seven raster env vars unset in a fresh checkout, which cannot come from
`~/.Renviron` because the repo's tracked `.Renviron` shadows it (#456).
Documented in the README and tracked in #559, which I'd leave open for it.

`lint_package()` clean, `air` formatted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TvvcyfcfaSxW9pywZsdvAY
