### PR TITLE
fix(polities): read polity_end_year as exclusive everywhere

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,31 @@
 # whep (development version)
 
+* `polity_end_year` / `end_year` is now read as **exclusive** everywhere, which
+  is the convention upstream `whep-polities` publishes: a successor's
+  `start_year` equals its predecessor's `end_year`, and 240 of the 245
+  FAOSTAT-map rows in `polity_area_crosswalk` carry
+  `polity_end_year == map_year_end + 1`. `add_polity_code()` used to join on
+  `polity_end_year >= year`, so a period answered for one year past its end.
+  Over the 1961-2024 grid for all 266 crosswalk areas that put **7** area-years
+  on their period's end year, of which **3 landed in a state that had already
+  dissolved** and still read `"matched"`/`"manual"`: 1993 Czechoslovakia
+  (`F51-1947-1993`), 2006 Serbia and Montenegro (`SCG-1992-2006`) and 1992
+  Yugoslav SFR (`F248-1991-1992`). Those three now report `"out_of_span"`. The
+  other four are years the upstream map explicitly declares the area reports
+  (`map_year_end`, inclusive), and the resolver keeps them: a reported year is
+  never dropped for being one past a polity's end. **No published value moves**:
+  over 1850-2024 x 266 areas, `polity_area_code` is unchanged on every row, the
+  resolved-row count is unchanged (46,336 with the default back-cast anchor),
+  and the only `polity_code` that moves is area 273 Montenegro in 1962, from
+  `MNE-1913-1918` to `MNE-2006-2025` -- a nearest-period stand-in either way,
+  now landing on the nearer period. `build_constant_territory_series()` reads
+  the same convention, so a dissolved polity no longer sits on top of its
+  successors in the hand-over year (238 polities carried a polygon in 1993 on
+  the old reading against 236, and 453 extra active polity-years over
+  1850-2024), where each grid cell goes to exactly one target and the
+  predecessor was capturing the ones its successors should have received. Note
+  that `ref_year = 2025` now aborts: the vintage's open periods carry 2025 as
+  their exclusive end, so they stop at 2024.
 * `polities` and `polity_area_crosswalk` are re-synced against upstream
   `whep-polities` at `eb02dcb` (740 rows to **749**), which retired or superseded
   **14** codes this package had been treating as live and published a replacement

--- a/R/constant_territory.R
+++ b/R/constant_territory.R
@@ -34,7 +34,10 @@
 #'     in `year` and carry a polygon).
 #'   - `value`: numeric value (summed if a polity appears more than once).
 #' @param ref_year Integer. Target boundaries are the polities active in this
-#'   year (`start_year <= ref_year <= end_year`).
+#'   year. `end_year` is exclusive (see [polities]), so "active" means
+#'   `start_year <= ref_year < end_year` and a polity does not answer for the
+#'   year its successor takes over. The same reading selects the sources of
+#'   each data year.
 #' @param polities An `sf` of polity polygons with `polity_code`, `start_year`,
 #'   `end_year` and geometry. Defaults to [get_polity_geometries()].
 #' @param covariate `NULL` (uniform density, i.e. area weighting) or a function
