### PR TITLE
fix(tests): keep the last network-reading test out of r-universe and CRAN checks

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -346,6 +346,16 @@ Conventions of the codebase (follow them; they are how the code reads):
   that does turns an unrelated outage into a hard `R CMD check` ERROR (#490).
   Stub the reader with `testthat::local_mocked_bindings()` (43 call sites do
   this already) or use a fixture under `tests/testthat/fixtures/`.
+  - `skip_on_ci()` does **not** enforce this: r-universe runs its check without
+    `CI` set, so a `skip_on_ci()` test runs there for real. Use
+    `skip_on_cran()`, which fires wherever `NOT_CRAN` is unset (r-universe,
+    CRAN) while `r-lib/actions/setup-r` and `devtools::test()` both set it. A
+    real-data test that genuinely cannot be rescoped onto a fixture needs
+    **both**. Guarding on a local file or `WHEP_*` env var is equally fine —
+    that is what the LPJmL/HWSD/LUH2 smoke tests do.
+  - The `offline-tests` job is the enforcement, and it only sees these tests
+    because it unsets `CI`. If it fails alone, add a fixture — do not skip the
+    test and do not relax the job.
 - Access exported objects via `whep::name` — never `:::` or
   `getFromNamespace()` for something exported. Private helpers are tested
   directly as `whep:::.helper()`, which is the established practice. For

--- a/tests/testthat/test_select_best_source_aggregates.R
+++ b/tests/testthat/test_select_best_source_aggregates.R
@@ -77,6 +77,17 @@ testthat::test_that("values are quantities, not counts, at build scale", {
   # A guard on the property rather than on a fixture: after a real build the primary-source
   # magnitudes must be implausible as counts. Skipped where the pins are unavailable, and it is
   # the one test here that would have caught the defect from the outside.
+  #
+  # Reading the pins over the network is the whole point here, so this cannot be
+  # rescoped onto a fixture -- it is instead kept out of every automated check.
+  # `skip_on_ci()` alone does not do that: r-universe does not set `CI`, so this
+  # was the only test in the suite still fetching remote data during a check, and
+  # its download time (3 min CPU against 58 min wall clock) pushed r-universe's
+  # Windows job past its 60-minute cap. `skip_on_cran()` covers the check
+  # surfaces, because `NOT_CRAN` is unset on r-universe and on CRAN while
+  # `r-lib/actions/setup-r` and `devtools::test()` both set it -- so the test
+  # still runs locally and in offline-tests, where it belongs.
+  testthat::skip_on_cran()
   testthat::skip_on_ci()
   cbs <- tryCatch(
     suppressWarnings(suppressMessages(


### PR DESCRIPTION
Stops the last test that reads internet data from running during a check. This
is what has been failing r-universe since #521 fixed the OOM.

## Why r-universe keeps failing

r-universe's test phase reports **~3 minutes of CPU against ~58 minutes of wall
clock**. The suite is not slow — it spends most of an hour *waiting on the pin
host*. That crosses r-universe's 60-minute per-job cap, and it has started
timing jobs out at random:

| build | outcome |
| --- | --- |
| 11:09Z | 4 previously-OOMing jobs green (#521 worked); **Windows R-release timed out** at 59 min |
| 13:20Z | **three** jobs timed out — Linux R-devel, Windows R-release, macOS oldrel |

All `timed out`. None is the OOM that #521 fixed. Windows was never the issue —
whichever platform loses the race against the pin host fails.

## The cause

`test_select_best_source_aggregates.R`'s build-scale guard fetches the FAOSTAT
pins and builds production + CBS for 2015–2016. It was guarded only by
`skip_on_ci()` — and **r-universe runs its check without `CI` set**, so the
guard never fired there. It was the only test in the suite still reaching the
network during a check.

## The fix

This test's whole purpose is asserting a property of a *real* build — it is what
would have caught #425 from the outside — so it cannot be rescoped onto a
fixture. It is instead kept out of automated checks with `skip_on_cran()`, which
lands exactly where wanted:

| surface | `NOT_CRAN` | behaviour |
| --- | --- | --- |
| r-universe, CRAN | unset | **skips** (`Reason: On CRAN`) |
| your CI (`r-lib/actions/setup-r`) | `true` | unchanged |
| local `devtools::test()` | `true` | still runs |
| `offline-tests` | `true` | still runs, skips on `CBS pins unavailable` |

So it keeps its value as a real-data guard everywhere it had it, and stops
running where it was causing timeouts.

## The rest of the suite is clean

Swept rather than assumed — this genuinely was the only one:

- The other four `skip_on_ci()` sites are local-file guarded and documented as
  never fetching: `WHEP_LPJML_RUN_DIR`, `WHEP_HWSD_DIR`, LUH2 cache presence,
  real `states.nc` presence.
- The `read_luh2_landuse()` calls that look unguarded are mocked via
  `local_mocked_bindings(.luh2_read_states_source = ...)` — no Zenodo download.
- `test_input_files.R`'s remote-down test stubs `.check_remote_reachable`.

## CLAUDE.md

The rule *"the suite must never reach the network"* was already there. What was
missing is that `skip_on_ci()` does not enforce it — which is exactly how this
survived. The rule now names `skip_on_cran()`, says a real-data test that cannot
be rescoped needs **both**, and records that `offline-tests` only sees these
tests because it unsets `CI`.

## Verification

- `NOT_CRAN` unset + `CI` unset → skips, `Reason: On CRAN`.
- `NOT_CRAN=true` → runs, unchanged.
- Full suite offline (`CI=false`, dead proxy, empty pin cache):
  `FAIL 0 | WARN 10 | SKIP 13 | PASS 5613` in 113 s, with the test still reached
  and skipping on `CBS pins unavailable`.
- `air format .` no changes; `lintr` clean.

Expected effect on r-universe: elapsed drops from ~58 min to the few minutes of
real CPU, and the check becomes deterministic rather than a race against a
remote host.
