### PR TITLE
Source mueller's legacy ISO repairs from the published alias map (#494)

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,15 @@
 # whep (development version)
 
+* `inst/scripts/prepare_spatialize_all.R` no longer repairs
+  `mueller_synthetic_n`'s FAO-style legacy ISO codes with a hand-maintained
+  14-entry `recode()` list. The mapping now comes from
+  `whep::polity_label_aliases` through `resolve_polity_label()`, bridged back to
+  the country grid's numeric `area_code` through the polity's `iso3_code` and the
+  same `regions.csv` lookup the grid is rasterised from. **No published values
+  change**: the resulting `crop_synthetic` table is byte-identical, 5,043 rows
+  resolving to the same 156 area codes with a maximum rate difference of 0. Four
+  of the 14 list entries (`BHA`, `BAR`, `DMI`, `STL`) named codes the dataset
+  never uses.
 * `polities` and `polity_area_crosswalk` are re-synced against upstream
   `whep-polities` at `eb02dcb` (740 rows to **749**), which retired or superseded
   **14** codes this package had been treating as live and published a replacement

--- a/inst/scripts/prepare_spatialize_all.R
+++ b/inst/scripts/prepare_spatialize_all.R
@@ -884,6 +884,68 @@ cft_to_pft <- c(
   lookup[!duplicated(lookup$iso3c), ]
 }
 