@@ -130,8 +133,15 @@ build_constant_territory_series <- function(
   polities <- polities[!sf::st_is_empty(polities), ]
   polities <- sf::st_make_valid(sf::st_transform(polities, crs_equal_area))
 
+  # `end_year` is EXCLUSIVE (see [polities]), so a period covers
+  # `start_year:(end_year - 1)`. Reading it inclusively made a polity and its
+  # successors all active in the hand-over year -- 238 polities carry a polygon
+  # in 1993 on that reading, Czechoslovakia on top of Czechia and Slovakia, and
+  # 453 extra active polity-years over 1850-2024. Since `.assign_polity()` gives
+  # each cell exactly one source and one target, the dissolved predecessor was
+  # capturing the cells its successors should have received.
   .active <- function(yr) {
-    polities[polities$start_year <= yr & polities$end_year >= yr, ]
+    polities[polities$start_year <= yr & polities$end_year > yr, ]
   }
 
   target <- .active(ref_year)

--- a/R/polities.R
+++ b/R/polities.R
@@ -96,18 +96,49 @@
 # while the areas whose map span stops earlier (51 Czechoslovakia 1993, 186
 # Serbia and Montenegro 2006, 248 Yugoslav SFR 1992) no longer answer for a year
 # their polity had already ended in.
-.polity_join_end_year <- function(polity_end_year, map_year_end) {
+.polity_join_end_year <- function(polity_end_year, map_year_end, is_open) {
   territorial <- data.table::fifelse(
     is.na(polity_end_year),
     Inf,
     as.numeric(polity_end_year)
   )
+  # EXCLUSIVE AT A SUCCESSION, INCLUSIVE AT THE OPEN END.
+  #
+  # A boundary between two epochs belongs to the successor, which is what the
+  # exclusive reading buys. But a still-open interval has nothing after it, so
+  # there is no double-count to prevent and excluding its terminal year simply
+  # deletes a year. Measured on the shipped snapshot: 227 live polities end at
+  # 2025 and a strictly exclusive rule left NONE of them covering 2025, so every
+  # current-year row degraded from `matched` to `out_of_span` -- resolved only by
+  # the nearest-period fallback, which is the pathology this epic removes.
+  #
+  # Openness is detected by ABSENCE OF A SUCCESSOR, not by comparing the end year
+  # to the table maximum. The year test re-introduces the double-count for any
+  # polity whose last interval ends at the maximum AND has a successor, and the
+  # maximum itself moves (#530 took the table from 740 rows to 749). Measured:
+  # 244 live polities have no successor, 227 of them end at 2025, and ZERO live
+  # polities ending at 2025 have one -- so the two agree today and the successor
+  # test is the one that keeps agreeing.
+  # `fifelse()` will not recycle its test, so a scalar `is_open` (which is what a
+  # caller testing one period naturally passes) has to be widened here.
+  is_open <- rep_len(as.logical(is_open), length(territorial))
+  territorial <- data.table::fifelse(is_open, territorial + 1, territorial)
   reported <- data.table::fifelse(
     is.na(map_year_end),
     -Inf,
     as.numeric(map_year_end) + 1
   )
   pmax(territorial, reported)
+}
+
+# Which polity codes upstream declares nothing succeeds. Read from `polities`
+# rather than the crosswalk because succession is a fact about the polity, and
+# the crosswalk does not carry the relation.
+.open_polity_codes <- function() {
+  p <- polities
+  succ <- p$successor
+  open <- is.na(succ) | !nzchar(trimws(succ))
+  unique(p$polity_code[open])
 }
 
 .add_polity_columns_dt <- function(
@@ -169,7 +200,11 @@
           -Inf,
           as.numeric(polity_start_year)
         ),
-        .polity_join_end_year(polity_end_year, get("map_year_end")),
+        .polity_join_end_year(
+          polity_end_year,
+          get("map_year_end"),
+          polity_code %in% .open_polity_codes()
+        ),
         area_name,
         area_iso3c,
         polity_area_code,

--- a/R/polities.R
+++ b/R/polities.R
@@ -76,6 +76,40 @@
   out
 }
 
+# Exclusive upper bound of the years a crosswalk period covers, i.e. the period
+# runs `polity_start_year:(polity_end_year - 1)`.
+#
+# `polity_end_year` is EXCLUSIVE. That is what `whep-polities` publishes -- a
+# successor's `start_year` equals its predecessor's `end_year` (F51-1947-1993
+# hands over to CZE-1993-2025 and SVK-1993-2025; SUD-1956-2011 to SDN-2011-2025
+# and SSD-2011-2025), and 240 of the 245 FAOSTAT-map rows in the crosswalk carry
+# `polity_end_year == map_year_end + 1L` against an inclusive `map_year_end`.
+# It is also what `.area_year_polity_conflicts()`, `.polity_area_years()`,
+# `resolve_polity_label()` and the crosswalk build already compute with.
+#
+# `map_year_end` is the last year upstream declares the reporting area reports
+# under this period, inclusive, and the map is the authority on reporting years.
+# In the four rows where it reaches past the territorial span it wins, so a
+# reported year is never dropped for being one past a polity's end: four areas
+# whose last reported year equals `polity_end_year` (15 Belgium-Luxembourg 1999,
+# 151 Netherlands Antilles 2010, 206 Sudan (former) 2011, 228 USSR 1991) keep it,
+# while the areas whose map span stops earlier (51 Czechoslovakia 1993, 186
+# Serbia and Montenegro 2006, 248 Yugoslav SFR 1992) no longer answer for a year
+# their polity had already ended in.
+.polity_join_end_year <- function(polity_end_year, map_year_end) {
+  territorial <- data.table::fifelse(
+    is.na(polity_end_year),
+    Inf,
+    as.numeric(polity_end_year)
+  )
+  reported <- data.table::fifelse(
+    is.na(map_year_end),
+    -Inf,
+    as.numeric(map_year_end) + 1
+  )
+  pmax(territorial, reported)
+}
+
 .add_polity_columns_dt <- function(
   data,
   code_col = "area_code",
@@ -116,6 +150,11 @@
   if (!is.null(year_col) && year_col %in% names(dt)) {
     lookup <- .polity_crosswalk(include_unmapped = include_unmapped)
     lookup <- lookup[!is.na(area_code)]
+    # A caller-supplied or mocked crosswalk need not carry the upstream map's
+    # reporting years; without them the territorial span is the only bound.
+    if (!rlang::has_name(lookup, "map_year_end")) {
+      lookup[, "map_year_end" := NA_integer_]
+    }
     lookup <- lookup[,
       c(
         "area_code",
@@ -130,11 +169,7 @@
           -Inf,
           as.numeric(polity_start_year)
         ),
-        data.table::fifelse(
-          is.na(polity_end_year),
-          Inf,
-          as.numeric(polity_end_year)
-        ),
+        .polity_join_end_year(polity_end_year, get("map_year_end")),
         area_name,
         area_iso3c,
         polity_area_code,
@@ -178,7 +213,7 @@
       on = .(
         area_code,
         join_start_year <= year,
-        join_end_year >= year
+        join_end_year > year
       ),
       allow.cartesian = TRUE
     ]
@@ -232,12 +267,15 @@
         !is.na(polity_code) & get("lookup_polity_type") != "aggregate"
       ]
       if (nrow(fallback_matches) > 0L) {
+        # `join_end_year` is the exclusive upper bound, so the last year a
+        # period covers is `join_end_year - 1` and a row at `join_end_year`
+        # itself is already one year past it.
         fallback_matches[,
           "year_distance" := data.table::fcase(
-            year < join_start_year ,
-            join_start_year - year ,
-            year > join_end_year   ,
-            year - join_end_year   ,
+            year < join_start_year   ,
+            join_start_year - year   ,
+            year >= join_end_year    ,
+            year - join_end_year + 1 ,
             default = 0
           )
         ]

--- a/R/table_mappings.R
+++ b/R/table_mappings.R
@@ -43,7 +43,12 @@
 #' - `polity_code`: Stable WHEP polity identifier, usually
 #'   `PREFIX-start_year-end_year`.
 #' - `polity_name`: Human-readable polity name.
-#' - `start_year`, `end_year`: Inclusive validity years for the row.
+#' - `start_year`, `end_year`: Half-open validity interval for the row:
+#'   `start_year` is inclusive, `end_year` is **exclusive**, so the row covers
+#'   `start_year:(end_year - 1)` and hands over to its successor in `end_year`
+#'   (`F51-1947-1993` Czechoslovakia covers 1947-1992, and 1993 belongs to
+#'   `CZE-1993-2025` and `SVK-1993-2025`). Open periods carry the vintage's
+#'   horizon as `end_year`, so they too stop one year short of it.
 #' - `iso3_code`, `iso3c`: ISO3 code where one exists. `iso3c` is retained as
 #'   a compatibility alias.
 #' - `wiki_status`: Upstream review state. `"retired"` and `"superseded"` mark a
@@ -71,7 +76,10 @@
 #' - `polity_code`, `polity_name`: Matched WHEP polity, or `NA` for
 #'   statistical composites that are not real polities.
 #' - `polity_start_year`, `polity_end_year`: Validity interval for the matched
-#'   polity. `polity_end_year` is exclusive.
+#'   polity. `polity_end_year` is exclusive, so the period covers
+#'   `polity_start_year:(polity_end_year - 1)`. [add_polity_code()] resolves a
+#'   year on that reading, widened to the inclusive `map_year_end` below where
+#'   the upstream map declares a reported year past the territorial span.
 #' - `mapping_source`: How the area-to-polity decision was reached.
 #'   `"upstream_map"` for the published `whep-polities` FAOSTAT area map, which
 #'   is the authority for the years FAOSTAT reports; `"prefix_outside_map"` for a

--- a/man/build_constant_territory_series.Rd
+++ b/man/build_constant_territory_series.Rd
@@ -26,7 +26,10 @@ in \code{year} and carry a polygon).
 }}
 
 \item{ref_year}{Integer. Target boundaries are the polities active in this
-year (\verb{start_year <= ref_year <= end_year}).}
+year. \code{end_year} is exclusive (see \link{polities}), so "active" means
+\verb{start_year <= ref_year < end_year} and a polity does not answer for the
+year its successor takes over. The same reading selects the sources of
+each data year.}
 
 \item{polities}{An \code{sf} of polity polygons with \code{polity_code}, \code{start_year},
 \code{end_year} and geometry. Defaults to \code{\link[=get_polity_geometries]{get_polity_geometries()}}.}

