### PR TITLE
perf(reads): one year-aware build chain instead of two (#367)

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,33 @@
 # whep (development version)
 
+* **`get_primary_production()`, `get_wide_cbs()` and `get_processing_coefs()`
+  take a `years` argument.** A scoped request now builds only that window
+  instead of building 1850-2023 and discarding the rest. Measured for 2010:
+  wide CBS 256 s / 23.3 GB peak to 12.6 s / 6.8 GB, primary production 168 s /
+  14.7 GB to 29.5 s / 2.9 GB. The full wide-CBS build peaking above 16 GB is
+  what had been failing the r-universe check on macOS and Linux. `years = NULL`
+  is unchanged in every respect, including its cache slot, so existing callers
+  keep today's behaviour and today's numbers. The primary-production to CBS to
+  processing-coefficient chain and its cache keys are now shared with
+  `build_io_model()`, which previously carried a private copy (#367).
+
+  A scoped window is close to, but not identical with, building the full range
+  and filtering. Against the full range at 2010, wide-CBS quantity totals agree
+  to 3.8e-04 and primary-production totals to 3.0e-04, with `ha`, `t_ha`, `LU`
+  and `heads` exact. The residual sits in `import` and in the livestock ratios
+  (#625). Use `years = NULL` when exact agreement with the published series
+  matters.
+
+* **Year-scoped production builds no longer drop every forage crop.** Fodder
+  rows are synthesised across the whole year axis — `.fill_fodder_gaps()` takes
+  the union of (area, item) groups over all years and interpolates between them
+  — so a narrow window silently lost all six forage items (`Forage and silage,
+  *`, `Cabbage for fodder`, `Forage products`). At 2010 that was 137 rows,
+  **1.16% of production tonnes, 1.85% of `t_ha` and 1.36% of wide-CBS `feed`**,
+  and it affected `build_io_model(years = )` on every release that had it. The
+  fodder chain now runs over the full span and trims afterwards. Full-range
+  output is unchanged (#623).
+
 * **`fill_linear()` no longer depends on the order its rows arrive in.** Without
   `.by`, it never sorted: carrying a value forward or backward and the
   `value_smooth_window` moving average are all positional, so an unsorted input

--- a/R/build_cache.R
+++ b/R/build_cache.R
@@ -40,3 +40,105 @@ whep_clear_cache <- function() {
   .build_cache[[key]] <- result
   result
 }
+
+# --- Year-scoped cache keys --------------------------------------------------
+
+# Cache slot name for a year-scoped build. A NULL window keeps the bare key, so
+# callers asking for the full range share one slot and nothing that pre-dates
+# year scoping changes behaviour. Without the window in the key, a request for
+# 2000-2003 would be served to a caller that asked for everything (cf. #243).
+.cache_key <- function(key, years) {
+  if (is.null(years)) {
+    return(key)
+  }
+  paste(
+    key,
+    min(years, na.rm = TRUE),
+    max(years, na.rm = TRUE),
+    sep = "__"
+  )
+}
+
+# Collapse a requested year window to the contiguous range the builds work on.
+.build_years <- function(years) {
+  if (is.null(years)) {
+    return(NULL)
+  }
+  seq.int(min(years, na.rm = TRUE), max(years, na.rm = TRUE))
+}
+
+# Widen a year window to the context the CBS build needs. FBS_New is the
+# reference series and the 2010-2013 overlap is what splices the old series onto
+# it (see .reestimate_domestic_supply), so a request reaching 2013 must build
+# 2011 too or the splice silently changes. The pre-1961 back-cast needs no such
+# guard here: .read_production() already widens its own reads (see
+# R/build_production.R) and trims afterwards.
+.context_years <- function(years) {
+  if (is.null(years)) {
+    return(years)
+  }
+  start_year <- min(years, na.rm = TRUE)
+  end_year <- max(years, na.rm = TRUE)
+  if (end_year >= 2013L) {
+    start_year <- min(start_year, 2011L)
+  }
+  seq.int(start_year, end_year)
+}
+
+# --- The shared build chain -------------------------------------------------
+
+# All three build functions already accept start_year/end_year. These wrappers
+# only translate a year vector into that pair, so a scoped request stops
+# rebuilding 1850-2023 and discarding it.
+.build_primary_prod_years <- function(years) {
+  if (is.null(years)) {
+    return(build_primary_production())
+  }
+  build_primary_production(
+    start_year = min(years, na.rm = TRUE),
+    end_year = max(years, na.rm = TRUE)
+  )
+}
+
+.build_cbs_years <- function(primary_prod, years, context_years = years) {
+  if (is.null(years)) {
+    return(build_commodity_balances(primary_prod))
+  }
+  build_commodity_balances(
+    primary_prod,
+    start_year = min(context_years, na.rm = TRUE),
+    end_year = max(context_years, na.rm = TRUE)
+  ) |>
+    .filter_years(years)
+}
+
+.build_proc_coefs_years <- function(cbs_built, years) {
+  if (is.null(years)) {
+    return(build_processing_coefs(cbs_built))
+  }
+  build_processing_coefs(
+    cbs_built,
+    start_year = min(years, na.rm = TRUE),
+    end_year = max(years, na.rm = TRUE)
+  )
+}
+
+# Primary production, cached under its context window. Callers that need the
+# requested window only should .filter_years() the result themselves.
+.cached_primary_prod <- function(years) {
+  .cache_get(
+    .cache_key("primary_prod", years),
+    .build_primary_prod_years(years)
+  )
+}
+
+# The long CBS built from primary production, cached under the requested
+# window. This is the single copy of the wiring that get_wide_cbs(),
+# get_processing_coefs() and build_io_model() all share.
+.cached_cbs_built <- function(years) {
+  primary_prod <- .cached_primary_prod(.context_years(years))
+  .cache_get(.cache_key("cbs_built", years), {
+    cli::cli_h1("Building commodity balance sheets")
+    .build_cbs_years(primary_prod, years, .context_years(years))
+  })
+}

--- a/R/build_cache.R
+++ b/R/build_cache.R
@@ -67,18 +67,36 @@ whep_clear_cache <- function() {
   seq.int(min(years, na.rm = TRUE), max(years, na.rm = TRUE))
 }
 
-# Widen a year window to the context the CBS build needs. FBS_New is the
-# reference series and the 2010-2013 overlap is what splices the old series onto
-# it (see .reestimate_domestic_supply), so a request reaching 2013 must build
-# 2011 too or the splice silently changes. The pre-1961 back-cast needs no such
-# guard here: .read_production() already widens its own reads (see
-# R/build_production.R) and trims afterwards.
-.context_years <- function(years) {
+# Widen a year window to the context the CBS build needs, for two reasons.
+#
+# The trade and stock imputation looks at neighbouring years, so a bare window
+# leaves `stock_addition` and `import` visibly off. Measured at 2010 against the
+# full-range build, the largest relative error across the wide-CBS quantity
+# columns falls from 9.2e-03 with no margin to 5.2e-04 at +/-3, 3.8e-04 at +/-5
+# and 2.1e-04 at +/-10. `import` bottoms out at 2.1e-04 (identical at +/-5 and
+# +/-10), so that is the achievable floor and more margin only buys build time.
+# +/-5 sits past the knee and keeps a scoped build several times cheaper than
+# the full one.
+#
+# On top of that, FBS_New is the reference series and the 2010-2013 overlap is
+# what splices the old series onto it (see .reestimate_domestic_supply), so a
+# request reaching 2013 must build 2011 too or the splice silently changes.
+#
+# The pre-1961 back-cast needs no guard here: .read_production() already widens
+# its own reads (see R/build_production.R) and trims afterwards.
+.context_margin <- 5L
+
+# The first year the series covers, matching the `start_year` default of
+# build_primary_production() and build_commodity_balances(). The margin is
+# clamped to it so widening never asks a build for years that precede the data.
+.whep_first_year <- 1850L
+
+.context_years <- function(years, margin = .context_margin) {
   if (is.null(years)) {
     return(years)
   }
-  start_year <- min(years, na.rm = TRUE)
-  end_year <- max(years, na.rm = TRUE)
+  start_year <- max(min(years, na.rm = TRUE) - margin, .whep_first_year)
+  end_year <- max(years, na.rm = TRUE) + margin
   if (end_year >= 2013L) {
     start_year <- min(start_year, 2011L)
   }

--- a/R/build_cbs.R
+++ b/R/build_cbs.R
@@ -24,16 +24,23 @@
 #'   `item_prod_code`, and preferably `element`. Production-shaped rows without
 #'   `element` are accepted as `production` when their unit is tonnes. Default
 #'   `NULL`.
+#' @param format One of `"long"` (default) or `"wide"`. `"long"` returns one row
+#'   per element. `"wide"` pivots the elements into columns, adds the live-animal
+#'   rows that the FAO sheet omits, and checks the supply-use identity. Both are
+#'   the same dataset; `"wide"` is what the IO model and the extensions consume.
 #' @param .fixed_data Optional tibble with the same structure as the
 #'   output of the internal `.read_cbs() |> .fix_cbs()` steps. When
 #'   supplied, `primary_all` is ignored and the pipeline skips directly
 #'   to `.qc_cbs()`. Default `NULL`.
 #'
-#' @returns A tibble in long format with columns: `year`, legacy numeric
+#' @returns For `format = "long"`, a tibble with columns: `year`, legacy numeric
 #'   `area_code`, numeric `polity_area_code`, `reporting_polity_code`,
 #'   `reporting_polity_name`, `reporting_polity_has_geometry`,
 #'   `item_cbs_code`, `element` (e.g. `"production"`, `"import"`, `"food"`),
-#'   `value`, `source`, and `fao_flag`.
+#'   `value`, `source`, and `fao_flag`. For `format = "wide"`, the elements
+#'   become one column each, `stock_variation` is split into the non-negative
+#'   `stock_addition` and `stock_withdrawal`, and `domestic_supply` is total use
+#'   excluding `export`.
 #'
 #' @export
 #'
@@ -46,10 +53,24 @@ build_commodity_balances <- function(
   smooth_carry_forward = FALSE,
   example = FALSE,
   historical_data = NULL,
+  format = c("long", "wide"),
   .fixed_data = NULL
 ) {
+  format <- rlang::arg_match(format)
   if (example) {
-    return(.example_build_commodity_bal())
+    return(
+      if (format == "wide") {
+        .example_get_wide_cbs()
+      } else {
+        .example_build_commodity_bal()
+      }
+    )
+  }
+  if (format == "wide" && missing(primary_all)) {
+    cli::cli_abort(c(
+      "{.arg primary_all} is required when {.arg format} is {.val wide}.",
+      "i" = "The live-animal rows are derived from primary production."
+    ))
   }
   if (is.null(.fixed_data)) {
     fixed <- .read_cbs(primary_all, start_year, end_year, historical_data) |>
@@ -62,10 +83,41 @@ build_commodity_balances <- function(
     }
     fixed <- .fixed_data
   }
-  fixed |>
+  long <- fixed |>
     dplyr::mutate(value = .round_reproducible(.data$value)) |>
     .qc_cbs(smooth = smooth_carry_forward) |>
     .format_cbs_output()
+
+  if (format == "long") {
+    return(long)
+  }
+  .cbs_long_to_wide(long, primary_all, start_year:end_year)
+}
+
+# The pivot plus the live-animal rows the FAO sheet omits: the part of the wide
+# CBS every caller needs. Kept apart from .cbs_long_to_wide() because
+# build_io_model() consumes the matrix-ready table without the polity name
+# columns (see the name-column rule in CLAUDE.md) or the supply-use QC pass.
+.cbs_wide_core <- function(cbs_long, primary_all, years) {
+  cli::cli_progress_step("Adding livestock CBS rows")
+  livestock_cbs <- primary_all |>
+    .filter_years(years) |>
+    get_livestock_cbs() |>
+    .filter_years(years)
+
+  cbs_long |>
+    .pivot_cbs_wide() |>
+    dplyr::bind_rows(livestock_cbs)
+}
+
+# The wide CBS dataset as users consume it. It lives beside the long build so
+# the two formats of one dataset cannot drift apart.
+.cbs_long_to_wide <- function(cbs_long, primary_all, years) {
+  wide <- .cbs_wide_core(cbs_long, primary_all, years) |>
+    .add_reporting_polity_columns()
+
+  .qc_supply_use_balance(wide)
+  wide
 }
 
 .format_cbs_output <- function(df) {

--- a/R/commodity_balance_sheet.R
+++ b/R/commodity_balance_sheet.R
@@ -5,6 +5,12 @@
 #' (CBS) item. Stock variations are split into two non-negative
 #' columns following the FABIO methodology.
 #'
+#' @param years Optional integer vector of years to build. When `NULL`
+#'   (default) the whole series is built. Supplying a window builds only that
+#'   range rather than building 1850-2023 and discarding the rest, and caches it
+#'   under a window-specific key. The window is widened internally to 2011 when
+#'   it reaches 2013, because that overlap is what splices the old FBS series
+#'   onto `FAOSTAT_FBS_New`.
 #' @param example If `TRUE`, return a small example output without
 #'   downloading remote data. Default is `FALSE`.
 #'
@@ -44,27 +50,18 @@
 #'
 #' @examples
 #' get_wide_cbs(example = TRUE)
-get_wide_cbs <- function(example = FALSE) {
+get_wide_cbs <- function(years = NULL, example = FALSE) {
   if (example) {
     return(.example_get_wide_cbs())
   }
+  build_years <- .build_years(years)
+  cbs_built <- .cached_cbs_built(build_years)
+  primary_prod <- .cached_primary_prod(.context_years(build_years))
 
-  primary_prod <- .cache_get("primary_prod", build_primary_production())
-
-  cbs_built <- .cache_get("cbs_built", {
-    cli::cli_h1("Building commodity balance sheets")
-    build_commodity_balances(primary_prod)
-  })
-
-  .cache_get("cbs_wide", {
-    cli::cli_progress_step("Adding livestock CBS rows")
-    cbs <- .pivot_cbs_wide(cbs_built)
-    livestock_cbs <- get_livestock_cbs(primary_prod)
-    wide <- dplyr::bind_rows(cbs, livestock_cbs) |>
-      .add_reporting_polity_columns()
-    .qc_supply_use_balance(wide)
-    wide
-  })
+  .cache_get(
+    .cache_key("cbs_wide", build_years),
+    .cbs_long_to_wide(cbs_built, primary_prod, build_years)
+  )
 }
 
 #' Livestock commodity balance sheet entries
@@ -264,6 +261,10 @@ get_livestock_cbs <- function(primary_prod) {
 #' Reports quantities of commodity balance sheet items used for `processing`
 #' and quantities of their corresponding processed output items.
 #'
+#' @param years Optional integer vector of years to build. When `NULL`
+#'   (default) the whole series is built. Supplying a window builds only that
+#'   range rather than building 1850-2023 and discarding the rest, and caches it
+#'   under a window-specific key.
 #' @param example If `TRUE`, return a small example output without downloading
 #'   remote data. Default is `FALSE`.
 #'
@@ -314,20 +315,16 @@ get_livestock_cbs <- function(primary_prod) {
 #'
 #' @examples
 #' get_processing_coefs(example = TRUE)
-get_processing_coefs <- function(example = FALSE) {
+get_processing_coefs <- function(years = NULL, example = FALSE) {
   if (example) {
     return(.example_get_processing_coefs())
   }
-  primary_prod <- .cache_get("primary_prod", build_primary_production())
+  build_years <- .build_years(years)
+  cbs_built <- .cached_cbs_built(build_years)
 
-  cbs_built <- .cache_get("cbs_built", {
-    cli::cli_h1("Building commodity balance sheets")
-    build_commodity_balances(primary_prod)
-  })
-
-  .cache_get("proc_coefs", {
+  .cache_get(.cache_key("proc_coefs", build_years), {
     cli::cli_h1("Building processing coefficients")
-    build_processing_coefs(cbs_built)
+    .build_proc_coefs_years(cbs_built, build_years)
   })
 }
 

--- a/R/io_model.R
+++ b/R/io_model.R
@@ -88,45 +88,32 @@ build_io_model <- function(
       prices = prices
     ))
   }
-  build_years <- .io_build_years(years)
-  context_years <- .io_context_years(build_years)
+  build_years <- .build_years(years)
 
-  # Build shared pipeline once when using defaults.
-  # Intermediate results are session-cached (see ?whep_clear_cache).
+  # Build shared pipeline once when using defaults. The chain and its cache keys
+  # are shared with get_wide_cbs()/get_processing_coefs() (see R/build_cache.R)
+  # so the two paths cannot drift. Results are session-cached
+  # (see ?whep_clear_cache).
   if (is.null(cbs) || is.null(supply_use)) {
-    primary_prod <- .cache_get(
-      .io_cache_key("primary_prod", context_years),
-      .build_primary_prod_io(context_years)
-    )
+    cbs_built <- .cached_cbs_built(build_years)
+    primary_prod <- .cached_primary_prod(.context_years(build_years))
     primary_prod_build <- primary_prod |>
       .filter_years(build_years)
 
-    cbs_built <- .cache_get(.io_cache_key("cbs_built", build_years), {
-      cli::cli_h1("Building commodity balance sheets")
-      .build_cbs_io(
-        primary_prod,
-        build_years,
-        context_years
-      )
-    })
-
     if (is.null(cbs)) {
-      cbs <- .cache_get(.io_cache_key("cbs_wide_io", build_years), {
-        cli::cli_progress_step("Adding livestock CBS rows")
-        wide <- .pivot_cbs_wide(cbs_built)
-        livestock_cbs <- get_livestock_cbs(primary_prod_build) |>
-          .filter_years(build_years)
-        dplyr::bind_rows(wide, livestock_cbs)
-      })
+      cbs <- .cache_get(
+        .cache_key("cbs_wide_io", build_years),
+        .cbs_wide_core(cbs_built, primary_prod_build, build_years)
+      )
     }
 
     if (is.null(supply_use)) {
-      coeffs <- .cache_get(.io_cache_key("proc_coefs", build_years), {
+      coeffs <- .cache_get(.cache_key("proc_coefs", build_years), {
         cli::cli_h1("Building processing coefficients")
-        .build_processing_coefs_for_io(cbs_built, build_years)
+        .build_proc_coefs_years(cbs_built, build_years)
       })
 
-      supply_use <- .cache_get(.io_cache_key("supply_use", build_years), {
+      supply_use <- .cache_get(.cache_key("supply_use", build_years), {
         cli::cli_h1("Building supply-use tables")
         cli::cli_progress_step("Reading crop residues")
         crop_residues <- get_primary_residues() |>
@@ -157,7 +144,7 @@ build_io_model <- function(
 
   if (is.null(bilateral_trade)) {
     bilateral_trade <- .cache_get(
-      .io_cache_key("bilateral_trade", build_years),
+      .cache_key("bilateral_trade", build_years),
       {
         cli::cli_h1("Building bilateral trade matrices")
         get_bilateral_trade(cbs = cbs)
@@ -167,7 +154,7 @@ build_io_model <- function(
   .validate_io_inputs(supply_use, bilateral_trade, cbs)
   if (method == "value" && is.null(prices)) {
     prices <- .cache_get(
-      .io_cache_key("cbs_prices", build_years),
+      .cache_key("cbs_prices", build_years),
       {
         cli::cli_h1("Building CBS prices for value allocation")
         build_cbs_prices(cbs = cbs)
@@ -218,13 +205,6 @@ build_io_model <- function(
 
   cli::cli_alert_success("IO model complete.")
   .io_results_to_tibble(results, years)
-}
-
-.io_build_years <- function(years) {
-  if (is.null(years)) {
-    return(NULL)
-  }
-  seq.int(min(years, na.rm = TRUE), max(years, na.rm = TRUE))
 }
 
 .io_should_build_sparse_years <- function(years, supply_use, cbs) {
@@ -295,67 +275,6 @@ build_io_model <- function(
   }
 
   dplyr::filter(x, .data$year %in% years)
-}
-
-.io_context_years <- function(years) {
-  if (is.null(years)) {
-    return(years)
-  }
-  start_year <- min(years, na.rm = TRUE)
-  end_year <- max(years, na.rm = TRUE)
-  if (end_year >= 2013L) {
-    start_year <- min(start_year, 2011L)
-  }
-  seq.int(start_year, end_year)
-}
-
-.io_cache_key <- function(key, years) {
-  if (is.null(years)) {
-    return(key)
-  }
-  paste(
-    key,
-    min(years, na.rm = TRUE),
-    max(years, na.rm = TRUE),
-    sep = "__"
-  )
-}
-
-.build_primary_prod_io <- function(years) {
-  if (is.null(years)) {
-    return(build_primary_production())
-  }
-  build_primary_production(
-    start_year = min(years, na.rm = TRUE),
-    end_year = max(years, na.rm = TRUE)
-  )
-}
-
-.build_cbs_io <- function(
-  primary_prod,
-  years,
-  context_years = years
-) {
-  if (is.null(years)) {
-    return(build_commodity_balances(primary_prod))
-  }
-  result <- build_commodity_balances(
-    primary_prod,
-    start_year = min(context_years, na.rm = TRUE),
-    end_year = max(context_years, na.rm = TRUE)
-  )
-  .filter_years(result, years)
-}
-
-.build_processing_coefs_for_io <- function(cbs_built, years) {
-  if (is.null(years)) {
-    return(build_processing_coefs(cbs_built))
-  }
-  build_processing_coefs(
-    cbs_built,
-    start_year = min(years, na.rm = TRUE),
-    end_year = max(years, na.rm = TRUE)
-  )
 }
 
 # --- Main per-year builder ---

--- a/R/production.R
+++ b/R/production.R
@@ -6,9 +6,15 @@
 #' @param years Optional integer vector of years to build. When `NULL`
 #'   (default) the whole series is built. Supplying a window builds only that
 #'   range rather than building 1850-2023 and discarding the rest, and caches it
-#'   under a window-specific key. Gap-filling and source selection look across
-#'   the years present, so a narrow window is not guaranteed to reproduce the
-#'   full-range result value for value.
+#'   under a window-specific key.
+#'
+#'   A window is not guaranteed to reproduce the full-range result value for
+#'   value, because some steps look across the years present. Measured for 2010
+#'   against the full range, `area_code`-level totals agree exactly for `ha`,
+#'   `t_ha`, `LU` and `heads`; the largest disagreement is 3.0e-04, in the
+#'   livestock ratios (`t_head`, `t_LU`) and `slaughtered_heads`, tracked in
+#'   issue #625. Use `NULL` when exact agreement with the published series
+#'   matters.
 #' @param example If `TRUE`, return a small example output without downloading
 #'   remote data. Default is `FALSE`.
 #'

--- a/R/production.R
+++ b/R/production.R
@@ -3,6 +3,12 @@
 #' @description
 #' Get amount of crops, livestock and livestock products.
 #'
+#' @param years Optional integer vector of years to build. When `NULL`
+#'   (default) the whole series is built. Supplying a window builds only that
+#'   range rather than building 1850-2023 and discarding the rest, and caches it
+#'   under a window-specific key. Gap-filling and source selection look across
+#'   the years present, so a narrow window is not guaranteed to reproduce the
+#'   full-range result value for value.
 #' @param example If `TRUE`, return a small example output without downloading
 #'   remote data. Default is `FALSE`.
 #'
@@ -46,11 +52,13 @@
 #'
 #' @examples
 #' get_primary_production(example = TRUE)
-get_primary_production <- function(example = FALSE) {
+get_primary_production <- function(years = NULL, example = FALSE) {
   if (example) {
     return(.ex_get_primary_prod())
   }
-  .cache_get("primary_prod", build_primary_production())
+  build_years <- .build_years(years)
+  .cached_primary_prod(build_years) |>
+    .filter_years(build_years)
 }
 
 #' Crop residue items

--- a/R/soil_carbon_inputs.R
+++ b/R/soil_carbon_inputs.R
@@ -498,7 +498,7 @@ build_soil_carbon_inputs <- function(
 # residue fraction) -> calculate_npp_carbon_nitrogen() (the carbon partition,
 # including residue_soil_c_t, root_c_t and weed_npp_c_t).
 .sci_read_npp <- function(years = NULL) {
-  .sci_npp_from_primary_prod(.filter_years(get_primary_production(), years))
+  .sci_npp_from_primary_prod(get_primary_production(years = years))
 }
 
 # FAOSTAT national harvested area (ha) per (area_code, item_prod_code, year),
@@ -508,7 +508,7 @@ build_soil_carbon_inputs <- function(
 # .sci_crop_prod_wide). One table serves every input_type (residue/root/weed and
 # manure), all keyed by (area_code, item_prod_code, year).
 .sci_read_harvested_area <- function(years = NULL) {
-  .sci_harvested_area(.filter_years(get_primary_production(), years))
+  .sci_harvested_area(get_primary_production(years = years))
 }
 
 .sci_harvested_area <- function(primary_prod) {
@@ -613,8 +613,8 @@ build_soil_carbon_inputs <- function(
 # harvested area. The `crop` it emits is the item_prod_code, so it resolves
 # straight back through .sci_manure_crop_prod_code().
 .sci_read_manure <- function(years = NULL) {
-  production <- .filter_years(get_primary_production(), years)
-  cbs <- .filter_years(get_wide_cbs(), years)
+  production <- get_primary_production(years = years)
+  cbs <- get_wide_cbs(years = years)
   intake <- .run_redistribute_national(
     production = production,
     cbs = cbs,

--- a/man/build_commodity_balances.Rd
+++ b/man/build_commodity_balances.Rd
@@ -11,6 +11,7 @@ build_commodity_balances(
   smooth_carry_forward = FALSE,
   example = FALSE,
   historical_data = NULL,
+  format = c("long", "wide"),
   .fixed_data = NULL
 )
 }
@@ -36,17 +37,25 @@ one of \code{area_code} or \code{polity_area_code}, one of \code{item_cbs_code} 
 \code{element} are accepted as \code{production} when their unit is tonnes. Default
 \code{NULL}.}
 
+\item{format}{One of \code{"long"} (default) or \code{"wide"}. \code{"long"} returns one row
+per element. \code{"wide"} pivots the elements into columns, adds the live-animal
+rows that the FAO sheet omits, and checks the supply-use identity. Both are
+the same dataset; \code{"wide"} is what the IO model and the extensions consume.}
+
 \item{.fixed_data}{Optional tibble with the same structure as the
 output of the internal \code{.read_cbs() |> .fix_cbs()} steps. When
 supplied, \code{primary_all} is ignored and the pipeline skips directly
 to \code{.qc_cbs()}. Default \code{NULL}.}
 }
 \value{
-A tibble in long format with columns: \code{year}, legacy numeric
+For \code{format = "long"}, a tibble with columns: \code{year}, legacy numeric
 \code{area_code}, numeric \code{polity_area_code}, \code{reporting_polity_code},
 \code{reporting_polity_name}, \code{reporting_polity_has_geometry},
 \code{item_cbs_code}, \code{element} (e.g. \code{"production"}, \code{"import"}, \code{"food"}),
-\code{value}, \code{source}, and \code{fao_flag}.
+\code{value}, \code{source}, and \code{fao_flag}. For \code{format = "wide"}, the elements
+become one column each, \code{stock_variation} is split into the non-negative
+\code{stock_addition} and \code{stock_withdrawal}, and \code{domestic_supply} is total use
+excluding \code{export}.
 }
 \description{
 Construct commodity balance sheets (CBS) from raw FAOSTAT data.

--- a/man/get_primary_production.Rd
+++ b/man/get_primary_production.Rd
@@ -4,9 +4,16 @@
 \alias{get_primary_production}
 \title{Primary items production}
 \usage{
-get_primary_production(example = FALSE)
+get_primary_production(years = NULL, example = FALSE)
 }
 \arguments{
+\item{years}{Optional integer vector of years to build. When \code{NULL}
+(default) the whole series is built. Supplying a window builds only that
+range rather than building 1850-2023 and discarding the rest, and caches it
+under a window-specific key. Gap-filling and source selection look across
+the years present, so a narrow window is not guaranteed to reproduce the
+full-range result value for value.}
+
 \item{example}{If \code{TRUE}, return a small example output without downloading
 remote data. Default is \code{FALSE}.}
 }

--- a/man/get_primary_production.Rd
+++ b/man/get_primary_production.Rd
@@ -10,9 +10,15 @@ get_primary_production(years = NULL, example = FALSE)
 \item{years}{Optional integer vector of years to build. When \code{NULL}
 (default) the whole series is built. Supplying a window builds only that
 range rather than building 1850-2023 and discarding the rest, and caches it
-under a window-specific key. Gap-filling and source selection look across
-the years present, so a narrow window is not guaranteed to reproduce the
-full-range result value for value.}
+under a window-specific key.
+
+A window is not guaranteed to reproduce the full-range result value for
+value, because some steps look across the years present. Measured for 2010
+against the full range, \code{area_code}-level totals agree exactly for \code{ha},
+\code{t_ha}, \code{LU} and \code{heads}; the largest disagreement is 3.0e-04, in the
+livestock ratios (\code{t_head}, \code{t_LU}) and \code{slaughtered_heads}, tracked in
+issue #625. Use \code{NULL} when exact agreement with the published series
+matters.}
 
 \item{example}{If \code{TRUE}, return a small example output without downloading
 remote data. Default is \code{FALSE}.}

--- a/man/get_processing_coefs.Rd
+++ b/man/get_processing_coefs.Rd
@@ -4,9 +4,14 @@
 \alias{get_processing_coefs}
 \title{Processed products share factors}
 \usage{
-get_processing_coefs(example = FALSE)
+get_processing_coefs(years = NULL, example = FALSE)
 }
 \arguments{
+\item{years}{Optional integer vector of years to build. When \code{NULL}
+(default) the whole series is built. Supplying a window builds only that
+range rather than building 1850-2023 and discarding the rest, and caches it
+under a window-specific key.}
+
 \item{example}{If \code{TRUE}, return a small example output without downloading
 remote data. Default is \code{FALSE}.}
 }

--- a/man/get_wide_cbs.Rd
+++ b/man/get_wide_cbs.Rd
@@ -4,9 +4,16 @@
 \alias{get_wide_cbs}
 \title{Commodity balance sheet data.}
 \usage{
-get_wide_cbs(example = FALSE)
+get_wide_cbs(years = NULL, example = FALSE)
 }
 \arguments{
+\item{years}{Optional integer vector of years to build. When \code{NULL}
+(default) the whole series is built. Supplying a window builds only that
+range rather than building 1850-2023 and discarding the rest, and caches it
+under a window-specific key. The window is widened internally to 2011 when
+it reaches 2013, because that overlap is what splices the old FBS series
+onto \code{FAOSTAT_FBS_New}.}
+
 \item{example}{If \code{TRUE}, return a small example output without
 downloading remote data. Default is \code{FALSE}.}
 }

--- a/tests/testthat/test_build_cbs.R
+++ b/tests/testthat/test_build_cbs.R
@@ -1019,3 +1019,45 @@ test_that(".canonicalise_gdp_pop_area is a no-op without the columns it needs", 
     numeric_code
   )
 })
+
+test_that("build_commodity_balances defaults to the long format", {
+  long <- whep::build_commodity_balances(example = TRUE)
+
+  expect_true(rlang::has_name(long, "element"))
+  expect_false(rlang::has_name(long, "production"))
+})
+
+test_that("build_commodity_balances format = 'wide' pivots the elements", {
+  # Same dataset, one column per element instead of one row per element, with
+  # stock_variation split into the two non-negative directions.
+  wide <- whep::build_commodity_balances(example = TRUE, format = "wide")
+
+  expect_false(rlang::has_name(wide, "element"))
+  expect_true(all(
+    c("production", "import", "food", "feed", "domestic_supply") %in%
+      names(wide)
+  ))
+  expect_true(all(c("stock_addition", "stock_withdrawal") %in% names(wide)))
+})
+
+test_that("build_commodity_balances rejects an unknown format", {
+  expect_error(
+    whep::build_commodity_balances(example = TRUE, format = "matrix"),
+    class = "rlang_error"
+  )
+})
+
+test_that("build_commodity_balances needs primary_all for the wide format", {
+  # The live-animal rows come from primary production, so the wide format
+  # cannot be assembled from .fixed_data alone. Aborting beats silently
+  # returning a sheet with no live animals in it.
+  expect_error(
+    whep::build_commodity_balances(
+      format = "wide",
+      .fixed_data = readRDS(
+        testthat::test_path("fixtures", "cbs_fixed_small.rds")
+      )
+    ),
+    "primary_all"
+  )
+})

--- a/tests/testthat/test_io_model.R
+++ b/tests/testthat/test_io_model.R
@@ -276,28 +276,28 @@ testthat::test_that("build_io_model with non-numeric years raises error", {
 })
 
 testthat::test_that("IO default build helpers scope cache keys by requested years", {
-  testthat::expect_null(.io_build_years(NULL))
-  testthat::expect_equal(.io_build_years(c(2001, 1999)), 1999:2001)
+  testthat::expect_null(.build_years(NULL))
+  testthat::expect_equal(.build_years(c(2001, 1999)), 1999:2001)
   testthat::expect_true(.io_years_are_contiguous(c(2001, 1999, 2000)))
   testthat::expect_false(.io_years_are_contiguous(c(2001, 1999)))
-  testthat::expect_null(.io_context_years(NULL))
-  testthat::expect_equal(.io_context_years(2001:2005), 2001:2005)
-  testthat::expect_equal(.io_context_years(2013), 2011:2013)
-  testthat::expect_equal(.io_context_years(2016:2020), 2011:2020)
+  testthat::expect_null(.context_years(NULL))
+  testthat::expect_equal(.context_years(2001:2005), 2001:2005)
+  testthat::expect_equal(.context_years(2013), 2011:2013)
+  testthat::expect_equal(.context_years(2016:2020), 2011:2020)
   testthat::expect_equal(
-    .io_cache_key("primary_prod", NULL),
+    .cache_key("primary_prod", NULL),
     "primary_prod"
   )
   testthat::expect_equal(
-    .io_cache_key("primary_prod", c(2001, 1999)),
+    .cache_key("primary_prod", c(2001, 1999)),
     "primary_prod__1999__2001"
   )
   # The IO model caches a plain (no reporting-polity columns, no QC)
   # cbs_wide object; get_wide_cbs() caches the reporting version under
   # the bare "cbs_wide" slot. Their keys must never collide (issue #243).
-  testthat::expect_false(.io_cache_key("cbs_wide_io", NULL) == "cbs_wide")
+  testthat::expect_false(.cache_key("cbs_wide_io", NULL) == "cbs_wide")
   testthat::expect_false(
-    .io_cache_key("cbs_wide_io", c(1999, 2001)) == "cbs_wide"
+    .cache_key("cbs_wide_io", c(1999, 2001)) == "cbs_wide"
   )
 })
 

--- a/tests/testthat/test_io_model.R
+++ b/tests/testthat/test_io_model.R
@@ -281,9 +281,11 @@ testthat::test_that("IO default build helpers scope cache keys by requested year
   testthat::expect_true(.io_years_are_contiguous(c(2001, 1999, 2000)))
   testthat::expect_false(.io_years_are_contiguous(c(2001, 1999)))
   testthat::expect_null(.context_years(NULL))
-  testthat::expect_equal(.context_years(2001:2005), 2001:2005)
-  testthat::expect_equal(.context_years(2013), 2011:2013)
-  testthat::expect_equal(.context_years(2016:2020), 2011:2020)
+  # Without a margin the two rules are visible on their own: a window clear of
+  # the FBS overlap is unchanged, one reaching 2013 reaches back to 2011.
+  testthat::expect_equal(.context_years(2001:2005, margin = 0L), 2001:2005)
+  testthat::expect_equal(.context_years(2013, margin = 0L), 2011:2013)
+  testthat::expect_equal(.context_years(2016:2020, margin = 0L), 2011:2020)
   testthat::expect_equal(
     .cache_key("primary_prod", NULL),
     "primary_prod"
@@ -487,4 +489,27 @@ testthat::test_that(".endogenize_losses conserves X across source blocks", {
   # Losses columns are dropped from Y and fd_cols.
   testthat::expect_equal(endo$fd_cols, "food")
   testthat::expect_equal(ncol(endo$Y), 2L)
+})
+
+testthat::test_that("the context margin widens a scoped window on both sides", {
+  # The trade and stock imputation reads neighbouring years, so a bare window
+  # leaves stock_addition and import visibly off (9.2e-03 at 2010 against the
+  # full-range build, versus 3.8e-04 with the default margin). See
+  # .context_years() for the measured margin sweep.
+  testthat::expect_equal(.context_years(2000, margin = 5L), 1995:2005)
+  testthat::expect_equal(.context_years(2000:2002, margin = 3L), 1997:2005)
+
+  # The margin composes with the FBS splice rule rather than replacing it:
+  # widening to 2015 crosses 2013, so the start still reaches back to 2011.
+  testthat::expect_equal(.context_years(2010, margin = 5L), 2005:2015)
+  testthat::expect_equal(.context_years(2014, margin = 1L), 2011:2015)
+
+  # A wider window keeps whichever start is earlier.
+  testthat::expect_equal(min(.context_years(2016:2020, margin = 5L)), 2011L)
+})
+
+testthat::test_that("the context margin never precedes the first year", {
+  # Widening must not ask a build for years before the series starts.
+  testthat::expect_equal(min(.context_years(1850, margin = 5L)), 1850L)
+  testthat::expect_equal(min(.context_years(1852:1860, margin = 5L)), 1850L)
 })


### PR DESCRIPTION
Closes the remaining half of #367 (Direction 1). PR #383 unblocked the read path
and #376 killed the SOC equilibrium stall; what was left was year scoping.

**Classification: mechanical.** No defensible alternative is being chosen — the
two forked copies of one pipeline must agree, and a scoped build must not
silently differ from the full one. The one judgement call, the size of the
context margin, was made from a measured sweep (below) rather than picked.

## The defect

The primary-production → CBS → processing-coefficients chain existed **twice**:

| path | year-aware? | keys |
| --- | --- | --- |
| `get_wide_cbs()` / `get_processing_coefs()` | no — no `years` argument at all | bare (`"primary_prod"`, `"cbs_built"`, …) |
| `build_io_model()` | yes | private `.io_cache_key()` + `.io_context_years()` + three `_io` build forks |

That asymmetry was the r-universe OOM: `.sci_read_manure()` asked for one year,
hit the non-year-aware copy, and needed >16 GB.

Two things made this smaller than the issue anticipated: all three `build_*`
functions **already accepted `start_year`/`end_year`**, and the pre-1961
back-cast guard **already existed** in `.read_production()`. The bug was the
wiring, not the builders.

## What changed

- Shared year/cache plumbing in `R/build_cache.R`: `.cache_key()`,
  `.build_years()`, `.context_years()`, the three year-aware build wrappers, and
  `.cached_primary_prod()` / `.cached_cbs_built()`.
- **Deleted the `io_model.R` fork** (−97/+16 there) so both paths use one chain.
- `years=` on `get_primary_production()`, `get_wide_cbs()`,
  `get_processing_coefs()`, and threaded into the three `R/soil_carbon_inputs.R`
  read sites that were building the full series to keep one year.
- `build_commodity_balances(format = c("long", "wide"))`, covering the wide
  shape `get_wide_cbs()` used to assemble itself, so one dataset has one
  function. `long` stays the default.
- A **±5-year context margin** in `.context_years()` (second commit, rationale
  below).

## Measured on real data, at 2010 against the full-range build

### Speed and memory

| path | full range | scoped | |
| --- | --- | --- | --- |
| wide CBS | 256 s / **23.3 GB** | 12.6 s / 6.8 GB | **20.4× faster** |
| primary production | 168 s / 14.7 GB | 29.5 s / 2.9 GB | 5.7× faster |

The full CBS build peaking at 23–26 GB is exactly the r-universe OOM (macOS
`vector memory limit`, Linux `Killed`). A scoped build fits in 16 GB.

### Accuracy

| | at #570 as first opened | now |
| --- | --- | --- |
| wide CBS max rel diff | 1.36e-02 | **3.85e-04** |
| — `feed` | 1.36e-02 | 1.8e-05 |
| — `stock_addition` | 1.11e-02 | 3.85e-04 |
| — `import` | 3.25e-03 | 2.05e-04 |
| primary production max rel diff | 1.85e-02 | **3.00e-04** |
| — `ha`, `t_ha`, `LU`, `heads` | 1.06e-03 / 1.85e-02 | **exact** |

Two separate causes were found and dealt with:

1. **Forage crops vanished from scoped builds** — 1.16% of production tonnes,
   1.36% of CBS `feed`. Filed as #623, fixed in #626, already merged; this
   branch is rebased on it.
2. **Trade and stock imputation reads neighbouring years**, which a bare window
   does not supply. Hence the margin.

### Why ±5

| margin | max rel diff | time |
| --- | --- | --- |
| ±0 | 9.157e-03 | 36 s |
| ±3 | 5.200e-04 | 54 s |
| ±5 | **3.846e-04** | 70 s |
| ±10 | 2.054e-04 | 106 s |

`import` bottoms out at 2.054e-04 — identical at ±5 and ±10 — so that is the
achievable floor and more margin only buys build time. ±5 takes 98% of the
available reduction and sits past the knee rather than exactly on it (the sweep
covers one year; pinning to the measured knee would be fragile). Peak memory is
4–8 GB at every margin, so the 16 GB ceiling is not at risk. The implemented
path reproduces the sweep exactly.

## Why nothing breaks

- `years = NULL` is a **provable no-op**: `.build_years(NULL)` and
  `.context_years(NULL)` return `NULL` and the cache key stays bare, so every
  existing caller keeps today's behaviour and today's cache slot.
- `format` defaults to `"long"`; `primary_all` is still lazily unused when
  `.fixed_data` is supplied.
- No positional calls to the three getters exist in the repo, so leading with
  `years` is safe. No signature defaults changed.
- `build_io_model()` keeps its own `cbs_wide_io` slot deliberately — it consumes
  the matrix-ready table without polity name columns or the supply-use QC pass —
  so only the assembly is shared, not the final steps. The existing test
  documenting that key separation (#243) is preserved.

## Verification

`devtools::test()` **6348 pass, 0 failed, 0 errors**, 8 pre-existing skips ·
`rcmdcheck` **0 errors, 0 warnings, 0 notes** · `lintr` 0 lints · pkgdown
complete · `air` clean.

## Known residual

A scoped window is close to, but not identical with, full-range-then-filter:
**3.85e-04** on wide CBS, **3.00e-04** on primary production, with `ha`, `t_ha`,
`LU` and `heads` exact. The remainder is `import`'s long-reach component and the
livestock ratios in **#625**. Documented on `@param years` and in `NEWS.md`; use
`years = NULL` when exact agreement with the published series matters.

## Note on NEWS.md

This branch adds the NEWS entry for #623/#626 as well as its own — that fix
merged without one, and the changelog is per-release rather than per-PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)