### PR TITLE
#444: the 7% feed shift is not on main, and the polity data's real effect is four areas' pre-1961 back-cast

### DIFF
--- a/inst/scripts/compare_cbs_totals.R
+++ b/inst/scripts/compare_cbs_totals.R
@@ -45,10 +45,10 @@
   )
 }
 
-# Count buckets emitted under more than one label IN A GIVEN YEAR. Across years a
-# bucket legitimately carries several `reporting_polity_name` values, because the
-# polity name is periodized -- so the year has to be in the key or this metric
-# reports every relabelling as a split.
+# Count buckets emitted under more than one label IN A GIVEN YEAR. Across
+# years a bucket legitimately carries several `reporting_polity_name` values,
+# because the polity name is periodized -- so the year has to be in the key
+# or this metric reports every relabelling as a split.
 .cbs_split_labels <- function(x) {
   lab <- unique(x[, c("area_code", "year", "reporting_polity_name")])
   sum(table(lab$area_code, lab$year) > 1L)

--- a/inst/scripts/compare_cbs_totals.R
+++ b/inst/scripts/compare_cbs_totals.R
@@ -45,9 +45,13 @@
   )
 }
 
+# Count buckets emitted under more than one label IN A GIVEN YEAR. Across years a
+# bucket legitimately carries several `reporting_polity_name` values, because the
+# polity name is periodized -- so the year has to be in the key or this metric
+# reports every relabelling as a split.
 .cbs_split_labels <- function(x) {
-  lab <- unique(x[, c("area_code", "reporting_polity_name")])
-  sum(table(lab$area_code) > 1L)
+  lab <- unique(x[, c("area_code", "year", "reporting_polity_name")])
+  sum(table(lab$area_code, lab$year) > 1L)
 }
 
 .cbs_totals_structure <- function(a, b) {

--- a/inst/scripts/compare_cbs_totals.R
+++ b/inst/scripts/compare_cbs_totals.R
@@ -1,0 +1,156 @@
+# Compare two full-range `get_wide_cbs()` builds, by magnitude AND by
+# structure.
+#
+# WHY THIS EXISTS. Nothing in the test suite compares a CBS column total
+# against anything, because a full-range build needs pins and ~9 minutes and
+# so cannot live in `R CMD check`. That gap is how whep#425 shipped row counts
+# in place of tonnes, and how whep#444 could report feed moving 7% with no way
+# to localise it except hand-written throwaway code. This is that code, kept.
+#
+# WHY IT REPORTS STRUCTURE AS WELL AS TOTALS. whep#480 moved no value at all
+# -- mass conserved, `polity_area_code` unchanged for all 266 areas -- and it
+# still broke the build, because one bucket started coming out under two
+# labels. "No number moved" is not evidence on its own; row counts, key counts
+# and label counts are the other half.
+#
+# USAGE
+#   Rscript --vanilla inst/scripts/compare_cbs_totals.R build <root> <out.rds>
+#   Rscript --vanilla inst/scripts/compare_cbs_totals.R compare <a.rds> <b.rds>
+#
+# To isolate a data change from a code change, `git archive` the package into
+# a scratch directory, replace the `data/*.rda` under test, and `build` from
+# that root. Run each half alone: one measurement over two candidate causes
+# attributes nothing (whep#418).
+#
+# RECORDED BASELINE -- `main` at 6e5af760, full range 1850-2023, 9.1 min:
+#   rows 2,005,267   areas 195   feed 9.05014e11   production 3.00743e12
+#   other_uses 9.17874e10   domestic_supply 3.14683e12   food 3.14340e11
+#   processing 1.76770e12   import 1.11382e11   export 7.91341e10
+#   seed 5.03169e10   stock_addition 3.93577e10   stock_withdrawal 1.46513e11
+
+.cbs_totals_build <- function(pkg_root, out) {
+  pkgload::load_all(pkg_root, quiet = TRUE)
+  started <- Sys.time()
+  wide <- get_wide_cbs()
+  mins <- as.numeric(difftime(Sys.time(), started, units = "mins"))
+  cli::cli_inform("Built in {round(mins, 2)} min.")
+  saveRDS(wide, out, compress = FALSE)
+  invisible(wide)
+}
+
+.cbs_value_cols <- function(wide) {
+  setdiff(
+    names(wide)[vapply(wide, is.numeric, logical(1))],
+    c("year", "area_code", "polity_area_code", "item_cbs_code")
+  )
+}
+
+.cbs_split_labels <- function(x) {
+  lab <- unique(x[, c("area_code", "reporting_polity_name")])
+  sum(table(lab$area_code) > 1L)
+}
+
+.cbs_totals_structure <- function(a, b) {
+  key <- c("year", "area_code", "item_cbs_code")
+  data.frame(
+    metric = c(
+      "rows",
+      "distinct keys",
+      "duplicate keys",
+      "areas",
+      "items",
+      "codes with >1 polity label"
+    ),
+    a = c(
+      nrow(a),
+      nrow(unique(a[, key])),
+      nrow(a) - nrow(unique(a[, key])),
+      length(unique(a$area_code)),
+      length(unique(a$item_cbs_code)),
+      .cbs_split_labels(a)
+    ),
+    b = c(
+      nrow(b),
+      nrow(unique(b[, key])),
+      nrow(b) - nrow(unique(b[, key])),
+      length(unique(b$area_code)),
+      length(unique(b$item_cbs_code)),
+      .cbs_split_labels(b)
+    )
+  )
+}
+
+.cbs_sum_by <- function(x, group, value) {
+  stats::aggregate(
+    x[[value]],
+    by = list(g = x[[group]]),
+    FUN = sum,
+    na.rm = TRUE
+  )
+}
+
+.cbs_totals_by <- function(a, b, group, value) {
+  out <- merge(
+    .cbs_sum_by(a, group, value),
+    .cbs_sum_by(b, group, value),
+    by = "g",
+    all = TRUE,
+    suffixes = c("_a", "_b")
+  )
+  out$x_a[is.na(out$x_a)] <- 0
+  out$x_b[is.na(out$x_b)] <- 0
+  out$delta <- out$x_b - out$x_a
+  out$ratio <- out$x_b / out$x_a
+  names(out)[names(out) == "g"] <- group
+  out[order(-abs(out$delta)), ]
+}
+
+.cbs_totals_compare <- function(fa, fb) {
+  a <- as.data.frame(readRDS(fa))
+  b <- as.data.frame(readRDS(fb))
+
+  cat("== structure\n")
+  print(.cbs_totals_structure(a, b), row.names = FALSE)
+
+  cat("\n== column totals\n")
+  cols <- intersect(.cbs_value_cols(a), .cbs_value_cols(b))
+  totals <- data.frame(
+    column = cols,
+    a = vapply(cols, \(n) sum(a[[n]], na.rm = TRUE), numeric(1)),
+    b = vapply(cols, \(n) sum(b[[n]], na.rm = TRUE), numeric(1))
+  )
+  totals$ratio <- totals$b / totals$a
+  print(totals, row.names = FALSE)
+
+  for (value in c("feed", "production")) {
+    cat("\n== top 10 areas by |", value, "| delta\n", sep = "")
+    print(
+      utils::head(.cbs_totals_by(a, b, "area_code", value), 10),
+      row.names = FALSE
+    )
+    cat("\n== top 10 items by |", value, "| delta\n", sep = "")
+    print(
+      utils::head(.cbs_totals_by(a, b, "item_cbs_code", value), 10),
+      row.names = FALSE
+    )
+  }
+  invisible(NULL)
+}
+
+.cbs_totals_main <- function(args) {
+  if (length(args) < 3L) {
+    cli::cli_abort("Usage: compare_cbs_totals.R build|compare <arg1> <arg2>")
+  }
+  switch(
+    args[1],
+    build = .cbs_totals_build(args[2], args[3]),
+    compare = .cbs_totals_compare(args[2], args[3]),
+    cli::cli_abort(
+      "Unknown mode {.val {args[1]}}; use {.val build} or {.val compare}."
+    )
+  )
+}
+
+if (sys.nframe() == 0L && !interactive()) {
+  .cbs_totals_main(commandArgs(trailingOnly = TRUE))
+}

--- a/tests/testthat/test_polity_resolution_coverage.R
+++ b/tests/testthat/test_polity_resolution_coverage.R
@@ -1,0 +1,92 @@
+# WHAT A POLITY RE-SYNC MAY DO TO A BUILD, PINNED WITHOUT BUILDING (whep#444).
+#
+# `.aggregate_to_polities()` drops every row whose `area_code`/`year` resolves
+# to no polity, and it groups by `polity_name` beside `polity_area_code`. So a
+# change to the shipped crosswalk moves published quantities through exactly
+# two doors:
+#
+#   1. COVERAGE -- an area-year that used to resolve stops resolving (or
+#      starts), so source rows leave or enter the build.
+#   2. LABEL SPLIT -- two areas folded into one bucket stop sharing a
+#      `polity_name`, so the bucket is emitted as several rows instead of
+#      summed into one. That is whep#480, reverted in whep#561:
+#      `polity_area_code` was unchanged for all 266 areas and mass conserved,
+#      and the build broke anyway.
+#
+# Neither door is visible to a value-neutrality check, and finding out which
+# one a vintage opened used to cost two ~9-minute full-range `get_wide_cbs()`
+# builds. Both are decidable from `polity_area_crosswalk` alone, offline, in
+# about a second -- so they are decided here.
+#
+# Both are tripwires: they are meant to fail on a deliberate re-sync, and the
+# maintainer is meant to re-state the new expectation rather than delete them.
+
+# The default `build_commodity_balances()` window, which is what the published
+# wide CBS covers. `.add_polity_columns_dt()` floors the lookup year at its
+# 1961 back-cast anchor, so pre-1961 rows resolve to the 1961 territory.
+.resolution_grid <- function(years = 1850:2023) {
+  cw <- whep::polity_area_crosswalk
+  areas <- sort(unique(stats::na.omit(cw$area_code)))
+  grid <- data.table::CJ(area_code = areas, year = years)
+  whep:::.add_polity_columns_dt(
+    grid,
+    code_col = "area_code",
+    year_col = "year",
+    include_unmapped = FALSE
+  )
+}
+
+testthat::test_that("only three reporting areas fail to resolve", {
+  resolved <- .resolution_grid()
+
+  gaps <- resolved[is.na(polity_code), c("area_code", "year"), with = FALSE]
+
+  # Stated as rules rather than as a count, so the expectation carries the
+  # reason it holds:
+  #   15  Belgium-Luxembourg   -- reports jointly only to 1999, after which
+  #                               Belgium (255) and Luxembourg (256) report
+  #                               separately.
+  #   151 Netherlands Antilles -- dissolved in 2010.
+  #   351 China                -- the FAOSTAT statistical aggregate, left
+  #                               unmapped on purpose so that it cannot
+  #                               double-count areas 41, 96, 128 and 214.
+  expected <- rbind(
+    data.frame(area_code = 15L, year = 2000:2023),
+    data.frame(area_code = 151L, year = 2011:2023),
+    data.frame(area_code = 351L, year = 1850:2023)
+  )
+
+  testthat::expect_setequal(
+    paste(gaps$area_code, gaps$year),
+    paste(expected$area_code, expected$year)
+  )
+
+  # Non-vacuity: the grid really was resolved, not empty.
+  testthat::expect_equal(
+    sum(!is.na(resolved$polity_code)),
+    nrow(resolved) - nrow(expected)
+  )
+})
+
+testthat::test_that("one bucket carries one polity name per year, except 206", {
+  # The shipped-data counterpart of the three-row fixture in
+  # `test_read_raw_inputs.R`. That one proves the aggregator sums a bucket;
+  # this one proves the crosswalk hands it a bucket that can be summed.
+  #
+  # Bucket 206 is the single live exception and is already filed: FAOSTAT areas
+  # 206 "Sudan (former)", 276 "Sudan" and 277 "South Sudan" share
+  # `polity_area_code` 206 under three different polity names, so the
+  # aggregator emits three rows for one key. That is why
+  # `.select_best_source()`'s `fun.aggregate = sum` is load-bearing (whep#557),
+  # and why the bucket's own label is contested (whep#546, whep#414).
+  resolved <- .resolution_grid()
+  resolved <- resolved[!is.na(polity_area_code)]
+
+  labels <- resolved[,
+    list(n_labels = data.table::uniqueN(polity_name)),
+    by = c("polity_area_code", "year")
+  ]
+  split_buckets <- sort(unique(labels$polity_area_code[labels$n_labels > 1L]))
+
+  testthat::expect_equal(split_buckets, 206L)
+})


### PR DESCRIPTION
## What was wrong

#444 reported that the `polities-integration` branch (#382) moved `feed` **+7.0%**,
`other_uses` +3.1%, `production` +2.0% and `domestic_supply` +1.9% against `main` at
`3f479f7a`, localised onto areas 999, 229 and 11, and that after five rejected
hypotheses the cause was unknown. It split the move "one third code, two thirds data"
and nominated five datasets to test one at a time, `regions_full` first.

Three things are wrong with that as it stands on today's `main`:

1. **The shift is not here.** Today's `main` sits at the *un-shifted* end on every
   column.
2. **The data half does not reproduce.** With `main`'s code, swapping the polity data
   back to the `3f479f7a` vintage moves `feed` by **−0.15%**, not +5.3%, and in the
   other direction.
3. **Three of the five nominated suspects cannot differ at all** — their contents are
   identical between `main` and the branch.

What the polity data *does* move is real, small, and had never been measured: 13,986
rows and −0.15% of `feed`, entirely from six areas this re-sync renamed — four of
them losing their pre-1961 back-cast. That mechanism is filed as #584.

## Evidence, measured before touching anything

Three full-range `get_wide_cbs()` builds (1850–2023, ~9 min each). `main` at
`6e5af760`; the isolation build is that same tree with `polities.rda`,
`polity_area_crosswalk.rda`, `regions_full.rda` and `polities_cats.rda` replaced by
`3f479f7a`'s, via `git archive` into a scratch root.

### The isolation build reproduces #444's `main` exactly

| column | #444's `main` @ `3f479f7a` | main's code + that vintage's data |
|---|---|---|
| `feed` | 9.0636e11 | 9.0636110563e11 |
| `other_uses` | 9.2130e10 | 9.2129959162e10 |
| `production` | 3.0076e12 | 3.0075949466e12 |
| `domestic_supply` | 3.1490e12 | 3.1490305877e12 |
| `stock_withdrawal` | 1.4828e11 | 1.4828010752e11 |
| `export` | 7.9264e10 | 7.9263667005e10 |
| rows | 2,019,253 | **2,019,253** |
| areas | 195 | 195 |

Every figure #444 recorded is reproduced to every digit it quoted, and the row count
matches exactly. So **the code has not moved the CBS by one row since `3f479f7a`** —
all **243** commits in between are value-neutral here — and the isolation is clean.

### Today's `main` against both ends

| column | #444 `main` | #444 branch | today's `main` | today / #444 `main` |
|---|---|---|---|---|
| `feed` | 9.0636e11 | 9.6982e11 (**1.070**) | 9.05014e11 | **0.9985** |
| `other_uses` | 9.2130e10 | 9.4941e10 (1.031) | 9.17874e10 | 0.9963 |
| `production` | 3.0076e12 | 3.0674e12 (1.020) | 3.00743e12 | 0.9999 |
| `domestic_supply` | 3.1490e12 | 3.2098e12 (1.019) | 3.14683e12 | 0.9993 |
| `stock_withdrawal` | 1.4828e11 | 1.4908e11 (1.005) | 1.46513e11 | 0.9881 |
| rows | 2,019,253 | 1,999,609 | 2,005,267 | 0.9931 |
| areas | 195 | 195 | 195 | 1.000 |

Largest column move against the pre-#444 baseline: **1.19%** (`stock_withdrawal`).
Against the branch, `feed` is 6.7% *lower*. The shift does not reproduce.

### Structure, because "no number moved" is not evidence (#480/#563)

|  | isolation build | today's `main` |
|---|---|---|
| rows | 2,019,253 | 2,005,267 |
| distinct `(year, area_code, item_cbs_code)` keys | 2,019,253 | 2,005,267 |
| **duplicate keys** | **0** | **0** |
| areas | 195 | 195 |
| items | 152 | 152 |
| **`area_code`s under >1 label in a given year** | **0** | **0** |

### Three of #444's five suspects are content-identical

Verified with `git show`:

- `inst/extdata/harmonization/regions_full.csv` — body **byte-identical** to the
  branch's, all 272 rows. Only the first header cell differs (`polity_code` vs
  `polity_prefix`). `main` adopted it in #517/#551.