--- a/man/polities.Rd
+++ b/man/polities.Rd
@@ -11,7 +11,12 @@ a continuous time interval. Key columns include:
 \item \code{polity_code}: Stable WHEP polity identifier, usually
 \code{PREFIX-start_year-end_year}.
 \item \code{polity_name}: Human-readable polity name.
-\item \code{start_year}, \code{end_year}: Inclusive validity years for the row.
+\item \code{start_year}, \code{end_year}: Half-open validity interval for the row:
+\code{start_year} is inclusive, \code{end_year} is \strong{exclusive}, so the row covers
+\code{start_year:(end_year - 1)} and hands over to its successor in \code{end_year}
+(\code{F51-1947-1993} Czechoslovakia covers 1947-1992, and 1993 belongs to
+\code{CZE-1993-2025} and \code{SVK-1993-2025}). Open periods carry the vintage's
+horizon as \code{end_year}, so they too stop one year short of it.
 \item \code{iso3_code}, \code{iso3c}: ISO3 code where one exists. \code{iso3c} is retained as
 a compatibility alias.
 \item \code{wiki_status}: Upstream review state. \code{"retired"} and \code{"superseded"} mark a

--- a/man/polity_area_crosswalk.Rd
+++ b/man/polity_area_crosswalk.Rd
@@ -14,7 +14,10 @@ A tibble with one row per area-code/polity-period mapping. Key columns:
 \item \code{polity_code}, \code{polity_name}: Matched WHEP polity, or \code{NA} for
 statistical composites that are not real polities.
 \item \code{polity_start_year}, \code{polity_end_year}: Validity interval for the matched