+# Resolve a reference dataset's own country labels to the grid's `area_code`.
+#
+# The reference N datasets name countries in their own vocabulary, so each one
+# used to carry its own repair list in this script. `resolve_polity_label()`
+# decides those labels against `whep::polity_label_aliases`, the map published
+# by whep-polities, so the decision lives upstream instead of being re-stated
+# here (#494).
+#
+# THE RESOLVER ANSWERS A POLITY AND THIS SCRIPT IS KEYED ON AN AREA, so the
+# answer has to be bridged back, and WHICH bridge is not a free choice.
+# `polity_area_crosswalk$polity_area_code` is a different code space from the
+# one the grid carries: it holds 206 "Sudan (former)" where `regions.csv` holds
+# 276, and Ethiopia's two FAOSTAT areas (62 and 238) both sit under 238. Neither
+# 206 nor 62 is a code any grid cell has, so bridging through it would attach
+# Sudan's rates to cells that do not exist. The bridge therefore goes through
+# the polity's own `iso3_code` and back through the SAME iso3c -> area_code
+# table the grid is rasterised from, which is a relabelling of the join this
+# script already did rather than a change of code space.
+#
+# `area_lookup` is any data frame carrying `iso3c` and `area_code`; pass the
+# same one the caller joins with.
+.spatialize_label_area_code <- function(label, source, year, area_lookup) {
+  keys <- unique(data.frame(
+    label = as.character(label),
+    year = as.integer(year),
+    stringsAsFactors = FALSE
+  ))
+  polity <- whep::resolve_polity_label(
+    keys$label,
+    source = source,
+    year = keys$year
+  )
+  # `match()` treats NA as a value, so an unresolved label would otherwise pick
+  # up whatever row happens to carry an NA key. An unresolved label must stay
+  # unresolved through both hops.
+  iso <- .lookup_no_na(
+    polity,
+    whep::polities$polity_code,
+    whep::polities$iso3_code
+  )
+  area <- .lookup_no_na(iso, area_lookup$iso3c, area_lookup$area_code)
+  area[match(
+    paste(as.character(label), as.integer(year)),
+    paste(keys$label, keys$year)
+  )]
+}
+
+# `match()` with `NA` on either side, made to answer NA.
+.lookup_no_na <- function(x, from, to) {
+  hit <- match(x, from)
+  hit[is.na(x)] <- NA_integer_
+  to[hit]
+}
+
+# Mueller et al. (2012) publish crop-specific fertiliser application rates
+# "circa 2000" (Nature 490:254-257, doi:10.1038/nature11420; the archived
+# rasters are Zenodo record 5260732), and `whep::mueller_synthetic_n` carries no
+# year of its own. The year is load-bearing rather than cosmetic: the published
+# alias `SRM -> SCG-1992-2006` is scoped to 1992-2006, which is what makes the
+# dataset's "SRM" resolve to Serbia and Montenegro instead of to nothing.
+.mueller_base_year <- function() 2000L
+
 prepare_country_grid <- function(l_files_dir, target_res) {
   cli::cli_h2("Section 1: Country grid")
 
@@ -2075,25 +2137,13 @@ prepare_nitrogen_inputs <- function(
     crop_synthetic <- whep::mueller_synthetic_n |>
       rename(crop_name = crop_process) |>
       mutate(
-        iso3c = recode(
+        area_code = .spatialize_label_area_code(
           iso3c,
-          "SRM" = "SCG",
-          "GUA" = "GTM",
-          "BZE" = "BLZ",
-          "COS" = "CRI",
-          "ELS" = "SLV",
-          "HAI" = "HTI",
-          "HON" = "HND",
-          "ROM" = "ROU",
-          "TRI" = "TTO",
-          "ZAR" = "COD",
-          "BHA" = "BHS",
-          "BAR" = "BRB",
-          "DMI" = "DMA",
-          "STL" = "LCA"
+          source = "mueller-synthetic-n",
+          year = .mueller_base_year(),
+          area_lookup = regions
         )
       ) |>
-      left_join(select(regions, iso3c, area_code), by = "iso3c") |>
       filter(!is.na(area_code), !is.na(rate_value)) |>
       summarize(
         kg_n_ha_synth = mean(rate_value, na.rm = TRUE),

--- a/tests/testthat/test_prepare_nitrogen.R
+++ b/tests/testthat/test_prepare_nitrogen.R
@@ -175,3 +175,129 @@ test_that(".aggregate_nitrogen_pft drops zero-area bands and NaN", {
   out <- .aggregate_nitrogen_pft(ng)
   expect_equal(nrow(out), 0L)
 })
+
+
+# ---- label -> area_code resolution (#494) --------------------------------
+#
+# `.read_crop_base_rates_local()` used to repair mueller_synthetic_n's FAO-style
+# legacy ISO codes with a hand-maintained 14-entry `recode()` list before
+# joining on iso3c. The list is gone; the mapping now comes from
+# `whep::polity_label_aliases`. These tests are the lock that the substitution
+# stays value-for-value identical, and that the bridge back to a numeric code
+# stays in the grid's area space.
+
+# The retired list, kept here as the expectation the replacement must reproduce.
+.retired_mueller_recode <- function() {
+  tibble::tribble(
+    ~legacy, ~iso3c,
+    "SRM",   "SCG",
+    "GUA",   "GTM",
+    "BZE",   "BLZ",
+    "COS",   "CRI",
+    "ELS",   "SLV",
+    "HAI",   "HTI",
+    "HON",   "HND",
+    "ROM",   "ROU",
+    "TRI",   "TTO",
+    "ZAR",   "COD",
+    "BHA",   "BHS",
+    "BAR",   "BRB",
+    "DMI",   "DMA",
+    "STL",   "LCA"
+  )
+}
+
+
+test_that(".spatialize_label_area_code reproduces the retired recode list", {
+  skip_if_not(exists(".spatialize_label_area_code", mode = "function"))
+  regions <- .spatialize_area_lookup()
+  recode_list <- .retired_mueller_recode()
+  present <- recode_list$legacy %in% whep::mueller_synthetic_n$iso3c
+  # 10 of the 14 entries name a code the dataset actually uses; the other 4
+  # (BHA, BAR, DMI, STL) never occur in it and were dead weight.
+  expect_equal(sum(present), 10L)
+  expect_setequal(
+    recode_list$legacy[!present],
+    c("BHA", "BAR", "DMI", "STL")
+  )
+  live <- recode_list[present, ]
+  got <- .spatialize_label_area_code(
+    live$legacy,
+    source = "mueller-synthetic-n",
+    year = .mueller_base_year(),
+    area_lookup = regions
+  )
+  want <- regions$area_code[match(live$iso3c, regions$iso3c)]
+  expect_equal(got, want)
+})
+
+
+test_that("mueller synthetic rates are unchanged by dropping the list", {
+  skip_if_not(exists(".spatialize_label_area_code", mode = "function"))
+  regions <- .spatialize_area_lookup()
+  mueller <- whep::mueller_synthetic_n
+  recode_list <- .retired_mueller_recode()
+  legacy_iso <- dplyr::coalesce(
+    recode_list$iso3c[match(mueller$iso3c, recode_list$legacy)],
+    mueller$iso3c
+  )
+  before <- regions$area_code[match(legacy_iso, regions$iso3c)]
+  after <- .spatialize_label_area_code(
+    mueller$iso3c,
+    source = "mueller-synthetic-n",
+    year = .mueller_base_year(),
+    area_lookup = regions
+  )
+  # Row-for-row identity over all 5,043 rows, not just a matching total.
+  expect_equal(after, before)
+  expect_equal(sum(!is.na(after)), nrow(mueller))
+  expect_equal(dplyr::n_distinct(after), dplyr::n_distinct(before))
+})
+
+
+test_that(".spatialize_label_area_code stays in the grid's area space", {
+  skip_if_not(exists(".spatialize_label_area_code", mode = "function"))
+  regions <- .spatialize_area_lookup()
+  got <- .spatialize_label_area_code(
+    c("SDN", "ETH"),
+    source = "mueller-synthetic-n",
+    year = .mueller_base_year(),
+    area_lookup = regions
+  )
+  # `polity_area_crosswalk` would answer 206 "Sudan (former)" and 238 for both
+  # of Ethiopia's FAOSTAT areas. regions.csv -- the table the country grid is
+  # rasterised from -- carries 276 and 238 and has no 206 and no 62 at all, so
+  # a bridge through `polity_area_code` would attach rates to absent cells.
+  expect_equal(got, c(276L, 238L))
+  expect_false(any(c(206L, 62L) %in% regions$area_code))
+  expect_true(all(got %in% regions$area_code))
+})
+
+
+test_that(".spatialize_label_area_code honours the alias year scope", {
+  skip_if_not(exists(".spatialize_label_area_code", mode = "function"))
+  regions <- .spatialize_area_lookup()
+  # The published alias is `SRM -> SCG-1992-2006`. Outside that window nothing
+  # claims the label, so the honest answer is NA rather than a nearest guess.
+  got <- .spatialize_label_area_code(
+    c("SRM", "SRM"),
+    source = "mueller-synthetic-n",
+    year = c(2000L, 2020L),
+    area_lookup = regions
+  )
+  expect_equal(got[[1]], regions$area_code[match("SCG", regions$iso3c)])
+  expect_true(is.na(got[[2]]))
+})
+
+
+test_that(".spatialize_label_area_code returns NA for unknown labels", {
+  skip_if_not(exists(".spatialize_label_area_code", mode = "function"))
+  regions <- .spatialize_area_lookup()
+  got <- .spatialize_label_area_code(
+    c("ZZZ", "not a country"),
+    source = "mueller-synthetic-n",
+    year = .mueller_base_year(),
+    area_lookup = regions
+  )
+  expect_true(all(is.na(got)))
+})


### PR DESCRIPTION
## What was wrong

`inst/scripts/prepare_spatialize_all.R` repaired `mueller_synthetic_n`'s
FAO-style legacy ISO codes with a hand-maintained 14-entry `recode()` list
before joining on `iso3c` — a fourth territorial vocabulary living in a script,
restating by hand what `polity_label_aliases` now publishes.

Two of the issue's premises did not survive checking, and the correction
matters for what this PR does:

- **The list served one call site, not three.** `recode()` appears exactly once
  in the file. `crops_manure_n` joins straight on `ISO` and
  `lassaletta_grassland_share` joins on a country *name*; neither ever touched
  the list. So deleting the list requires only the `mueller` site, and the two
  other sites are a separate, value-moving question (measured below, not done
  here).
- **The list is not lossy for the data it serves.** With it, all 5,043 rows of
  `mueller_synthetic_n` resolve. What is actually wrong with it is that it is a
  private copy of published data, and that **4 of its 14 entries are dead**:
  `BHA`, `BAR`, `DMI` and `STL` name codes the dataset never uses.

## Evidence it reproduced BEFORE the change

At `origin/main` (`2759be3e`), driving the real package data and the real
`regions.csv`:

| site | rows | resolved by the current code | dropped |
|---|---|---|---|
| `mueller_synthetic_n` | 5,043 | 5,043 | 0 |
| `crops_manure_n` | 31,648 | 31,476 | 172 (`RoW`) |
| `lassaletta_grassland_share` | 6,909 | 6,370 | 539 (11 labels) |

The 14-entry list against the 869-row published map, entry by entry:

```
  SRM -> SCG :   31 raw rows      BHA -> BHS :    0 raw rows
  GUA -> GTM :   37 raw rows      BAR -> BRB :    0 raw rows
  BZE -> BLZ :   36 raw rows      DMI -> DMA :    0 raw rows
  COS -> CRI :   31 raw rows      STL -> LCA :    0 raw rows
  ELS -> SLV :   35 raw rows
  HAI -> HTI :   31 raw rows      published `mueller-synthetic-n` aliases: 10
  HON -> HND :   34 raw rows      live list entries:                       10
  ROM -> ROU :   28 raw rows      targets that disagree:                    0
  TRI -> TTO :   23 raw rows      labels the map adds:                      0
  ZAR -> COD :   42 raw rows      dead list entries:                        4
```

So for this site the map is a strict superset of the list, agreeing on every
live entry — which is what makes the substitution provably value-preserving
rather than merely plausible.

## What I changed

1. New script helper `.spatialize_label_area_code(label, source, year,
   area_lookup)`: `resolve_polity_label()` → `polities$iso3_code` →
   the caller's `iso3c -> area_code` table. It de-duplicates on
   `(label, year)` first, so the 5,043-row site costs 0.15 s.
2. `.read_crop_base_rates_local()` uses it for `mueller_synthetic_n`; the
   `recode()` list is deleted.
3. `.mueller_base_year()` records the year the labels are read in, 2000. It is
   load-bearing, not cosmetic: the published alias `SRM -> SCG-1992-2006` is
   year-scoped, and that scope is what makes `"SRM"` resolve to Serbia and
   Montenegro rather than to nothing. Mueller et al. (2012), *Nature*
   490:254–257, doi:10.1038/nature11420, publish the rates "circa 2000"
   (archived as Zenodo record 5260732) and `mueller_synthetic_n` carries no year
   column of its own.
4. `.lookup_no_na()`, because `match()` treats `NA` as a value: without it an
   unresolved label picks up whichever row happens to carry an `NA` key.

### The bridge is the decision, and it is not free

The resolver answers a **polity**; this script is keyed on a numeric **area**,
so the answer has to be bridged back. `polity_area_crosswalk$polity_area_code`
is a *different code space* from the one the country grid carries:

| | `regions.csv` (what the grid is rasterised from) | `polity_area_code` |
|---|---|---|
| Sudan | **276** | 206 |
| Ethiopia | 238 | 238 (and 62 folds in) |
| has 206? | **no** | — |
| has 62? | **no** | — |

Bridging through `polity_area_code` therefore attaches rates to codes no grid
cell has. Measured by mutating the helper to do exactly that: **4,954 of 5,043
rows resolve instead of 5,043**, and the distinct area codes drop from 156 to
154. The shipped bridge goes through the polity's `iso3_code` and back through
the same lookup the grid uses, which is a relabelling of the join the script
already did rather than a change of code space.

## How I verified

Equivalence, running the real `.read_crop_base_rates_local()` pipeline before
and after over the real package data:

```
BEFORE rows: 5043        AFTER rows: 5043
BEFORE distinct area_code: 156   AFTER: 156
identical (area_code, crop_name) keys: TRUE
max abs kg_n_ha_synth difference: 0
all.equal(before, after): TRUE
sum kg_n_ha_synth: 261418 -> 261418
```

Structural checks, not just "no number moved" (#480's lesson):

- rows: 5,043 → 5,043; grouped output keys identical, none added, none removed.
- **one `area_code` → one `area` label**: 0 of the 156 produced codes carry more
  than one label, and 0 are absent from `regions.csv`.
- `tests/testthat/test_read_raw_inputs.R` (the `.aggregate_to_polities()` bucket
  guard added after the #480 revert): **7 assertions, all passing**.
- unresolved labels stay unresolved through both hops (the `NA`-match trap).

Gates:

- `air format .` — clean, no diff.
- `devtools::document()` — no `man/` change (script-scope helper, nothing
  exported), so `_pkgdown.yml` is untouched; the `comm` check is empty.
- `lintr::lint_package(...)` with the four repo-disabled linters — **0 lints**.
- `devtools::test()` — **5,712 passing, 0 failures, 0 errors, 8 skips**.

Assertion count: the new block adds **12 assertions** to
`test_prepare_nitrogen.R` (26 → 38). Mutating the helper to bridge through
`polity_area_code` fails **7 of them**, including the two that state the code
space explicitly:

```
`got` (`actual`) not equal to c(276L, 238L) (`expected`).
  `actual`: 206 238
sum(!is.na(after)) (`actual`) not equal to nrow(mueller) (`expected`).
  `actual`: 4954   `expected`: 5043
```

The equality test embeds the retired 14-entry list as its expectation, so it is
also the lock that a future re-sync of `polity_label_aliases` cannot silently
move these rates.

## Moves published values

**No.** Byte-identical `crop_synthetic`: same 5,043 rows, same 156 area codes,
maximum rate difference 0. `NEWS.md` records that as a checked claim.

Classification: **mechanical**. The substitution is value-for-value identical
and the bridge choice is settled by a code space the grid already fixes, not by
a defensible alternative.

## What I deliberately did not do

**I did not rewire `crops_manure_n` or `lassaletta_grassland_share` onto the
alias map.** They never used the deleted list, and routing them through it is a
science decision that moves values in both directions. Measured, so the decision
can be taken on numbers:

`crops_manure_n` (base year 2000, which is itself an assumption — West et al.
2014's base year is not stated in the package docs and I did not verify it):

| label | now | alias map | rows |
|---|---|---|---|
| `SRB` | 272 Serbia | **186 Serbia and Montenegro** | 172 |
| `MNE` | 273 Montenegro | **186 Serbia and Montenegro** | 172 |
| `SSD` | 277 South Sudan | **276 Sudan (former)** | 172 |
| `RoW` | dropped | **999 Rest of World** | 172 |

Grouped output 31,476 → 31,304 rows; total manure N 112,832,103 → 112,887,685
Mg.

`lassaletta_grassland_share` (per-row year): **+415 rows** across 9 labels
(`China` 41, `Cote d'Ivoire` 107, `DPRepublic of Korea` 116, `Cape Verde` 35,
`Swaziland` 209, `Sudan (former)` 276, `Ethiopia PDR` 238, `Belgium-Luxemburg`
255, `Occupied Palestinian Territory` 299) but also **−102 rows** across 5
labels the current code keeps (`South Sudan` 49, `Yugoslav SFR` 18,
`Czechoslovakia` 16, `Viet Nam` 14, `Botswana` 5) — years in which the resolver
correctly says the territory did not exist. Net +312, not the +411 the issue
quotes; the issue's number is close to the **gross** gain and omits the losses
entirely.

And the reason that one must not simply be switched on: the alias route makes
`"Sudan"` and `"Sudan (former)"` both resolve to area 276 for 1961–2009,
producing **49 duplicate `(year, area_code)` keys**. `.distribute_n_to_crops()`
joins the Lassaletta share by exactly that key, so every Sudan nitrogen row
would fan out. That is invisible to a row-count or a mass check on the reader's
own output — the same shape of structural break as #480.

I also did not touch `run_spatialize.R` or attempt any gridded build; those need
multi-GB local rasters and hours.

## The open decision

For `crops_manure_n` and `lassaletta_grassland_share`, should a circa-2000 /
1961–2009 reference layer be keyed on the territories that existed **in the data
year** (alias map: `SRB`+`MNE` → Serbia and Montenegro, `SSD` → Sudan (former),
South Sudan and post-1992 Yugoslavia dropped), or on the **modern successors**
the country grid actually rasterises (status quo)? The grid is a present-day
NaturalEarth rasterisation, which argues for the status quo; the epic's
"everything routes through polities" argues the other way. Filed as a follow-up
with these numbers rather than decided here.

Closes #494.
Part of the polity migration epic #458.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
