### PR TITLE
fix(polities): name a folded reporting bucket after the bucket, not the member that sorts first

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,30 @@
 # whep (development version)
 
+* A reporting bucket that folds several territories is now named after the
+  **bucket**, not after whichever member sorted first. `.aggregate_to_polities()`
+  grouped by each row's own `polity_name`, so bucket 206 -- FAOSTAT areas 276
+  Sudan and 277 South Sudan summed into FABIO's Sudan region -- came out as two
+  rows sharing one `area_code` under two `area` labels, and the one that survived
+  downstream was decided by row order. Measured on real FAOSTAT crops/livestock
+  for 2015, bucket 206 held 439 rows, 268 labelled "Sudan" and 171 "South
+  Sudan", and the commodity-balance lookup kept **"South Sudan"** for a bucket
+  that is 78% Sudan by production, contradicting `reporting_polity_name` on the
+  same row. The bucket is now labelled from its own numeric code, the same
+  resolution `reporting_polity_name` uses, so the two agree: bucket 206 reads
+  `"Sudan (1956-2011)"`, the unified Sudan whose extent is Sudan plus South
+  Sudan. The period is still wrong for post-2011 rows and cannot be fixed here --
+  no live polity means "Sudan and South Sudan" (whep#414,
+  lbm364dl/whep-polities#139).
+* That collapse moves a small number of published values, all descending from
+  bucket 206. Because the members used to arrive as separate rows, the
+  non-primary-source mean in `.select_best_source()` averaged Sudan against South
+  Sudan instead of summing them, which is not what a fold means. On a
+  2012-2016 `build_commodity_balances()`, **104 of 407,312 keys change (0.026%)**:
+  35 in bucket 206, at most +15,444 t on one key, and 69 elsewhere reached
+  through trade balancing, at most 2.7 t (0.1%). Global element totals move by at
+  most 2.1e-6 (`export`); `production`, `food` and `seed` do not move at all. Row
+  counts, key sets and column names are unchanged.
+
 * `polities` and `polity_area_crosswalk` are re-synced against upstream
   `whep-polities` at `eb02dcb` (740 rows to **749**), which retired or superseded
   **14** codes this package had been treating as live and published a replacement

--- a/R/build_cbs.R
+++ b/R/build_cbs.R
@@ -1224,12 +1224,17 @@ build_processing_coefs <- function(
   )
   dt <- dt[!is.na(polity_code)]
 
+  # Same bucket-labelling rule as `.aggregate_to_polities()`, which this
+  # repeats by hand: a folded bucket is named after the bucket, not after
+  # whichever member sorts first (whep#546). Both paths feed joins keyed on
+  # `c("year", "area", "area_code", ...)`, so they must share one vocabulary.
+  dt <- .label_polity_buckets(dt)
   dt <- dt[,
     .(value = sum(value, na.rm = TRUE)),
     by = c(
       "year",
       "polity_area_code",
-      "polity_name",
+      "polity_bucket_name",
       "item_cbs",
       "item_cbs_code",
       "element"
@@ -1237,7 +1242,7 @@ build_processing_coefs <- function(
   ]
   data.table::setnames(
     dt,
-    c("polity_area_code", "polity_name"),
+    c("polity_area_code", "polity_bucket_name"),
     c("area_code", "area")
   )
   dt

--- a/R/polity_folds.R
+++ b/R/polity_folds.R
@@ -126,6 +126,54 @@ polity_bucket_coverage <- function(years = NULL) {
     )
 }
 
+# Name a reporting bucket after the BUCKET, not after one of its members.
+#
+# `.aggregate_to_polities()` sums rows into `polity_area_code` and then renames
+# that pair onto `area_code`/`area`. Until whep#546 the name half came from each
+# row's own `polity_name`, so a bucket folding two live territories emitted one
+# row per member, each carrying the member's name under the bucket's code. The
+# name that then survived downstream was decided by row order:
+# `build_cbs.R`'s `unique(dt_raw[, .(area_code, area)], by = "area_code")` keeps
+# the first row, and `.read_fao_crop_liv()` sorts by `area` first. Measured on
+# real FAOSTAT 2015, bucket 206 held 268 "Sudan" rows and 171 "South Sudan"
+# rows, and "South Sudan" won because "South" sorts before "Sudan" -- naming a
+# bucket that is 78% Sudan by production after the smaller successor.
+#
+# The rule here is the one every unfolded code already follows, and which
+# bucket 999 follows by luck (all 62 Rest-of-World members resolve to the same
+# polity): a bucket carries the name its own numeric code resolves to for that
+# year. That is also exactly what `.add_reporting_polity_columns()` resolves
+# `reporting_polity_name` from, so the two name columns can no longer disagree
+# about which territory the value belongs to.
+#
+# Bucket 206 is the only bucket this moves, and it moves it to
+# "Sudan (1956-2011)" -- the unified Sudan, whose extent IS Sudan plus South
+# Sudan. The period is wrong for post-2011 rows and that is not fixable here:
+# no live polity means "Sudan and South Sudan" -- see whep#414 and upstream
+# issue 139 in lbm364dl/whep-polities. An explicit, documented, wrong-period
+# name beats a right-period name for 22% of the value.
+#
+# Falling back to the row's own polity name keeps a bucket whose code resolves
+# to nothing labelled rather than NA; no bucket needs it today.
+.label_polity_buckets <- function(dt) {
+  keys <- unique(
+    dt[!is.na(polity_area_code), .(area_code = polity_area_code, year)]
+  )
+  labels <- .add_polity_columns_dt(
+    keys,
+    code_col = "area_code",
+    year_col = "year",
+    include_unmapped = FALSE
+  )[, .(polity_area_code = area_code, year, polity_bucket_name = polity_name)]
+  dt[
+    labels,
+    polity_bucket_name := i.polity_bucket_name,
+    on = c("polity_area_code", "year")
+  ]
+  dt[is.na(polity_bucket_name), polity_bucket_name := polity_name]
+  dt
+}
+
 # Warn where a build has just summed several territories into one bucket whose
 # polity names only part of them. Wired into `.aggregate_to_polities()`, which
 # is where the sum is created; the reporting-column helper runs on ~100 outputs

--- a/R/polity_folds.R
+++ b/R/polity_folds.R
@@ -258,7 +258,7 @@ polity_bucket_coverage <- function(years = NULL) {
 #' Two kinds exist, and they are not equally defensible:
 #'
 #' - `"fabio_rest_of_world"`: FABIO collapses the area into its single
-#'   Rest-of-World row (`polity_area_code` 999, `ROW-1850-2023`). Most such
+#'   Rest-of-World row (`polity_area_code` 999, `ROW-1850-2025`). Most such
 #'   areas report nothing, but several report substantial data of their own:
 #'   Syria, Eswatini, New Caledonia, North Macedonia, Reunion, Guadeloupe,
 #'   Palestine, the Faroe Islands. Their observed values are attributed to Rest

--- a/R/read_raw_inputs.R
+++ b/R/read_raw_inputs.R
@@ -326,10 +326,13 @@
   # that covers only part of it (whep#414).
   .warn_partial_bucket_polities(dt)
   .warn_folded_areas(dt, source_label)
+  # Label the bucket after the bucket, not after whichever member happens to
+  # sort first (whep#546). See `.label_polity_buckets()`.
+  dt <- .label_polity_buckets(dt)
   by_cols <- c(
     "year",
     "polity_area_code",
-    "polity_name",
+    "polity_bucket_name",
     "unit",
     "element",
     dots
@@ -347,7 +350,7 @@
 
   data.table::setnames(
     dt,
-    c("polity_area_code", "polity_name"),
+    c("polity_area_code", "polity_bucket_name"),
     c("area_code", "area")
   )
   dt

--- a/R/utils.R
+++ b/R/utils.R
@@ -1788,7 +1788,10 @@ utils::globalVariables(
     "iso3_code",
     "profile_row",
     # polity_folds.R (#419) — reporting-area fold diagnostic
-    "rows"
+    "rows",
+    # polity_folds.R (#546) — deterministic label for a folded reporting bucket
+    "polity_bucket_name",
+    "i.polity_bucket_name"
   )
 )
 

--- a/man/folded_reporting_areas.Rd
+++ b/man/folded_reporting_areas.Rd
@@ -31,7 +31,7 @@ well, only to a territory that did not report the data.
 Two kinds exist, and they are not equally defensible:
 \itemize{
 \item \code{"fabio_rest_of_world"}: FABIO collapses the area into its single
-Rest-of-World row (\code{polity_area_code} 999, \code{ROW-1850-2023}). Most such
+Rest-of-World row (\code{polity_area_code} 999, \code{ROW-1850-2025}). Most such
 areas report nothing, but several report substantial data of their own:
 Syria, Eswatini, New Caledonia, North Macedonia, Reunion, Guadeloupe,
 Palestine, the Faroe Islands. Their observed values are attributed to Rest

--- a/tests/testthat/test_polity_folds.R
+++ b/tests/testthat/test_polity_folds.R
@@ -508,6 +508,31 @@ testthat::test_that("an unfolded area keeps the label it always had", {
   testthat::expect_equal(out$area, "Spain")
 })
 
+testthat::test_that(".read_crop_residues uses the same bucket label", {
+  # `.read_crop_residues()` repeats the aggregation by hand, and both paths feed
+  # joins keyed on `c("year", "area", "area_code", ...)`, so a second `area`
+  # vocabulary for one bucket is the shape #382 measured at 702,166 dropped
+  # rows. Mocked, not pinned -- the suite must not reach the network.
+  testthat::local_mocked_bindings(
+    get_primary_residues = function(...) {
+      tibble::tribble(
+        ~year, ~area_code, ~item_cbs_code_crop, ~item_cbs_code_residue, ~value,
+        2015,  276,        2511,                2105,                   800,
+        2015,  277,        2511,                2105,                   200
+      )
+    }
+  )
+
+  out <- suppressWarnings(whep:::.read_crop_residues(years = 2015L))
+
+  testthat::expect_setequal(out$area_code, 206L)
+  testthat::expect_setequal(out$area, "Sudan (1956-2011)")
+  # One row per element, not one per member: production plus the derived
+  # feed/other-uses row that this reader adds.
+  testthat::expect_equal(nrow(out), data.table::uniqueN(out$element))
+  testthat::expect_equal(sum(out$value[out$element == "production"]), 1000)
+})
+
 testthat::test_that(".label_polity_buckets falls back to the row's polity", {
   # No bucket needs this today; it exists so a bucket code that resolves to no
   # polity stays labelled rather than turning `area` into NA.

--- a/tests/testthat/test_polity_folds.R
+++ b/tests/testthat/test_polity_folds.R
@@ -139,9 +139,9 @@ test_that(".aggregate_to_polities warns when it folds Sudan into bucket 206", {
     "Bucket 206"
   )
 
-  # No value moved: the two members keep their own rows and their own values,
-  # and both now sit under bucket code 206.
-  expect_equal(folded$area_code, c(206L, 206L))
+  # One bucket, one row, one label (whep#546 -- before that the two members
+  # came back as two rows carrying their own names under the bucket's code).
+  expect_equal(folded$area_code, 206L)
   expect_equal(sum(folded$value), 3405356)
 
   withr::local_options(whep.warn_polity_folds = FALSE)
@@ -390,4 +390,132 @@ testthat::test_that("folded_reporting_areas() rejects a frame it cannot read", {
     whep::folded_reporting_areas(tibble::tibble(area_code = 1L)),
     "missing"
   )
+})
+
+# A folded bucket's name is a decision, not a sort accident (whep#546) ---------
+
+testthat::test_that("a folded bucket is named after the bucket, not a member", {
+  # BEFORE whep#546 this came back as two rows, "South Sudan" first, because
+  # `.aggregate_to_polities()` grouped by each row's OWN `polity_name` and
+  # `.read_fao_crop_liv()` sorts by `area`. Measured on real FAOSTAT 2015,
+  # bucket 206 held 268 "Sudan" rows and 171 "South Sudan" rows, and
+  # `unique(dt_raw[, .(area_code, area)], by = "area_code")` in build_cbs.R kept
+  # "South Sudan" -- naming a bucket that is 78% Sudan by production after the
+  # smaller successor.
+  sudan <- data.table::data.table(
+    year = c(2015L, 2015L),
+    area_code = c(276L, 277L),
+    element = "production",
+    unit = "t",
+    item_prod_code = "83",
+    item_prod = "Sorghum",
+    value = c(2744000, 661356)
+  )
+
+  out <- suppressWarnings(
+    whep:::.aggregate_to_polities(
+      data.table::copy(sudan),
+      item_prod_code,
+      item_prod
+    )
+  )
+
+  testthat::expect_equal(nrow(out), 1L)
+  testthat::expect_equal(out$area_code, 206L)
+  testthat::expect_equal(out$area, "Sudan (1956-2011)")
+  testthat::expect_equal(out$value, 3405356)
+})
+
+testthat::test_that("the bucket label does not depend on input row order", {
+  # The mechanism, isolated: reverse the rows and nothing about the answer may
+  # move. Under the old rule the label flipped between the two members.
+  mk <- function(codes, values) {
+    data.table::data.table(
+      year = 2015L,
+      area_code = codes,
+      element = "production",
+      unit = "t",
+      item_prod_code = "83",
+      item_prod = "Sorghum",
+      value = values
+    )
+  }
+
+  forwards <- suppressWarnings(
+    whep:::.aggregate_to_polities(
+      mk(c(276L, 277L), c(2744000, 661356)),
+      item_prod_code,
+      item_prod
+    )
+  )
+  backwards <- suppressWarnings(
+    whep:::.aggregate_to_polities(
+      mk(c(277L, 276L), c(661356, 2744000)),
+      item_prod_code,
+      item_prod
+    )
+  )
+
+  testthat::expect_equal(
+    as.data.frame(forwards),
+    as.data.frame(backwards)
+  )
+})
+
+testthat::test_that("the bucket label agrees with reporting_polity_name", {
+  # The two name columns contradicted each other on the same row: `area` said
+  # "South Sudan" while `reporting_polity_name`, resolved from the bucket code,
+  # said "Sudan (1956-2011)". They are now resolved from the same place.
+  sudan <- data.table::data.table(
+    year = 2015L,
+    area_code = c(276L, 277L),
+    element = "production",
+    unit = "t",
+    item_prod_code = "83",
+    item_prod = "Sorghum",
+    value = c(2744000, 661356)
+  )
+
+  out <- suppressWarnings(
+    whep:::.aggregate_to_polities(
+      data.table::copy(sudan),
+      item_prod_code,
+      item_prod
+    )
+  ) |>
+    whep:::.add_reporting_polity_columns()
+
+  testthat::expect_equal(out$area, out$reporting_polity_name)
+})
+
+testthat::test_that("an unfolded area keeps the label it always had", {
+  # The rule generalises what every unfolded code already does, so no code
+  # whose bucket is itself may move.
+  spain <- data.table::data.table(
+    year = 2015L,
+    area_code = 203L,
+    element = "production",
+    unit = "t",
+    item_prod_code = "15",
+    item_prod = "Wheat",
+    value = 5000
+  )
+
+  out <- suppressWarnings(
+    whep:::.aggregate_to_polities(spain, item_prod_code, item_prod)
+  )
+  testthat::expect_equal(out$area_code, 203L)
+  testthat::expect_equal(out$area, "Spain")
+})
+
+testthat::test_that(".label_polity_buckets falls back to the row's polity", {
+  # No bucket needs this today; it exists so a bucket code that resolves to no
+  # polity stays labelled rather than turning `area` into NA.
+  dt <- data.table::data.table(
+    year = 2015L,
+    polity_area_code = -1L,
+    polity_name = "Somewhere"
+  )
+  out <- whep:::.label_polity_buckets(dt)
+  testthat::expect_equal(out$polity_bucket_name, "Somewhere")
 })

--- a/tests/testthat/test_read_raw_inputs.R
+++ b/tests/testthat/test_read_raw_inputs.R
@@ -102,3 +102,34 @@ test_that("a bucket comes out of the aggregator under exactly one area label", {
   # precisely why it is not sufficient on its own.
   expect_equal(sum(out$value), sum(raw$value))
 })
+
+test_that("the one-label invariant holds for the bucket that broke it", {
+  # The guard above uses bucket 999, whose 62 members all resolve to
+  # `ROW-1850-2025` -- so it passed even while bucket 206 was violating the
+  # invariant on every real build. Areas 276 Sudan and 277 South Sudan both
+  # carry `polity_area_code` 206 but resolve to DIFFERENT polities, so before
+  # whep#546 the aggregator emitted two rows under code 206, labelled "Sudan"
+  # and "South Sudan". Measured on real `.read_fao_crop_liv(years = 2015)`:
+  # 439 rows in bucket 206 under two labels, 268 / 171.
+  raw <- tibble::tribble(
+    ~year, ~area_code, ~item_cbs_code, ~element,     ~unit, ~value,
+    2015L, 276L,       2511,           "production", "t",   5312,
+    2015L, 277L,       2511,           "production", "t",   1488,
+    2015L, 203L,       2511,           "production", "t",   7
+  )
+
+  out <- suppressWarnings(
+    whep:::.aggregate_to_polities(
+      data.table::as.data.table(raw),
+      item_cbs_code
+    )
+  )
+
+  labels_per_code <- tapply(out$area, out$area_code, function(x) {
+    length(unique(x))
+  })
+  expect_true(all(labels_per_code == 1L))
+  expect_equal(nrow(out[out$area_code == 206L, ]), 1L)
+  expect_equal(sum(out$value[out$area_code == 206L]), 6800)
+  expect_equal(sum(out$value), sum(raw$value))
+})


### PR DESCRIPTION
## What was wrong

`.aggregate_to_polities()` (`R/read_raw_inputs.R`) grouped by `polity_area_code`
**and** each row's own `polity_name`, then renamed the pair onto `area_code` /
`area`. A bucket folding more than one live territory therefore emitted **one row
per member**, all sharing the bucket's numeric code but each carrying its
*member's* name. `build_cbs.R:1632` then reduced those to one name per bucket by
row order:

```r
area_lookup <- unique(dt_raw[, .(area_code, area)], by = "area_code")
```

`unique(..., by =)` keeps the first row, and `.read_fao_crop_liv()` sorts by
`area` before that. So the name a folded bucket carried downstream was whichever
member sorted **first alphabetically**.

Bucket 206 is the only bucket exposed: it folds FAOSTAT areas 276 Sudan and 277
South Sudan (bucket 999's 62 members all resolve to the single name
`Rest of World`, so it is already the aggregate's).

Two consequences beyond tidiness:

- It **also violated the one-`area_code`-one-`area`-label invariant** that #563
  is about, on every real build. The guard added for that in
  `test_read_raw_inputs.R` uses bucket 999, which cannot fail it — so the one
  bucket that was failing went unnoticed.
- `area` and `reporting_polity_name` **contradicted each other on the same row**.

## Evidence it reproduced BEFORE the change

At `origin/main` = `2759be3e`, real `whep:::.read_fao_crop_liv(years = 2015L)`
(FAOSTAT crops/livestock pin, offline cache):

```
rows: 52710
bucket 206 rows: 439
          area     N
1: South Sudan   171
2:       Sudan   268

name the CBS area_lookup picks (unique by area_code):
   area_code        area
1:       206 South Sudan

labels per area_code, buckets with >1:
   area_code     n
1:       206     2
```

The sort-order dependence, shown directly — same two rows, opposite order:

```
unique(by = area_code) on ascending-name order:   206  South Sudan
unique(by = area_code) on descending-name order:  206  Sudan
```

And the aggregator itself, on the real crosswalk:

```
   year area_code        area   unit    element item_cbs_code  value
1:  2015       206       Sudan tonnes production          2511 5312.4
2:  2015       206 South Sudan tonnes production          2511 1487.6

labels per area_code: 206 -> 2
```

Bucket 206 in 2015 is **78% Sudan** by production, and the label that survived
was `South Sudan`, because "South" sorts before "Sudan". On the same row
`reporting_polity_name` said `Sudan (1956-2011)`.

Scope check over the whole crosswalk, all 201 buckets x 1961-2025: **exactly one**
bucket emits more than one label in a year — 206, in all 65 years. Only three
buckets have more than one member at all (999 with 62, 206 with 3, 238 with 2).

## What I changed

`.label_polity_buckets()` (new, `R/polity_folds.R`) resolves each
`(polity_area_code, year)` through `.add_polity_columns_dt()` — the bucket's
**own** numeric code — and stamps that name on every row of the bucket.
`.aggregate_to_polities()` groups on it instead of on each row's `polity_name`.
`.read_crop_residues()`, which repeats the same aggregation by hand at
`build_cbs.R:1225`, gets the same rule so both paths share one `area` vocabulary
(four inner joins key on `c("year", "area", "area_code", ...)`).

The rule is not new: it is what **every unfolded code already does** (its bucket
is itself) and what bucket 999 does by luck. 206 was the sole exception, and only
by accident. It is also exactly the resolution
`.add_reporting_polity_columns()` uses for `reporting_polity_name`, so the two
name columns can no longer disagree.

Bucket 206 now reads **`Sudan (1956-2011)`** — the unified Sudan, whose extent
*is* Sudan plus South Sudan. There is a fallback to the row's own polity name if
a bucket code resolves to no polity; no bucket needs it today.

One drive-by, doc-only, in the same file: `folded_reporting_areas()`'s roxygen
still said the Rest-of-World bucket resolves to `ROW-1850-2023`. #551 retired
that code; the crosswalk returns `ROW-1850-2025`.

## How I verified

Gates, all from `Rscript --vanilla` in the worktree:

- `air format .` — clean, run as the binary.
- `devtools::document()` — no `man/` change (the helper is private).
- `lintr::lint_package(...)` with the four disabled linters — **0 lints**.
- `devtools::test()` — **FAIL 0 | WARN 11 | SKIP 8 | PASS 5717**.
- pkgdown `comm` check — empty.

**Assertions that fail without the change**: the new tests were copied onto a
clean `git archive origin/main` export and run there — **10 failures in
`test_polity_folds.R` plus 2 in `test_read_raw_inputs.R`**, across 7 test
blocks, including the updated `.aggregate_to_polities warns when it folds Sudan
into bucket 206`, the order-independence test, the
`area == reporting_polity_name` test, the `.read_crop_residues` test, and the
new bucket-206 arm of the #563 guard.

`.read_crop_residues()` had **no test at all** before this; it now has one, with
`get_primary_residues()` mocked (the suite must not reach the network).

**Structural checks — not just "no number moved"** (that is what #480 proved
insufficient). On real `.read_fao_crop_liv(years = 2015)`, before vs after:

| | before | after |
|---|---|---|
| rows | 52,710 | 52,552 |
| bucket 206 rows | 439 (2 labels) | 281 (1 label) |
| `area_code`s with >1 `area` label | 1 (code 206) | **0** |
| total value | 47,450,467,214 | 47,450,467,214 |
| bucket 206 total | 733,412,974 | 733,412,974 |
| rows outside 206 | identical | identical (`all.equal` TRUE) |
| bucket 206 keys | 281 | 281, 0 unmatched, max abs value diff **0** |

The 158 rows that disappear are exactly the duplicate member rows collapsing;
no key is added or removed, and the value on every key is unchanged.

**The #563 guard**: `test_read_raw_inputs.R` passes, and I added a second arm to
it using areas 276/277 — the pair that actually violated the invariant. That arm
fails on `origin/main`.

**Real pipeline**: `build_commodity_balances(get_primary_production(), 2012,
2016)` built on `origin/main` and on this branch, 407,312 rows each. Diff below.

## Moves published values

Yes, slightly, and traceably. Because the members used to arrive as *separate
rows*, the non-primary-source mean in `.select_best_source()`

```r
other_dt <- dt_raw[!source %in% primary_sources & !is.na(value),
                   .(other_mean = mean(value, na.rm = TRUE)), by = key_cols]
```

averaged Sudan against South Sudan instead of summing them — `key_cols`
deliberately excludes `area`, so the two member rows looked like two *sources*.
A fold means the sum (that is the reasoning already written into the `dcast`
`fun.aggregate` comment for the same rows). With one row per bucket it now sums.

Measured, 2012-2016 `build_commodity_balances()`:

- **104 of 407,312 keys change (0.026%)**; 35 in bucket 206, 69 elsewhere.
- Largest move: bucket 206, item 2748, 2015 `export` `mean`,
  15,443.65 -> 30,887.30 t (exactly 2x, i.e. mean-of-two -> sum-of-two).
- Largest move **outside** bucket 206: **2.7 t**, max relative **0.1%** — these
  are reached through trade balancing, not directly.
- Total |diff| **64,330 t** against a total of 353,063,427,088 t (1.8e-7).
- Global totals by element, after/before: `export` 1.0000021, `other_uses`
  0.9999986, `import` 1.0000002, `domestic_supply` 0.9999998, `feed` 1.0000000;
  `production`, `food`, `seed`, `stock_variation`, `processing` unchanged.
- Row count, column names, key set: **identical**. Zero duplicate
  `(year, area_code, item_cbs_code, element, source)` keys before and after.

`area` itself does not appear in the published `build_commodity_balances()` or
`build_primary_production()` outputs — both emit `polity_area_code` and
`reporting_polity_name` — so the label change is visible in the long-format CBS
intermediate and in the `area`-keyed joins, not in those two tables' columns.

## What I deliberately did not do

- **I did not create an aggregate polity for the fold.** That is option 2 of
  both #414 and #546 and it needs an upstream entity
  (lbm364dl/whep-polities#139, open). `Sudan (1956-2011)` has the right extent
  and the wrong period for post-2011 rows; that is stated in the code comment
  and in `NEWS.md` rather than papered over. **This PR does not close #414 or
  the upstream issue.**
- **I did not un-fold 276/277** (option 1). That changes the matrix
  regionalisation and diverges from FABIO — a science decision, not a naming
  one, and #563's live question.
- **I did not make `build_cbs.R:1632` deterministic across years.** With this
  fix a bucket has one label per *year*, but 44 buckets legitimately change
  their own label at a period boundary (e.g. `Algeria (1919-1962)` ->
  `Algeria (1962-2025)`), and that lookup still picks by row order across a
  multi-year build. Filed separately rather than widened into here.
- **I did not run a full-range 1850-2023 CBS or any gridded build.** The
  measurement above is 2012-2016, chosen because it brackets the 2011 secession
  and avoids the historical-extension path; gridded builds need multi-GB local
  rasters and hours.
- `fao_flag = fao_flag[1L]` in the aggregator is still order-dependent, and the
  collapse makes it pick from a larger group for bucket 206. Out of scope,
  filed separately.

## The open decision

**Is `Sudan (1956-2011)` the label the maintainer wants on a post-2011
two-territory bucket?** The alternatives are `Sudan (former)` (FAOSTAT's own
name for area 206, in the same vocabulary as the code) or a new upstream
aggregate polity meaning "Sudan and South Sudan, 2011 onwards". I picked the
bucket's resolved polity name because it is the rule every other code already
follows and it makes `area` and `reporting_polity_name` agree by construction —
but it is one line to change, and it is a naming call, not a numeric one.

Closes #546.
Part of the polity migration epic #458.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