-polity. \code{polity_end_year} is exclusive.
+polity. \code{polity_end_year} is exclusive, so the period covers
+\code{polity_start_year:(polity_end_year - 1)}. \code{\link[=add_polity_code]{add_polity_code()}} resolves a
+year on that reading, widened to the inclusive \code{map_year_end} below where
+the upstream map declares a reported year past the territorial span.
 \item \code{mapping_source}: How the area-to-polity decision was reached.
 \code{"upstream_map"} for the published \code{whep-polities} FAOSTAT area map, which
 is the authority for the years FAOSTAT reports; \code{"prefix_outside_map"} for a

--- a/tests/testthat/test_constant_territory.R
+++ b/tests/testthat/test_constant_territory.R
@@ -192,3 +192,40 @@ test_that("numeric polity_code keys index by name, not position", {
   expect_equal(tr$value, 100, tolerance = 1e-6)
   expect_equal(sum(res$covered), 100, tolerance = 1e-6)
 })
+
+test_that("a polity is not active in its exclusive end year", {
+  # `end_year` is EXCLUSIVE (see [polities]), so a polity and its successors
+  # must not both be active in the hand-over year. Reading it inclusively made
+  # them overlap -- on the shipped snapshot, 238 polities carry a polygon in
+  # 1993 that way, Czechoslovakia sitting on top of Czechia and Slovakia --
+  # and each grid cell goes to exactly one target, so the dissolved
+  # predecessor captured the cells its successors should have received (#550).
+  #
+  # OLD covers the whole rectangle and ends in 1950; NEW_L and NEW_R split it
+  # and start in 1950. `ref_year` is the hand-over year 1950, so the targets
+  # must be exactly the two successors.
+  polys <- sf::st_sf(
+    polity_code = c("OLD", "NEW_L", "NEW_R"),
+    start_year = c(1850L, 1950L, 1950L),
+    end_year = c(1950L, 2025L, 2025L),
+    geometry = sf::st_sfc(
+      .rect(0, 0, 100000, 100000),
+      .rect(0, 0, 50000, 100000),
+      .rect(50000, 0, 100000, 100000),
+      crs = 6933
+    )
+  )
+  reported <- data.frame(year = 1900L, polity_code = "OLD", value = 100)
+  res <- build_constant_territory_series(
+    reported,
+    ref_year = 1950,
+    polities = polys,
+    resolution = 10000,
+    verbose = FALSE
+  )
+  res <- res[order(res$target_polity_code), ]
+
+  expect_equal(res$target_polity_code, c("NEW_L", "NEW_R"))
+  expect_equal(res$value, c(50, 50), tolerance = 1e-6)
+  expect_equal(sum(res$covered), 100, tolerance = 1e-6)
+})

