### PR TITLE
test(polities): guard the bucket-split invariant that #480 slipped past

### DIFF
--- a/tests/testthat/test_read_raw_inputs.R
+++ b/tests/testthat/test_read_raw_inputs.R
@@ -55,3 +55,50 @@ test_that(".aggregate_to_polities works without fao_flag", {
   expect_false("fao_flag" %in% names(result))
   expect_true("value" %in% names(result))
 })
+
+test_that("a bucket comes out of the aggregator under exactly one area label", {
+  # THE INVARIANT THAT VALUE-NEUTRALITY CHECKS CANNOT SEE (whep#563).
+  #
+  # `.aggregate_to_polities()` groups by `polity_name` as well as
+  # `polity_area_code`, and renames the pair to `area`/`area_code`. So a change
+  # that gives two members of one FABIO bucket different polities splits the
+  # bucket's rows WITHOUT moving any value: mass still conserves, the bucket keeps
+  # its members, `polity_area_code` is untouched, and every check anyone thought
+  # to run passes. What breaks is downstream -- `area` is a join key, four inner
+  # joins use `c("area", "area_code")`, and duplicate `(area_code, year, item)`
+  # keys are what fed the `dcast()` `length()` fallback in whep#425.
+  #
+  # PR whep#480 did exactly this and had to be reverted (whep#561): FAOSTAT area
+  # 212 Syria was un-folded onto `SYR-*` while keeping bucket 999, so
+  # `999 Rest of World 340` became `999 Syrian Arab Republic 300` plus
+  # `999 Rest of World 40`. 347 tonnes in, 347 tonnes out, and a split bucket.
+  #
+  # Areas 212 and 999 are the live pair: both carry `polity_area_code` 999 today.
+  raw <- tibble::tribble(
+    ~year, ~area_code, ~item_cbs_code, ~element,     ~unit,    ~value,
+    2010L, 212L,       2511,           "production", "tonnes", 300,
+    2010L, 999L,       2511,           "production", "tonnes", 40,
+    2010L, 40L,        2511,           "production", "tonnes", 7
+  )
+
+  out <- suppressWarnings(
+    whep:::.aggregate_to_polities(
+      data.table::as.data.table(raw),
+      item_cbs_code
+    )
+  )
+
+  # One label per bucket. This is the assertion the reverted change failed.
+  labels_per_code <- tapply(out$area, out$area_code, function(x) {
+    length(unique(x))
+  })
+  expect_true(all(labels_per_code == 1L))
+
+  # And the fold therefore SUMS rather than merely conserving.
+  expect_equal(nrow(out[out$area_code == 999L, ]), 1L)
+  expect_equal(sum(out$value[out$area_code == 999L]), 340)
+
+  # Mass conservation is asserted too, but note it holds either way -- which is
+  # precisely why it is not sufficient on its own.
+  expect_equal(sum(out$value), sum(raw$value))
+})


### PR DESCRIPTION
A regression guard for #563, added before merging the rest of the epic's open PRs, since it is the check whose absence let #480 reach `main`.

## What it asserts

**One `area_code` comes out of `.aggregate_to_polities()` under exactly one `area` label.**

`by_cols` groups by `polity_name` alongside `polity_area_code`, and the pair is renamed to `area`/`area_code`. So giving two members of one FABIO bucket different polities splits the bucket's rows without moving a value:

| before | after |
|---|---|
| `999  Rest of World  340` | `999  Syrian Arab Republic  300` |
| | `999  Rest of World       40` |

347 tonnes in, 347 tonnes out.

## Why nothing caught it

Mass conserved. The bucket kept its 62 members. `polity_area_code` was identical for all 266 reporting areas — I measured that twice. Every value-neutrality check passed, because the numeric bucket is what values are summed *into* while `area` is what they are grouped *by*.

It surfaced only because a sibling PR (#555) happened to assert that bucket 999 comes to 340. That is luck, not coverage.

The consequence is not hypothetical: `area` is a join key — four inner joins use `c("area", "area_code")`, which cost #382 **702,166 rows** — and duplicate `(area_code, year, item)` keys are what fed the `dcast()` `length()` fallback in #425.

## Verified load-bearing

Not assumed. Run against `polity/459`'s crosswalk the new test **fails**; against `main`'s it **passes**. A test that cannot fail on the bug it exists for is decoration.

Uses areas 212 and 999, the live pair sharing bucket 999 today. Mass conservation is asserted alongside, with a comment noting it holds either way — which is the point.

Part of the polity migration epic #458. Closes nothing; #563 stays open for the redesign.

🤖 Generated with [Claude Code](https://claude.com/claude-code)