### PR TITLE
feat(climate): fetch CRU pet, which the SOC drivers need

### DIFF
--- a/inst/scripts/download/download_climate.R
+++ b/inst/scripts/download/download_climate.R
@@ -25,10 +25,22 @@ CRU_TS_RELEASE <- list(
   last_year = 2024L
 )
 
-# The four variables LPJmL reads. CRU ships each as a separate file that also
-# carries stn/mae/maea diagnostics LPJmL never uses; the prepare step strips
-# them, which is where most of the size goes.
-CRU_TS_VARIABLES <- c("tmp", "pre", "cld", "wet")
+# The CRU variables this project needs. The first four are what LPJmL reads as
+# forcing; `pet` is not read by LPJmL at all, but `get_soc_climate_drivers()`
+# needs it alongside `tmp` for the soil-carbon moisture drivers, and fetching it
+# here is what keeps both in one directory from ONE release.
+#
+# Fetching it here also keeps the SOC drivers off the PREPARED climate files.
+# Those are gap-filled for LPJmL's grid (.fill_cru_grid_gaps(): "0 degrees C
+# over land is wrong, so borrow the nearest valid CRU cell"), which is right for
+# forcing the model and wrong as a climate observation -- the filled `tmp`
+# carries 67,440 finite land cells against raw CRU's 67,420. Point
+# WHEP_CRU_DIR at this raw directory, not at the prepared one.
+#
+# CRU ships each variable as a separate file that also carries stn/mae/maea
+# diagnostics nothing here uses; the prepare step strips them, which is where
+# most of the size goes.
+CRU_TS_VARIABLES <- c("tmp", "pre", "cld", "wet", "pet")
 
 # The two monthly wind artefacts, pinned because neither can be rebuilt from
 # this repo: the 1901-2019 base was assembled from ISIMIP2a chunks by a script


### PR DESCRIPTION
`get_soc_climate_drivers()` needs CRU **`pet`** alongside `tmp`, and nothing
downloaded it — so it could not run from a fresh setup at all. Adding it to
`CRU_TS_VARIABLES` puts both in one directory from one download.

`pet` is not read by LPJmL, so it's the first entry in that vector that isn't
model forcing. The comment says so now, since "the four variables LPJmL reads" no
longer describes it.

## Why this matters beyond availability

The only local file carrying `pet` sat in a *different directory* from the `tmp`
the production run used — and the two disagreed on the land mask. Chasing that
down turned up the actual trap:

**The prepared climate files are gap-filled for LPJmL's grid.**
`.fill_cru_grid_gaps()` — *"0 degrees C over land is wrong, so borrow the nearest
valid CRU cell"* — so the prepared `tmp` carries **67,440** finite land cells
against raw CRU's **67,420**. That is correct for forcing the model and wrong as a
climate observation, which is what the SOC drivers want.

I initially read the mismatch as CRU having re-released 4.09. It hasn't:
re-downloading `tmp` gives byte-identical statistics to the older copy (67,420
cells, month-1 mean −2.409291), so only the *prepared* file differs.

So the comment now tells the reader to point `WHEP_CRU_DIR` at this **raw**
directory rather than the prepared one.

## Verified

`pet` downloads and unpacks (1.5 GB), and `read_cru_climate()` resolves both `tmp`
and `pet` from the raw directory. `lint_package()` clean.

Follow-up to #456, which had to be fixed first — until then no `WHEP_*` path was
visible from a session started at the repo root, `WHEP_CRU_DIR` included.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TvvcyfcfaSxW9pywZsdvAY
