### PR TITLE
fix(polities): make an aggregation bucket sum, under exactly one area label

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,32 @@
 # whep (development version)
 
+* **An aggregation bucket now sums, and comes out under one name.** The reader
+  aggregation grouped rows by the member's polity **name** as well as by
+  `polity_area_code`, so a bucket folding members that resolve to different
+  polities was never actually summed: it came back as several rows under one
+  `area_code`, carrying different `area` labels. That is live on the shipped
+  crosswalk, not hypothetical — bucket 206 "Sudan (former)" folds FAOSTAT areas
+  276 Sudan and 277 South Sudan, which resolve to two polities from 2012 on.
+  Measured over the real pins, four sources came out split: `faostat-fbs-new`
+  (2,056 duplicate `(area_code, year, item, element, unit)` keys),
+  `faostat-trade-totals` (3,739), `faostat-production` (2,000) and
+  `faostat-emissions-livestock` (144). The label is now derived after the sum
+  from the **bucket's own** code — the same polity `polity_bucket_coverage()`
+  reports and the reporting columns resolve — so one `area_code` has one `area`
+  in one year. Each reader's total is **unchanged to the digit** and its row
+  count falls by exactly its duplicate-key count.
+  **Published values do move, for bucket 206 only**, because the duplicated keys
+  were mishandled downstream in both directions: `build_primary_production()`
+  changes 1,673 of 6,170,595 keys, all in 2012-2023, and against the raw pin the
+  new value is the right one — bucket 206 goats in 2018 were 14,449,249 head
+  (South Sudan alone, Sudan's 40,846,000 dropped) and are now 55,295,249, while
+  2019 sugar cane was 10,898,000 t against 5,449,000 t reported and is now
+  5,449,000 t. On a real 2005-2020 `build_commodity_balances()` the effect is
+  678 changed keys, 559 of them area 206; every other area moves by **43.4 t in
+  total across 119 keys** (largest single move 3.91 t, 4e-9% of the build).
+  Element totals over that range move by 1.79% on `stock_variation` and by less
+  than 0.03% on everything else. `reporting_polity_code` for bucket 206 is
+  `SUD-1956-2011` before and after.
 * `polities` and `polity_area_crosswalk` are re-synced against upstream
   `whep-polities` at `eb02dcb` (740 rows to **749**), which retired or superseded
   **14** codes this package had been treating as live and published a replacement

--- a/R/build_cbs.R
+++ b/R/build_cbs.R
@@ -1319,23 +1319,22 @@ build_processing_coefs <- function(
   .warn_unmapped_codes(dt, "polity_code", "area_code", "crop residues")
   dt <- dt[!is.na(polity_code)]
 
+  # Same grouping and same labelling rule as `.aggregate_to_polities()`. Two
+  # sites emitting two `area` vocabularies for one `area_code` is what dropped
+  # 702,166 rows in whep#382, so the label comes from the shared helper rather
+  # than from whichever member this particular read happened to resolve.
+  labels <- .bucket_area_labels(dt)
   dt <- dt[,
     .(value = sum(value, na.rm = TRUE)),
     by = c(
       "year",
       "polity_area_code",
-      "polity_name",
       "item_cbs",
       "item_cbs_code",
       "element"
     )
   ]
-  data.table::setnames(
-    dt,
-    c("polity_area_code", "polity_name"),
-    c("area_code", "area")
-  )
-  dt
+  .apply_bucket_area_labels(dt, labels)
 }
 
 .read_land_areas_wide <- function(years = NULL) {

--- a/R/polity_folds.R
+++ b/R/polity_folds.R
@@ -25,6 +25,11 @@
 #' when it builds such a bucket; set `options(whep.warn_polity_folds = FALSE)`
 #' to silence that warning.
 #'
+#' The polity reported here as the bucket's own is also the `area` label the
+#' builds attach to the summed row, and the one the reporting columns resolve.
+#' A bucket carries one label whatever its members resolve to, because `area`
+#' is a join key and a bucket under two labels stops summing (whep#563).
+#'
 #' @param years Integer vector of years to classify. Defaults to the FAOSTAT
 #'   reporting era, 1961 to 2025. Years before the back-cast anchor resolve to
 #'   the anchor-year territory, so they classify identically to 1961.
@@ -355,6 +360,59 @@ folded_reporting_areas <- function(crosswalk = NULL) {
     )
   ]
   folded
+}
+
+# The `area` label an aggregation bucket carries, one per (bucket, year).
+#
+# A bucket is a numeric key that several reporting areas are summed into, so its
+# label has to be a property of the BUCKET. Taking it from a member row instead
+# -- which is what grouping by `polity_name` did -- means a bucket whose members
+# resolve to different polities comes out under several labels, and the sum the
+# bucket exists to produce never happens (whep#563, the defect that forced the
+# revert of whep#480 in whep#561). Resolving the bucket's own code is also what
+# `polity_bucket_coverage()` documents as the label a fold carries, and what
+# `add_reporting_polity_columns()` resolves downstream, so this makes the
+# aggregator agree with both rather than inventing a third rule.
+#
+# `dt` must already carry the polity columns, i.e. be past
+# `.add_polity_columns_dt()`.
+.bucket_area_labels <- function(dt) {
+  # The member label is only a fallback, for a bucket whose own code resolves to
+  # no polity in that year (an aggregate whose period has ended). Deterministic
+  # by lowest `area_code` so it cannot depend on row order or on which member
+  # happens to report.
+  members <- dt[
+    !is.na(polity_area_code),
+    .(member_name = polity_name[which.min(area_code)]),
+    by = c("polity_area_code", "year")
+  ]
+  if (nrow(members) == 0L) {
+    return(members[, .(polity_area_code, year, area = character(0))])
+  }
+  resolved <- .add_polity_columns_dt(
+    data.table::data.table(
+      area_code = members$polity_area_code,
+      year = members$year
+    ),
+    code_col = "area_code",
+    year_col = "year",
+    include_unmapped = FALSE
+  )
+  members[, area := data.table::fcoalesce(resolved$polity_name, member_name)]
+  members[, member_name := NULL]
+  members
+}
+
+# Attach the bucket labels to an aggregated table and rename it to the
+# `area_code` / `area` pair the rest of the pipeline expects, in the column
+# order the grouped key already had.
+.apply_bucket_area_labels <- function(dt, labels) {
+  # An update-join, not a merge: it cannot drop or reorder a row, so the label
+  # is provably an annotation rather than a second filter.
+  dt[labels, on = c("polity_area_code", "year"), area := i.area]
+  data.table::setnames(dt, "polity_area_code", "area_code")
+  data.table::setcolorder(dt, c("year", "area_code", "area"))
+  dt
 }
 
 # The alternative to the fold, selectable and OFF by default.