- `inst/extdata/harmonization/polities_cats.csv` — same: body byte-identical, header
  cell differs.
- `inst/extdata/cow_to_lpjml.csv` — identical **as a set of rows**; the 186-line diff
  is row order alone (`setdiff` empty both ways).

`urban_n_reference` is read only by `build_urban_n()` in the nitrogen balance and
appears nowhere in the CBS chain, so it cannot move `feed`. That leaves `polities`,
whose vintage `main` has since carried *past* the branch's (740 → 749, #551) — and the
isolation build above measures exactly what that is worth.

### What the polity data actually moves, localised

Isolation build → today's `main`, i.e. the effect of #517 + #551 + the mojibake repair:

| what | measurement |
|---|---|
| every column total | within **0.4%**, except `stock_withdrawal` at 1.19% |
| rows | −13,986 (−0.69%), **all of them 1850–1960**, 126 per year for all 111 years |
| areas changing rows | **4** of 195 |
| areas changing `feed` by >0.1% | **6** of 195 (32 more move by <0.001%, float noise) |
| areas, items, duplicate keys, split labels | unchanged |

| area | rows | `feed` all years | `feed` 1850–1960 | polity name before → after |
|---|---|---|---|---|
| 202 South Africa | −4,551 | −15.3% | **−58.6%** | `South Africa` → `South Africa (Union and Republic)` |
| 84 Greece | −5,328 | −14.2% | **−28.5%** | `Greece` → `Greece (1947-2025)` |
| 7 Angola | −3,330 | −23.0% | **−98.3%** | `Angola` → `Angola (1905-1975)` |
| 72 Djibouti | −777 | −2.3% | **−100%** | `Djibouti` → `French Somaliland` |
| 249 Yemen | 0 | +9.9% | **+54.0%** | `Yemen (1990-2025)` → `Yemen (combined reporting…)` |
| 272 Serbia | 0 | −0.17% | — | `Serbia` → `Serbia (including Kosovo)` |

