### PR TITLE
ci(lint): lint only the changed files on a PR, whole package on main

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -55,7 +55,14 @@ jobs:
           # silently failed" -- the latter would make a broken step read green.
           git cat-file -e "${base}^{commit}"
           git cat-file -e "${head}^{commit}"
-          git diff --name-only --diff-filter=ACMR "${base}" "${head}" \
+          # Diff from the MERGE BASE, not from the base branch head. base.sha is
+          # wherever the base branch has since advanced to, so base..head also
+          # reports every file main changed after this branch forked -- six
+          # unrelated files on the first run of this workflow, and more the
+          # staler the branch, which defeats the point.
+          merge_base=$(git merge-base "${base}" "${head}")
+          echo "Merge base: ${merge_base}"
+          git diff --name-only --diff-filter=ACMR "${merge_base}" "${head}" \
             -- '*.R' '*.r' > changed_r_files.txt
           count=$(grep -c . changed_r_files.txt || true)
           echo "count=${count}" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -1,5 +1,18 @@
 # Workflow derived from https://github.com/r-lib/actions/tree/v2/examples
 # Need help debugging build failures? Start at https://github.com/r-lib/actions#where-to-find-help
+#
+# Linting the whole package takes ~630 s on a GitHub runner (348 R files, ~133k
+# lines), i.e. ten minutes on every push to a PR. On a pull request this lints
+# only the R files that PR touches; pushes to main still lint everything, so
+# nothing can rot unnoticed (#569).
+#
+# That is sound for lintr specifically rather than a corner cut: every linter in
+# the active set is a per-file static check, so a lint in one file cannot be
+# caused by editing another. The one package-scope linter, object_usage_linter,
+# is disabled. The same argument would NOT justify running only the tests a PR
+# touches, where a change elsewhere can break a file you never opened.
+#
+# The linter set lives in .lintr, not here, so the two paths below cannot drift.
 on:
   push:
     branches: [main, master]
@@ -16,6 +29,10 @@ jobs:
       GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
     steps:
       - uses: actions/checkout@v4
+        with:
+          # Full history: the PR path diffs against the base commit, which a
+          # shallow clone does not contain.
+          fetch-depth: 0
 
       - uses: r-lib/actions/setup-r@v2
         with:
@@ -26,16 +43,51 @@ jobs:
           extra-packages: any::lintr, local::.
           needs: lint
 
-      - name: Lint
+      - name: Collect the R files this PR touches
+        if: github.event_name == 'pull_request'
+        id: changed
         run: |
-          lintr::lint_package(
-            linters = lintr::linters_with_defaults(
-              object_usage_linter = NULL,
-              line_length_linter = NULL,
-              indentation_linter = NULL,
-              commas_linter = NULL
-            )
-          )
+          set -euo pipefail
+          base='${{ github.event.pull_request.base.sha }}'
+          head='${{ github.event.pull_request.head.sha }}'
+          # Assert both ends of the range exist before trusting the diff. An
+          # empty list must mean "this PR changed no R files", never "the diff
+          # silently failed" -- the latter would make a broken step read green.
+          git cat-file -e "${base}^{commit}"
+          git cat-file -e "${head}^{commit}"
+          git diff --name-only --diff-filter=ACMR "${base}" "${head}" \
+            -- '*.R' '*.r' > changed_r_files.txt
+          count=$(grep -c . changed_r_files.txt || true)
+          echo "count=${count}" >> "$GITHUB_OUTPUT"
+          echo "Changed R files: ${count}"
+          cat changed_r_files.txt
+
+      - name: Lint changed files
+        if: github.event_name == 'pull_request' && steps.changed.outputs.count != '0'
+        run: |
+          files <- readLines("changed_r_files.txt")
+          files <- files[nzchar(files) & file.exists(files)]
+          # Linters and exclusions both come from .lintr, so this matches the
+          # whole-package run exactly.
+          lints <- unlist(lapply(files, lintr::lint), recursive = FALSE)
+          if (length(lints) > 0L) {
+            print(lints)
+            stop(sprintf(
+              "%d lint(s) across %d changed file(s).",
+              length(lints),
+              length(files)
+            ))
+          }
+          cat(sprintf("No lints in %d changed file(s).\n", length(files)))
+        shell: Rscript {0}
+
+      - name: No R files changed
+        if: github.event_name == 'pull_request' && steps.changed.outputs.count == '0'
+        run: echo "This PR changes no R files; nothing to lint."
+
+      - name: Lint whole package
+        if: github.event_name != 'pull_request'
+        run: lintr::lint_package()
         shell: Rscript {0}
         env:
           LINTR_ERROR_ON_LINT: true