--- a/R/read_raw_inputs.R
+++ b/R/read_raw_inputs.R
@@ -326,14 +326,14 @@
   # that covers only part of it (whep#414).
   .warn_partial_bucket_polities(dt)
   .warn_folded_areas(dt, source_label)
-  by_cols <- c(
-    "year",
-    "polity_area_code",
-    "polity_name",
-    "unit",
-    "element",
-    dots
-  )
+  # `polity_name` is deliberately NOT a grouping key. It is a property of the
+  # member row, so keying on it splits a bucket whose members resolve to
+  # different polities -- the bucket stops summing without a single value
+  # moving (whep#563). The label is attached after the sum instead, from the
+  # bucket's own code, which is what `polity_bucket_coverage()` and the
+  # reporting columns already say a bucket is called.
+  by_cols <- c("year", "polity_area_code", "unit", "element", dots)
+  labels <- .bucket_area_labels(dt)
 
   has_flag <- "fao_flag" %in% names(dt)
   if (has_flag) {
@@ -345,12 +345,7 @@
     dt <- dt[, .(value = sum(value, na.rm = TRUE)), by = by_cols]
   }
 
-  data.table::setnames(
-    dt,
-    c("polity_area_code", "polity_name"),
-    c("area_code", "area")
-  )
-  dt
+  .apply_bucket_area_labels(dt, labels)
 }
 
 .extract_fao <- function(pin_alias, years = NULL) {

--- a/R/utils.R
+++ b/R/utils.R
@@ -1790,7 +1790,9 @@ utils::globalVariables(
     # polity_folds.R (#419) — reporting-area fold diagnostic
     "rows",
     # build_production.R — dissolved-federation LUH2 land bridge (whep#408)
-    "n_successors"
+    "n_successors",
+    # polity_folds.R (#563) — bucket area-label derivation NSE columns
+    "member_name"
   )
 )
 