Every one of the six is an area this re-sync **renamed**, and no area it did not
rename moves by as much as 0.001%. At Greece, 48 of 115 items go from 112 pre-1962
years to **1** — the 1961 FAOSTAT observation survives and the whole back-cast hanging
off it does not. No item and no area leaves the build; only years do. Yemen and Serbia
move on value with no row change, so the name is doing more than one thing.

The cause is a join key that is a name. `.resolve_hist_trade_polities()` labels `area`
with the crosswalk's `area_name`; `.aggregate_to_polities()` labels it with
`polity_name`; `.cbs_extend_historical()` completes the pre-1961 grid on
`id_cols = c("area", "area_code", ...)`. **75 of 204 buckets** currently disagree
between the two vocabularies and **68 of them are emitted by
`.read_historical_trade()`**, so periodizing one more polity name silently deletes that
area's pre-1961 back-cast. Filed with the full measurement as **#584**; not fixed here,
because the honest fix is to stop keying on the name at all and that moves published
values for dozens of areas.

## What I changed

Nothing that runs in a build. Two files, both about being able to answer this question
next time without a 9-minute build:

**`tests/testthat/test_polity_resolution_coverage.R`** pins the two things a crosswalk
vintage can do to a build, both decidable from `polity_area_crosswalk` alone in ~1 s:

- **Coverage.** Resolving the whole `area × 1850:2023` grid leaves gaps at exactly
  three areas, and the expectation is written as the three rules rather than as a
  count: 15 Belgium-Luxembourg from 2000, 151 Netherlands Antilles from 2011, 351
  China throughout.
- **Label split.** No `polity_area_code` comes out under more than one `polity_name`
  in a given year, except 206. This is the shipped-data counterpart of the three-row
  fixture #563 added to `test_read_raw_inputs.R`.

**`inst/scripts/compare_cbs_totals.R`** is the build-level harness #418 asked to keep
and which never landed, with `main`'s totals recorded in its header. It reports
structure beside magnitude, because #480 moved no value at all and still broke the
build.

## How I verified

Gates, run, not predicted:

- `air format .` — binary, clean.
- `devtools::document()` — no `man/` change (no roxygen touched).
- `lintr::lint_package(...)` with the four CI-disabled linters — **0 lints**.
- `devtools::test()` — **5703 pass, 0 fail, 0 error, 8 skip**.
- pkgdown reference completeness: 293 `man/` topics, 0 missing from `_pkgdown.yml`.
- `rcmdcheck` left to CI (5 platforms; ten agents share this machine).

**Assertion count that fails without the new file: 3 of 3, and each on a real
historical state rather than a mutated fixture.**