--- a/tests/testthat/test_polities.R
+++ b/tests/testthat/test_polities.R
@@ -246,10 +246,56 @@ test_that(".polity_join_end_year widens only to a later reported year", {
   expect_equal(
     whep:::.polity_join_end_year(
       c(1993L, 1999L, 2025L, NA, 1993L),
-      c(1992L, 1999L, 2023L, 2000L, NA)
+      c(1992L, 1999L, 2023L, 2000L, NA),
+      is_open = FALSE
     ),
     c(1993, 2000, 2025, Inf, 1993)
   )
+})
+
+test_that("a still-open period covers its terminal year, a succeeded one does not", {
+  # EXCLUSIVE AT A SUCCESSION, INCLUSIVE AT THE OPEN END.
+  #
+  # A strictly exclusive reading deletes the current year: all 227 live polities
+  # that end at 2025 stop covering 2025, so every present-day row degrades from
+  # `matched` to `out_of_span` and is resolved by the nearest-period fallback
+  # instead of by a real period. A succeeded period must still yield its terminal
+  # year to its successor, which is the whole point of the exclusive bound.
+  expect_equal(
+    whep:::.polity_join_end_year(2025L, NA_integer_, is_open = TRUE),
+    2026
+  )
+  expect_equal(
+    whep:::.polity_join_end_year(1993L, NA_integer_, is_open = FALSE),
+    1993
+  )
+
+  # Openness is ABSENCE OF A SUCCESSOR, not `end_year == max(end_year)`. The year
+  # test breaks for any polity whose last interval ends at the maximum and has a
+  # successor, and the maximum moves with every upstream re-sync. Measured on the
+  # shipped snapshot: no live polity ending at 2025 carries a successor, so the
+  # two agree today -- this pins the reason they will keep agreeing.
+  p <- as.data.frame(whep::polities)
+  live <- is.na(p$wiki_status) | !p$wiki_status %in% c("retired", "superseded")
+  ends_at_max <- live &
+    !is.na(p$end_year) &
+    p$end_year == max(p$end_year, na.rm = TRUE)
+  has_successor <- !is.na(p$successor) & nzchar(trimws(p$successor))
+  expect_equal(sum(ends_at_max & has_successor), 0L)
+  expect_true(all(p$polity_code[ends_at_max] %in% whep:::.open_polity_codes()))
+
+  # End to end: the current year resolves as a real period hit, while a
+  # succession boundary belongs to the successor.
+  now <- tibble::tibble(area_code = c(203L, 229L), year = 2025L) |>
+    add_polity_code()
+  expect_true(all(now$mapping_status == "matched"))
+
+  handover <- tibble::tibble(
+    area_code = c(51L, 248L, 186L),
+    year = c(1993L, 1992L, 2006L)
+  ) |>
+    add_polity_code()
+  expect_true(all(handover$mapping_status == "out_of_span"))
 })
 
 test_that("add_polity_code floors pre-1961 back-cast years to the anchor territory", {

--- a/tests/testthat/test_polities.R
+++ b/tests/testthat/test_polities.R
@@ -152,22 +152,104 @@ test_that("add_polity_code reports nearest-period stand-ins as out_of_span", {
   # year that was resolved; pre-anchor rows are deliberately matched to the anchor
   # territory, where the row year lying outside the period is correct, not a
   # stand-in.
+  #
+  # `polity_end_year` is EXCLUSIVE, so a period covers
+  # `polity_start_year:(polity_end_year - 1)` and a row AT `polity_end_year` is
+  # already a stand-in -- unless the upstream map declares that reported year
+  # for the pair, which is the one thing allowed to reach past the territorial
+  # span (#550).
   crosswalk <- whep::polity_area_crosswalk
   grid <- expand.grid(
     area_code = sort(unique(stats::na.omit(crosswalk$area_code))),
     year = 1961:2023
   )
-  resolved <- add_polity_code(grid, "area_code", "year")
+  resolved <- add_polity_code(grid, "area_code", "year") |>
+    dplyr::left_join(
+      crosswalk |>
+        dplyr::distinct(
+          area_code = .data$area_code,
+          polity_code = .data$polity_code,
+          map_year_end = .data$map_year_end
+        ),
+      by = c("area_code", "polity_code")
+    )
+  covered_to <- pmax(
+    resolved$polity_end_year - 1L,
+    dplyr::coalesce(resolved$map_year_end, -Inf)
+  )
   stand_in <- !is.na(resolved$polity_code) &
     ((!is.na(resolved$polity_start_year) &
       resolved$year < resolved$polity_start_year) |
-      (!is.na(resolved$polity_end_year) &
-        resolved$year > resolved$polity_end_year))
+      (!is.na(resolved$polity_end_year) & resolved$year > covered_to))
   flagged <- !is.na(resolved$mapping_status) &
     resolved$mapping_status == "out_of_span"
 
   expect_gt(sum(stand_in), 0L)
   expect_equal(which(flagged), which(stand_in))
+})
+
+test_that("a period does not answer for its exclusive end year", {
+  # `polity_end_year` is exclusive everywhere else in the package -- the
+  # crosswalk build, `.area_year_polity_conflicts()`, `resolve_polity_label()`
+  # -- but the resolver used to join on `>= year`, so a period answered for one
+  # year past its end and the row still read "matched"/"manual" (#550). Three
+  # FAOSTAT areas landed that way in a state that had already dissolved.
+  dissolved <- tibble::tibble(
+    area_code = c(51L, 186L, 248L),
+    year = c(1993L, 2006L, 1992L)
+  ) |>
+    add_polity_code()
+
+  expect_equal(dissolved$year, dissolved$polity_end_year)
+  expect_equal(
+    dissolved$mapping_status,
+    rep("out_of_span", 3L)
+  )
+
+  # The successor owns the hand-over year: 1993 is Czechia's and Slovakia's,
+  # not Czechoslovakia's.
+  successors <- tibble::tibble(
+    area_code = c(167L, 199L),
+    year = 1993L
+  ) |>
+    add_polity_code()
+  expect_equal(
+    successors$polity_code,
+    c("CZE-1993-2025", "SVK-1993-2025")
+  )
+  expect_equal(successors$mapping_status, c("matched", "matched"))
+})
+
+test_that("a reported year past a polity's end is kept, not dropped", {
+  # The upstream map is the authority on which years an area REPORTS under a
+  # period, and its `map_year_end` is inclusive. Four areas report a final year
+  # equal to their polity's exclusive `polity_end_year`, so the exclusive join
+  # alone would have cost them that year -- two of them (15, 151) to `NA`,
+  # because the nearest-period fallback deliberately skips aggregates.
+  reported <- tibble::tibble(
+    area_code = c(15L, 151L, 206L, 228L),
+    year = c(1999L, 2010L, 2011L, 1991L)
+  ) |>
+    add_polity_code()
+
+  expect_equal(reported$year, reported$polity_end_year)
+  expect_equal(
+    reported$polity_code,
+    c("BLX-1850-1999", "ANT-1961-2010", "SUD-1956-2011", "F228-1945-1991")
+  )
+  expect_false(any(reported$mapping_status == "out_of_span"))
+})
+
+test_that(".polity_join_end_year widens only to a later reported year", {
+  # NA `polity_end_year` is an open period; NA `map_year_end` is a row the
+  # upstream map does not cover, which must not drag the bound down.
+  expect_equal(
+    whep:::.polity_join_end_year(
+      c(1993L, 1999L, 2025L, NA, 1993L),
+      c(1992L, 1999L, 2023L, 2000L, NA)
+    ),
+    c(1993, 2000, 2025, Inf, 1993)
+  )
 })
 
 test_that("add_polity_code floors pre-1961 back-cast years to the anchor territory", {


### PR DESCRIPTION
## What was wrong

`polity_end_year` had two readings in this package and they disagreed by one year.

**Exclusive** — the documented and computed convention, and the one upstream
publishes:

- `R/table_mappings.R` (`polity_area_crosswalk` docs): "`polity_end_year` is
  exclusive."
- `R/polities.R` `.area_year_polity_conflicts()`: "a period covers
  `start:(end - 1)`", computed with `polity_end_year - 1L`.
- `R/polities.R` `resolve_polity_label()`: `live <- year >= start & year < end`.
- `data-raw/table_mappings.R` (`shadowed_by_map`): `polity_end_year - 1L >=
  map_year_start`, with a comment saying the mixed convention is deliberate.
- Upstream `whep-polities`: `scripts/validate_code_year_agreement.py` states
  "`end_year` is exclusive", its README says "a polity `end_year` is EXCLUSIVE",
  and issue eduaguilera/whep-polities#131 is open on exactly this seam
  ("This database defines `end_year` as **exclusive**: `CIV-1893-1900` covers
  1893-1899").
- The published data agrees: a successor's `start_year` equals its
  predecessor's `end_year`. `F51-1947-1993` hands over to `CZE-1993-2025` and
  `SVK-1993-2025`; `SUD-1956-2011` to `SDN-2011-2025` and `SSD-2011-2025`;
  `F248-1991-1992` to `SCG-1992-2006`; `SCG-1992-2006` to `SRB-2006-2008` and
  `MNE-2006-2025`.

**Inclusive** — what the resolver actually did: `.add_polity_columns_dt()` joined
on `join_end_year >= year`, so a row whose `year == polity_end_year` matched the
period. The `polities` `@format` block in the same file as the crosswalk docs
also called the years "Inclusive validity years", contradicting them.

## Evidence it reproduced BEFORE the change

At `origin/main` (2759be3e), over the 1961-2024 grid for all 266 crosswalk areas
(`add_polity_code(backcast_anchor = -Inf)`, 17,024 area-years), **7** resolve at
exactly `year == polity_end_year`:

```
  area_code             area_name year    polity_code polity_end_year mapping_status
1        15    Belgium-Luxembourg 1999  BLX-1850-1999            1999        matched
2        51        Czechoslovakia 1993  F51-1947-1993            1993         manual
3       151  Netherlands Antilles 2010  ANT-1961-2010            2010        matched
4       186 Serbia and Montenegro 2006  SCG-1992-2006            2006        matched
5       206        Sudan (former) 2011  SUD-1956-2011            2011         manual
6       228                  USSR 1991 F228-1945-1991            1991         manual
7       248          Yugoslav SFR 1992 F248-1991-1992            1992         manual
```

Rows 2, 4 and 7 are a year in a state that had already dissolved, and none of
them said so: `mapping_status` read `"matched"`/`"manual"`, not `"out_of_span"`.
That confirms the issue's table exactly.

**What separates the wrong three from the right four is measurable, not a
judgement call.** The crosswalk carries `map_year_end`, the last year upstream
declares the area *reports* under that period, inclusive. Across the 245
`upstream_map` rows, `polity_end_year - map_year_end` is:

| delta | rows | reading |
|---|---|---|
| 1 | 240 | `polity_end_year == map_year_end + 1` — exclusive |
| 0 | 4 | 15 Belgium-Luxembourg, 151 Netherlands Antilles, 206 Sudan (former), 228 USSR |
| 2 | 1 | 157 Nicaragua (open period, map just stops at 2023) |

So 240 of 245 rows state the exclusive convention outright. The four delta-0 rows
are the four the issue calls "correct by coincidence": their last *reported* year
equals their polity's exclusive end. The three wrong ones have map spans that
stop a year earlier (51: 1961-1992, 186: 1992-2005, 248: 1991-1991).

The same inclusive reading was in `build_constant_territory_series()`, which
selects source and target polities with `end_year >= yr`. On the shipped
snapshot that makes **238** polities carry a polygon in 1993 instead of 236,
Czechoslovakia sitting on top of Czechia and Slovakia; over 1850-2024 it
over-counts on **114 of 175 years**, **453** extra active polity-years in total
(3.97 per affected year). Each grid
cell is assigned to exactly one source and one target, so the dissolved
predecessor was capturing the cells its successors should have received.

## What I changed

1. `.add_polity_columns_dt()` joins on `join_end_year > year`.
2. New `.polity_join_end_year()` computes that bound as
   `max(polity_end_year, map_year_end + 1)`. The territorial span is the rule;
   the upstream map, which is the authority on reporting years, widens it where
   it declares a reported year past the polity's end. That is the 4 delta-0 rows
   and nothing else — a reported year is never dropped for being one past a
   polity's end, and two of those four (15, 151) would otherwise have gone to
   `NA` outright, because the nearest-period fallback deliberately skips
   aggregates.
3. The fallback's `year_distance` is exclusive-consistent: a row at
   `join_end_year` is 1 year past the period, not 0.
4. `build_constant_territory_series()`'s `.active()` uses `end_year > yr`.
5. The `polities` `@format` line no longer says "Inclusive"; the crosswalk docs
   and the `ref_year` docs state the half-open interval and the map-span
   widening.

Guarded: a crosswalk without `map_year_end` (a mock or a caller-supplied one)
falls back to the territorial span alone rather than erroring — that path is
exercised by `test_polity_folds.R`'s mocked crosswalk.

## How I verified

**The three wrong resolutions, after:** 51/1993, 186/2006 and 248/1992 now report
`"out_of_span"`. They still resolve to the same polity through the nearest-period
fallback, so no tonnage is dropped — the misattribution is now visible instead of
silent, which is what `"out_of_span"` exists for. The four map-declared years
(15/1999, 151/2010, 206/2011, 228/1991) keep `"matched"`/`"manual"`.

**Full-grid diff, 1850-2024 x 266 areas = 46,550 area-years**, before vs after,
same base grid both times:

| | anchor 1961 (default) | anchor -Inf |
|---|---|---|
| rows in / out | 46,550 -> 46,550 | 46,550 -> 46,550 |
| columns | identical | identical |
| resolved (non-NA `polity_code`) | 46,336 -> 46,336 | 46,225 -> 46,225 |
| `polity_area_code` moved | **0** | **0** |
| `polity_code` moved | 1 | 2 |
| `mapping_status` moved | 3 | 16 |

The one `polity_code` move under the default anchor is area 273 Montenegro in
1962, `MNE-1913-1918` -> `MNE-2006-2025`: a nearest-period stand-in
(`out_of_span`) both before and after, now landing on the nearer period under
the exclusive distance. The second, under `-Inf`, is area 107 in 1901,
`CIV-1893-1900` -> `CIV-1902-1932` — the very year upstream #131 names as
falling in no polity, so this is the exclusive metric picking the nearer of two
stand-ins.

**Structural checks, not just "no number moved" (#480/#563):**

- Driving the real `.aggregate_to_polities()` over the same 1961-2024 grid:
  12,953 rows in and out, total value 16,921 in and out, **one** cell differs —
  the area-273 label, `"Montenegro (1913-1918)"` -> `"Montenegro"`.
- One `area_code` -> one `area` label: `area_code`s carrying more than one label
  are **45 before, 45 after**; `(year, area_code)` keys carrying more than one
  label are **64 before, 64 after**, all of them bucket 206 (the Sudan fold of
  whep#414, pre-existing and untouched).
- `tests/testthat/test_read_raw_inputs.R`'s bucket-split guard: passes.
- `.area_year_polity_conflicts()`: **0** rows before and after. The 4 widened
  rows create no overlap — no other period of the same area covers the widened
  year (checked explicitly, 0 for each).

**Tests.** Reverting only the `R/` changes and keeping the new tests gives
**5 failures/errors**:

- `test_constant_territory.R:228` and `:229` — the dissolved `OLD` takes all 100
  and the successors get nothing (`"OLD"` instead of `c("NEW_L", "NEW_R")`;
  `100` instead of `c(50, 50)`).
- `test_polities.R:188` — the existing stand-in invariant, updated to the
  exclusive reading, catches 3 unflagged boundary years.
- `test_polities.R:204` — the three dissolved states read
  `"manual"`/`"matched"`/`"manual"` instead of `"out_of_span"`.
- `test_polities.R:246` — `.polity_join_end_year()` does not exist.

**Gates.** `air format .` (binary), `devtools::document()` (3 `man/` files
refreshed), `lintr::lint_package(...)` -> "No lints found", pkgdown
`man/*.Rd` vs `_pkgdown.yml` comm check -> empty, `devtools::test()` full suite
`[ FAIL 0 | WARN 11 | SKIP 8 | PASS 5751 ]`. `rcmdcheck` left to CI as
instructed.

## Moves published values

**No published value moves.** `polity_area_code` — the bucket every matrix
workflow aggregates on — is unchanged on all 46,550 area-years under both
anchors, the resolved-row count is unchanged, and `.aggregate_to_polities()`
conserves both its row count and its total. What moves is one bucket *label*
(area 273 in 1962) and three `mapping_status` values, from a status that claimed
a real period hit to one that admits a stand-in.

`build_constant_territory_series()` does move numbers when `ref_year` or a data
year is a hand-over year, which is the point: the dissolved predecessor no longer
takes its successors' grid cells. It is not called anywhere in the package's
pipelines, so nothing downstream shifts.

## What I deliberately did not do

- **I did not extend the convention fix to upstream.** The four delta-0 rows are
  arguably an upstream inconsistency — a polity whose exclusive end equals the
  last year its area reports — and the clean fix would be upstream ending those
  four periods at `map_year_end + 1`. Until upstream decides that,
  honouring `map_year_end` here is the change that loses no reported year.
  Filed upstream as eduaguilera/whep-polities#164, with the 240/4/1 table and
  the three options, rather than widening this PR.
- **I did not touch `.area_year_polity_conflicts()`** to make it aware of the
  map-span widening. It reports 0 conflicts today and the 4 widened rows create
  none, so there is nothing to fix; a future vintage could change that.
- **I did not run any gridded build** (`build_nitrogen_balance()`,
  `build_carbon_balance()`, `build_water_balance()`): they need multi-GB local
  rasters and hours. None of them resolve polities at a period boundary in a way
  this could reach that `polity_area_code` invariance does not already cover.
- **I did not re-measure through a full `build_commodity_balances()`**, for the
  same reason. `.aggregate_to_polities()` is the seam every CBS/production read
  passes through, and it is driven for real above.

## The open decision

`build_constant_territory_series(ref_year = 2025)` now aborts with "No polities
with a polygon are active in `ref_year` = 2025", because the vintage's open
periods carry 2025 as their exclusive end and therefore stop at 2024. That is
correct under the convention and no WHEP data year reaches 2025, but it is a
behaviour change for a caller who passed the horizon year. The alternative would
be to treat the maximum `end_year` in the supplied table as an open sentinel that
does cover its own year — which reintroduces a second reading of the same field,
so I did not. Say if you would rather have the sentinel.

Closes #550
Part of the polity migration epic #458.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