--- a/.lintr
+++ b/.lintr
@@ -1,1 +1,7 @@
+linters: linters_with_defaults(
+    object_usage_linter = NULL,
+    line_length_linter = NULL,
+    indentation_linter = NULL,
+    commas_linter = NULL
+  )
 exclusions: list("inst/scripts", "inst/analysis")

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -143,14 +143,7 @@ rcmdcheck::rcmdcheck(
   args = c("--no-tests", "--ignore-vignettes"),
   error_on = "error"
 )
-lintr::lint_package(
-  linters = lintr::linters_with_defaults(
-    object_usage_linter = NULL,
-    line_length_linter = NULL,
-    indentation_linter = NULL,
-    commas_linter = NULL
-  )
-)
+lintr::lint_package()   # linters and exclusions come from .lintr
 ```
 
 Gotchas worth knowing before losing an hour:


### PR DESCRIPTION
Closes #569.

The lint job took **~630 s on every push to a PR** — ten minutes to re-lint 348 R
files and ~133k lines, when the typical PR here touches one or two. Recent ones:
#568 one R file, #567 none, #562 two, #558 none, #537 two.

On `pull_request` it now lints **only the R files that PR touches**. Pushes to
`main` still lint the whole package, so nothing rots unnoticed.

## Why this is sound rather than a corner cut

Every linter in the active set is a **per-file static check** — a lint in one file
cannot be caused by editing another — and the one package-scope linter,
`object_usage_linter`, is disabled.

Worth stating explicitly so nobody generalises it: **the same reasoning would not
justify running only the tests a PR touches**, where a change elsewhere can break
a file you never opened.

## The linter set moves into `.lintr`

Splitting the job in two introduces one real hazard: two code paths that could
silently disagree about which linters run. So the set now lives in `.lintr` and
both paths read it, rather than the workflow carrying its own copy.

Verified equivalent:

| | lints |
|---|---|
| `lint_package()` reading `.lintr` | 0 |
| the old explicit `linters_with_defaults(...)` call | 0 |

And — since the whole design rests on it — verified that `lintr::lint()` on a
**single file** honours `.lintr` too: **0 lints** on a file with 3325-character
lines, against **68** under bare defaults.

`CLAUDE.md` now documents plain `lint_package()`, since the long argument list is
redundant and a second copy of a config is a second thing to drift.

## Failing safe

An empty changed-file list must mean "no R files changed", never "the diff broke".
The step asserts both ends of the range exist (`git cat-file -e`) before trusting
`git diff`, so a missing base commit aborts instead of reading green. `fetch-depth:
0` is required for that, since a shallow clone lacks the base commit.

## Verified locally

- failure path catches real lints (`object_name_linter`, `T_and_F_symbol_linter`
  on a probe file)
- diff logic returns the expected files
- base-commit assertion fires
- workflow YAML parses

**Note:** this PR changes no R files, so its own lint job will exercise the
"nothing to lint" path rather than the linting one. The linting path was verified
locally as above; the first PR touching an `R/` file will exercise it in CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TvvcyfcfaSxW9pywZsdvAY