- Coverage, against the pre-#517/#551 polity data: **2 failures**, naming the 20
  recovered area-years on areas 901–906 (`46,053` resolved vs `46,073`).
- Label split, against `a9d092fc` — the #480 merge that had to be reverted:
  **1 failure**, `split_buckets` is `206 999` where the invariant wants `206`. So this
  test would have caught #480 from the crosswalk alone, before any build.
- Both pass on `main`, in 1.1 s.

Structural checks on my own change: it adds no R code to any build path, so
`area_code`s, labels, rows and keys are untouched by construction — and the
one-`area_code`-one-`area`-label check on the shipped crosswalk is now an assertion in
the suite rather than a claim (`split_buckets == 206L`, passing).

## Moves published values

**No.** Tests and one `inst/scripts` file; no `R/` and no `data/` change.

It does *report* that `main` moved published values earlier, which nobody had measured:
#517 + #551 cost 13,986 rows and up to 100% of pre-1961 `feed` at six renamed areas. That is
not a regression this PR introduces, and #551's PR body claimed neutrality on
crosswalk-level proxies in good faith — the full-build number simply did not exist
until now.

## What I deliberately did not do

- **Did not fix #584.** Making the two `area` vocabularies agree restores the pre-1961
  back-cast for up to 68 buckets, which is a large published-value move and a
  methodological call. The clean fix — dropping `area` from ~15 join keys in
  `build_cbs.R` in favour of `area_code` — is a refactor of its own. Filed with the
  measurement instead.
- **Did not chase the branch's remaining +7%.** #382 is closed, its data is either
  content-identical to `main`'s or superseded by it, and its code effect measured
  against `main`'s data (+1.6% `feed`, +3.3% `other_uses`) belongs to code that no
  longer exists as a merge candidate. The parts still slated to land carry their own
  measurements in #470/#481 and #493/#511.
- **Did not add a tripwire for the 75-bucket name mismatch.** Pinning a defect count
  is a bad tripwire; #584 proposes it as part of the fix instead.
- **Did not re-measure #419's promotion** — #555 did that, and no gridded build was
  attempted.

## The open decision

Whether `.read_historical_trade()`'s pre-1961 contribution *should* reach these areas
at all is #584's question, and it is a science call, not a mechanical one: restoring it
adds back pre-1961 supply for up to 68 areas at once. The status quo is unchanged by
this PR.

Closes #444
Part of the polity migration epic #458.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