--- a/man/polity_bucket_coverage.Rd
+++ b/man/polity_bucket_coverage.Rd
@@ -42,6 +42,11 @@ Sudan and 277 South Sudan after the 2011 secession while no live polity
 means "Sudan and South Sudan" (whep#414). \code{.aggregate_to_polities()} warns
 when it builds such a bucket; set \code{options(whep.warn_polity_folds = FALSE)}
 to silence that warning.
+
+The polity reported here as the bucket's own is also the \code{area} label the
+builds attach to the summed row, and the one the reporting columns resolve.
+A bucket carries one label whatever its members resolve to, because \code{area}
+is a join key and a bucket under two labels stops summing (whep#563).
 }
 \examples{
 polity_bucket_coverage(years = 2015L)

--- a/tests/testthat/test_polity_folds.R
+++ b/tests/testthat/test_polity_folds.R
@@ -139,10 +139,14 @@ test_that(".aggregate_to_polities warns when it folds Sudan into bucket 206", {
     "Bucket 206"
   )
 
-  # No value moved: the two members keep their own rows and their own values,
-  # and both now sit under bucket code 206.
-  expect_equal(folded$area_code, c(206L, 206L))
-  expect_equal(sum(folded$value), 3405356)
+  # The bucket SUMS. Until whep#563 this came back as two rows under one code,
+  # 2,744,000 and 661,356, because the aggregator also grouped by the member's
+  # `polity_name` -- so the fold the warning describes was not actually being
+  # performed, and every consumer keyed on `(area_code, year, item, element)`
+  # saw a duplicated key.
+  expect_equal(nrow(folded), 1L)
+  expect_equal(folded$area_code, 206L)
+  expect_equal(folded$value, 3405356)
 
   withr::local_options(whep.warn_polity_folds = FALSE)
   expect_no_warning(
@@ -390,4 +394,87 @@ testthat::test_that("folded_reporting_areas() rejects a frame it cannot read", {
     whep::folded_reporting_areas(tibble::tibble(area_code = 1L)),
     "missing"
   )
+})
+
+# The bucket label, which is what whep#563 is about ---------------------------
+#
+# One `area_code` must come out under one `area`, whatever the members resolve
+# to, because `area` is a join key and a duplicated `(area_code, year, item,
+# element)` is what fed the `dcast()` `length()` fallback in whep#425.
+
+.bucket_fixture_rows <- function() {
+  data.table::data.table(
+    area_code = c(900L, 901L, 902L, 951L, 952L, 960L, 961L, 970L),
+    year = 2015L,
+    element = "production",
+    unit = "t",
+    item_prod_code = "83",
+    value = c(1, 2, 4, 8, 16, 32, 64, 128)
+  )
+}
+
+testthat::test_that("every bucket gets exactly one label, whatever it folds", {
+  .local_fold_crosswalk()
+  out <- suppressWarnings(
+    whep:::.aggregate_to_polities(.bucket_fixture_rows(), item_prod_code)
+  )
+
+  # Four buckets, four rows, four labels -- not eight rows under four codes.
+  testthat::expect_equal(nrow(out), 4L)
+  labels <- stats::setNames(out$area, as.character(out$area_code))
+  testthat::expect_equal(
+    labels[c("900", "950", "960", "970")],
+    c(`900` = "Aggregate", `950` = "P", `960` = "R", `970` = "T")
+  )
+
+  # Bucket 900 is the shape whep#480 shipped: a member (901 "X", 902 "Y") with
+  # its own polity while `polity_area_code` stays on the aggregate. It sums.
+  totals <- stats::setNames(out$value, as.character(out$area_code))
+  testthat::expect_equal(unname(totals[["900"]]), 7)
+  testthat::expect_equal(unname(totals[["960"]]), 96)
+  testthat::expect_equal(sum(out$value), sum(.bucket_fixture_rows()$value))
+})
+
+testthat::test_that("a bucket with no row of its own falls back to a member", {
+  # Bucket 950 has no crosswalk row for its own code, so it cannot be labelled
+  # from the bucket. The member label is then used -- deterministically, the
+  # lowest `area_code`, so it does not depend on which member reported or on
+  # row order -- rather than leaving the rows unlabelled.
+  .local_fold_crosswalk()
+  rows <- .bucket_fixture_rows()[area_code %in% c(951L, 952L)]
+
+  out <- suppressWarnings(
+    whep:::.aggregate_to_polities(data.table::copy(rows), item_prod_code)
+  )
+  testthat::expect_equal(out$area, "P")
+
+  reversed <- suppressWarnings(
+    whep:::.aggregate_to_polities(
+      data.table::copy(rows)[order(-area_code)],
+      item_prod_code
+    )
+  )
+  testthat::expect_equal(reversed$area, "P")
+  testthat::expect_false(any(is.na(out$area)))
+})
+
+testthat::test_that("labelling annotates the aggregate, it cannot filter it", {
+  # `.apply_bucket_area_labels()` is an update-join precisely so that a missing
+  # label costs a label and never a row -- the 702,166-row drop in whep#382 came
+  # from a labelling change meeting an inner join.
+  agg <- data.table::data.table(
+    year = c(2015L, 2015L),
+    polity_area_code = c(900L, 111L),
+    value = c(7, 5)
+  )
+  labels <- data.table::data.table(
+    polity_area_code = 900L,
+    year = 2015L,
+    area = "Aggregate"
+  )
+
+  out <- whep:::.apply_bucket_area_labels(agg, labels)
+  testthat::expect_equal(nrow(out), 2L)
+  testthat::expect_equal(names(out)[1:3], c("year", "area_code", "area"))
+  testthat::expect_equal(out$area, c("Aggregate", NA_character_))
 })

--- a/tests/testthat/test_read_raw_inputs.R
+++ b/tests/testthat/test_read_raw_inputs.R
@@ -59,9 +59,9 @@ test_that(".aggregate_to_polities works without fao_flag", {
 test_that("a bucket comes out of the aggregator under exactly one area label", {
   # THE INVARIANT THAT VALUE-NEUTRALITY CHECKS CANNOT SEE (whep#563).
   #
-  # `.aggregate_to_polities()` groups by `polity_name` as well as
+  # `.aggregate_to_polities()` used to group by `polity_name` as well as
   # `polity_area_code`, and renames the pair to `area`/`area_code`. So a change
-  # that gives two members of one FABIO bucket different polities splits the
+  # that gives two members of one FABIO bucket different polities split the
   # bucket's rows WITHOUT moving any value: mass still conserves, the bucket keeps
   # its members, `polity_area_code` is untouched, and every check anyone thought
   # to run passes. What breaks is downstream -- `area` is a join key, four inner
@@ -101,4 +101,68 @@ test_that("a bucket comes out of the aggregator under exactly one area label", {
   # Mass conservation is asserted too, but note it holds either way -- which is
   # precisely why it is not sufficient on its own.
   expect_equal(sum(out$value), sum(raw$value))
+})
+
+test_that("the live Sudan bucket sums instead of splitting in two", {
+  # The same defect, already live on the shipped crosswalk rather than
+  # hypothetical: bucket 206 folds FAOSTAT areas 206 "Sudan (former)", 276
+  # Sudan and 277 South Sudan, and the three resolve to three different
+  # polities. Measured on `main` before this change, over the real pins, four
+  # sources came out split on bucket 206 -- faostat-fbs-new (4 area-years,
+  # 2,056 duplicate keys), faostat-production (13, 2,000),
+  # faostat-trade-totals (13, 3,739) and faostat-emissions-livestock (12, 144).
+  # Every one of those duplicate keys is a `(area_code, year, item, element)`
+  # the cast in `.select_best_source()` has to disambiguate, which is the
+  # class of defect whep#425 came from.
+  raw <- tibble::tribble(
+    ~year, ~area_code, ~item_cbs_code, ~element,     ~unit,    ~value,
+    2015L, 276L,       2511,           "production", "tonnes", 100,
+    2015L, 277L,       2511,           "production", "tonnes", 25,
+    2005L, 206L,       2511,           "production", "tonnes", 90
+  )
+
+  out <- suppressWarnings(
+    whep:::.aggregate_to_polities(
+      data.table::as.data.table(raw),
+      item_cbs_code
+    )
+  )
+
+  post <- out[out$year == 2015L, ]
+  expect_equal(nrow(post), 1L)
+  expect_equal(post$value, 125)
+  # And the label no longer flips mid-series: the same bucket is the same
+  # territory in 2005 and 2015, which is what a join key has to be.
+  expect_equal(length(unique(out$area)), 1L)
+  expect_equal(sum(out$value), sum(raw$value))
+})
+
+test_that("the aggregator labels a bucket from the bucket's own code", {
+  # Which label a fold carries is decided in exactly one place, and this is it:
+  # the polity the BUCKET code resolves to for the year. `polity_bucket_coverage()`
+  # already documents that as the label a fold carries and
+  # `add_reporting_polity_columns()` already resolves the reporting columns from
+  # the same code, so a member-derived label made the aggregator disagree with
+  # both.
+  raw <- tibble::tribble(
+    ~year, ~area_code, ~item_cbs_code, ~element,     ~unit,    ~value,
+    2015L, 277L,       2511,           "production", "tonnes", 25
+  )
+
+  out <- suppressWarnings(
+    whep:::.aggregate_to_polities(
+      data.table::as.data.table(raw),
+      item_cbs_code
+    )
+  )
+
+  # 277's own polity is South Sudan; the bucket it is summed into is not.
+  expect_equal(out$area_code, 206L)
+  expect_false(out$area == "South Sudan")
+  expect_equal(
+    out$area,
+    whep::polity_area_crosswalk$polity_name[
+      whep::polity_area_crosswalk$polity_code == "SUD-1956-2011"
+    ][[1]]
+  )
 })


### PR DESCRIPTION
## What was wrong

`.aggregate_to_polities()` grouped by the member's `polity_name` alongside
`polity_area_code`, then renamed the pair to `area` / `area_code`. So a bucket
that folds members resolving to **different** polities was never actually
summed: it came back as several rows under one `area_code`, under different
`area` labels. Mass conserved, `polity_area_code` was untouched, bucket
membership was identical — which is why #480 passed every check anyone ran and
still had to be reverted (#561).

**The issue frames this as a blocker for a future un-fold. It is not: it is
live on the shipped crosswalk today.** Bucket 206 "Sudan (former)" folds
FAOSTAT areas 206, 276 Sudan and 277 South Sudan, and from 2012 those resolve
to three different polities. So `main` has been emitting a split bucket for
thirteen years of four different sources, and the split was not cosmetic —
downstream it both **dropped** and **doubled** data (numbers below).

`.read_crop_residues()` (`R/build_cbs.R`) duplicated the same aggregation
inline, which is the second half of the hazard: two sites emitting two `area`
vocabularies for one `area_code` is exactly what dropped 702,166 rows in #382.

## Evidence it reproduced BEFORE the change

Driving the real readers over the real pins, at the base commit, full range:

| source | `(area_code, year)` under >1 label | duplicate `(area_code, year, item, element, unit)` keys |
|---|---|---|
| `faostat-fbs-new` | 4 | 2,056 |
| `faostat-production` | 13 | 2,000 |
| `faostat-trade-totals` | 13 | 3,739 |
| `faostat-emissions-livestock` | 12 | 144 |
| `faostat-fbs-old`, `-cbs-old-crops`, `-cbs-old-animal`, `-production-old` | 0 | 0 |

Every split is bucket 206, labels `South Sudan | Sudan`. Re-measured after
rebasing onto today's `main` (which had moved by #408/#405): **identical**.

The consequence, traced to the raw pin rather than asserted:

| bucket 206 | raw `faostat-production` | `build_primary_production()` before | after |
|---|---|---|---|
| goats, 2018, head | 40,846,000 (276) + 14,449,249 (277) = **55,295,249** | 14,449,249 — Sudan's 40.8 M **dropped** | 55,295,249 |
| sugar cane, 2019, t | **5,449,000** (276 only; 277 does not report) | 10,898,000 — **doubled** | 5,449,000 |

## What I changed

1. `polity_name` is no longer a grouping key. The label is attached **after**
   the sum, from the **bucket's own** code resolved for that year — which is
   what `polity_bucket_coverage()` already documents a fold as being called and
   what `add_reporting_polity_columns()` already resolves, so the aggregator now
   agrees with both instead of using a third rule. That is option 2 of the
   issue's three, carrying option 1's labelling rule.
2. Two shared helpers, `.bucket_area_labels()` and
   `.apply_bucket_area_labels()`, in `R/polity_folds.R`; `.read_crop_residues()`
   uses them too, so the two aggregation sites cannot diverge.
3. The label step is an **update-join**, not a merge, so it provably cannot drop
   or reorder a row — a missing label costs a label, never a row. That is the
   #382 failure mode made structurally impossible rather than tested for.
4. A bucket whose own code resolves to no polity for the year (an aggregate
   whose period has ended) falls back to the member label, deterministically by
   lowest `area_code`, so no row is left unlabelled.

## How I verified

**Structure, not just totals** — #480 is the reason:

- **Reader level, full range, all eight sources**: splits 42 → **0**, duplicate
  keys 7,939 → **0**, and each source's total is **unchanged to the digit**
  (e.g. `faostat-fbs-new` 948,260,434,000 before and after). Row counts fall by
  *exactly* the duplicate-key count: fbs-new −2,056, production −2,000,
  trade-totals −3,739, emissions-livestock −144.
- **`build_primary_production()`, full range**: 6,170,595 rows before and after,
  key set identical (0 keys added, 0 removed), **1,673 keys change value**, all
  in 2012-2023 and all in bucket 206 except two derived per-head ratios for
  Belgium in 2023 (0.0062 and 0.0006). Both directions of change verified
  against the raw pin (table above).
- **`build_commodity_balances()` on real data, 2005-2020** (a full-range build
  was OOM-killed on a machine shared with nine agents; this range covers every
  affected year): 1,276,337 → 1,276,340 rows, 678 keys change of which 559 are
  bucket 206. **Every other area moves 43.4 t in total across 119 keys**, largest
  single move 3.91 t — 4e-9 % of the build, trade-balancing knock-on.
  Element totals: `stock_variation` +1.79 %, everything else within 0.03 %.
  `reporting_polity_code` for bucket 206 is `SUD-1956-2011` before and after.
- **The one-`area_code`-one-`area` guard** in `test_read_raw_inputs.R` (the one
  added after the #480 revert) still passes, and two more assertions now pin the
  live 206 case and the labelling rule.

Gates: `air format .` clean; `devtools::document()` committed; `lintr` with the
CI config reports **0 lints**; every `man/*.Rd` is in `_pkgdown.yml`;
`devtools::test()` **5,781 pass / 0 fail / 8 skip** (run on the rebased base).

**Assertions that fail without the R change** (verified by stashing `R/` and
re-running): **13** — 5 in `test_read_raw_inputs.R`, 8 in `test_polity_folds.R`.

## Moves published values

Yes, and only for bucket 206. The move is a correction in both directions and
each direction is checked against the raw FAOSTAT pin, not against a prior WHEP
build. `NEWS.md` carries the magnitudes. Nothing else in the pipeline changes by
more than 3.91 t.

One existing test changed its expectation:
`.aggregate_to_polities warns when it folds Sudan into bucket 206` asserted
`area_code == c(206, 206)` — two rows for one bucket. It now asserts one row of
3,405,356, because that is what the warning next to it has always claimed was
happening.

## What I deliberately did not do

- **I did not re-land #480 / #459.** This PR is the prerequisite the issue asks
  for and nothing more: with the grouping fixed, a polity-level un-fold no longer
  splits a bucket. Which areas should be un-folded is still #459's call. Verified
  on the fixture crosswalk that already ships in `test_polity_folds.R`: bucket
  900 folding members 901 "X" and 902 "Y" onto their own polities now comes out
  as one row labelled "Aggregate" — the exact shape #480 shipped.
- **I did not change what bucket 206 means.** It still sums Sudan and South
  Sudan under a single polity, which is #414 and a science decision. This PR only
  makes the sum actually happen and gives it one name.
- **I did not touch the numeric-level un-fold.**
  `options(whep.unfold_rest_of_world = TRUE)` (option 3 in the issue) is
  unchanged and still off by default; it now labels each promoted bucket from its
  own crosswalk row, as before.
- **I did not fix the name-keyed proxy joins.** `.fill_with_proxies()` joins
  population and land by `c("year", "area")`, and `.read_land_areas()` labels
  with the FAOSTAT `area_name` while the aggregator labels with the polity name:
  63 of 166 CBS-side labels in 1961 have no counterpart in `land_wide`, including
  China (PRC), Czechoslovakia and Belgium-Luxembourg. That is pre-existing,
  unchanged by this PR (only bucket 206's label moved, and only for 2012+), and
  already tracked in #493 and #584.

## The open decision

Bucket 206 is labelled `SUD-1956-2011` "Sudan (1956-2011)" — a polity that had
ended by the years in question — because that is the polity its own code
resolves to, and because the pre-2012 half of the same series was already
labelled that way. The alternative is to keep labelling the post-2011 rows
"Sudan" (area 276's polity), which is what the split accidentally did for
roughly two thirds of them. I took the bucket's own label because it is the
rule the rest of the package already applies, and because a join key that flips
mid-series is the defect this PR exists to remove — but the choice of *which*
polity a two-territory bucket should name is #414's, not mine.

Closes #563
Part of the polity migration epic #458.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
