### PR TITLE
test(data-raw): gate data/*.rda against its data-raw builder

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -498,6 +498,19 @@ When modifying CSV files in `inst/extdata/harmonization/`:
    changed.
 4. Run `Rscript data-raw/whep_inputs.R` if `whep_inputs.csv` changed.
 
+Skipping the rebuild is a defect, not an omission: `data/*.rda` is a committed
+build product, so an edited CSV that was never rebuilt ships a table
+disagreeing with its own source, and it looks exactly like a fresh one
+(#384 — that is how `regions_full` came to resolve eight areas to polities
+upstream had retired). `tests/testthat/test_data_raw_freshness.R` is the gate.
+It re-runs every builder whose inputs live inside the repo, with the
+`usethis::use_data()` calls stripped so nothing is written, and compares each
+rebuilt object with the committed `.rda` by content. It covers 49 of the 56
+tables; the seven it cannot rebuild (the whep-polities GeoPackage, the Coello
+CSV, the GLEAM workbook) are listed there with the input that blocks each one,
+and the list is asserted to be exactly the complement, so a new dataset cannot
+arrive both unchecked and unexcluded.
+
 ## This is the only agent instruction file
 
 The repo used to carry per-tool copies of these rules

--- a/tests/testthat/test_data_raw_freshness.R
+++ b/tests/testthat/test_data_raw_freshness.R
@@ -1,0 +1,243 @@
+# Gate against a stale data/*.rda (#384).
+#
+# The tables under data/ are committed build products of the data-raw/ scripts,
+# and nothing used to assert that they still match what their builder emits
+# from the current inputs. An edited inst/extdata CSV that was never followed by
+# `Rscript data-raw/<builder>.R` therefore shipped a table disagreeing with its
+# own source, indistinguishable from a fresh one until someone happened to
+# re-run the builder. That is how regions_full and polities_cats came to resolve
+# eight areas to polities upstream had retired or superseded (#382).
+#
+# This gate re-runs every builder whose inputs live inside the repo, in a
+# private environment with the `usethis::use_data()` calls removed so nothing is
+# written, and compares each rebuilt object with the committed .rda by content.
+# The comparison has to be on content: `save()` output is not byte-reproducible,
+# and re-running one builder rewrites several unrelated .rda files with
+# identical content, so a byte or file-hash comparison would be pure noise.
+#
+# Coverage is partial by construction, and the partition is asserted below so a
+# new dataset cannot arrive both unchecked and unexcluded:
+#
+#   * checked  -- the 49 datasets written by the seven builders in
+#     `.offline_data_builders()`, which read only inst/extdata/, data-raw/ and
+#     committed data/*.rda.
+#   * excluded -- the 7 datasets in `.externally_built_datasets()`. Five come
+#     from table_mappings.R, which cannot run past `sf::st_read()` on the
+#     whep-polities GeoPackage (`WHEP_POLITIES_GPKG`); it does read items_cbs
+#     and items_prod verbatim from CSVs before that point, but only the whole
+#     script is a builder. coello_synthetic_n.R reads an off-repo >50 MB CSV
+#     (`WHEP_COELLO_DIR`). livestock_coefficients.R needs `openxlsx`, which the
+#     package does not even declare, and writes with `save()` from inside
+#     `main()` rather than through `use_data()`, so this mechanism does not
+#     reach it at all.
+#
+# R/sysdata.rda (one constant, from data-raw/constants.R) is internal data
+# rather than a data/*.rda, and is out of scope here.
+#
+# What the gate proves is that each table matches its builder's output from the
+# inputs currently in the repo. It does not prove those inputs are current
+# against their upstream source: polity_area_crosswalk is excluded, and
+# harmonization_tables.R reads it, so a crosswalk lagging whep-polities stays
+# invisible here. test_polity_output_coverage.R is the narrow backstop for that
+# -- it fails if regions_full or polities_cats stops resolving an area to a
+# reporting polity with a polygon.
+#
+# The gate skips where data-raw/ is absent, which is every check of a built
+# tarball -- `^data-raw$` is in .Rbuildignore. The `offline-tests` job runs
+# `devtools::test()` on the checkout, where data-raw/ is present, so the gate
+# runs there on every push and pull request.
+
+# Registry ---------------------------------------------------------------
+
+# Builders whose every input lives inside the repo, so re-running them needs no
+# network, no pin and no WHEP_* path.
+.offline_data_builders <- function() {
+  c(
+    "balance_coefficients.R",
+    "cft_mapping.R",
+    "feed_coefficients.R",
+    "harmonization_tables.R",
+    "nitrogen_refs.R",
+    "sjos_n_coefficients.R",
+    "whep_inputs.R"
+  )
+}
+
+# The data/*.rda this gate cannot rebuild, with what blocks each one. Asserted
+# below to be exactly the complement of what the offline builders write, so
+# adding a dataset -- or dropping an external dependency -- forces an update
+# here instead of silently shrinking the gate.
+.externally_built_datasets <- function() {
+  tibble::tribble(
+    ~dataset,                ~builder,                   ~blocked_by,
+    "items_cbs",             "table_mappings.R",         "WHEP_POLITIES_GPKG",
+    "items_prod",            "table_mappings.R",         "WHEP_POLITIES_GPKG",
+    "polities",              "table_mappings.R",         "WHEP_POLITIES_GPKG",
+    "polity_area_crosswalk", "table_mappings.R",         "WHEP_POLITIES_GPKG",
+    "polity_label_aliases",  "table_mappings.R",         "WHEP_POLITIES_GPKG",
+    "coello_synthetic_n",    "coello_synthetic_n.R",     "WHEP_COELLO_DIR",
+    "livestock_coefs",       "livestock_coefficients.R", "openxlsx"
+  )
+}
+
+# Mechanics --------------------------------------------------------------
+
+# The builders resolve their inputs with here::here(), so the gate resolves the
+# repo root the same way rather than from the test path: two different answers
+# would compare one checkout's .rda against another's CSVs. here::here() aborts
+# when no project root sits above the working directory, which is the normal
+# case when the tests run from a built tarball.
+.data_gate_root <- function() {
+  root <- tryCatch(here::here(), error = function(cnd) NA_character_)
+  if (is.na(root) || !dir.exists(file.path(root, "data-raw"))) {
+    return(NA_character_)
+  }
+  root
+}
+
+.skip_without_data_raw <- function() {
+  testthat::skip_if_not_installed("here")
+  root <- .data_gate_root()
+  if (is.na(root)) {
+    testthat::skip("data-raw/ is not in the built package (.Rbuildignore)")
+  }
+  root
+}
+
+.is_use_data_call <- function(expr) {
+  is.call(expr) && identical(rlang::expr_text(expr[[1]]), "usethis::use_data")
+}
+
+# The saved objects are the unnamed arguments; `overwrite`, `compress` and
+# `internal` are named.
+.use_data_object_names <- function(expr) {
+  args <- rlang::call_args(expr)
+  purrr::map_chr(args[rlang::names2(args) == ""], rlang::as_name) |>
+    unname()
+}
+
+.builder_object_names <- function(builder, root) {
+  exprs <- as.list(parse(file.path(root, "data-raw", builder)))
+  exprs[purrr::map_lgl(exprs, .is_use_data_call)] |>
+    purrr::map(.use_data_object_names) |>
+    purrr::list_c()
+}
+
+# Runs the builder with its `use_data()` calls dropped, so the committed .rda
+# files are read but never rewritten, and returns what it would have saved.
+.rebuild_data_objects <- function(builder, root) {
+  exprs <- as.list(parse(file.path(root, "data-raw", builder)))
+  code <- exprs[!purrr::map_lgl(exprs, .is_use_data_call)]
+  env <- new.env(parent = globalenv())
+  withr::local_dir(root)
+  suppressMessages(suppressWarnings(purrr::walk(code, eval, envir = env)))
+  rlang::env_get_list(env, .builder_object_names(builder, root))
+}
+
+.committed_data_object <- function(dataset, root) {
+  env <- new.env()
+  load(file.path(root, "data", paste0(dataset, ".rda")), envir = env)
+  rlang::env_get(env, dataset)
+}
+
+# readr tags a freshly read tibble with a `spec` attribute, a `problems`
+# external pointer and the spec_tbl_df class. None of that is data -- the
+# pointer does not survive save()/load() and the spec's shape is a readr
+# implementation detail -- so comparing it would make the gate fail on a readr
+# upgrade instead of on stale data.
+.drop_readr_bookkeeping <- function(x) {
+  if (!inherits(x, "data.frame")) {
+    return(x)
+  }
+  attr(x, "spec") <- NULL
+  attr(x, "problems") <- NULL
+  class(x) <- setdiff(class(x), "spec_tbl_df")
+  x
+}
+
+.shipped_datasets <- function(root) {
+  list.files(file.path(root, "data"), pattern = "\\.rda$") |>
+    stringr::str_remove("\\.rda$")
+}
+
+# A throwaway repo -- one builder, one input CSV, one committed .rda -- standing
+# in for the real thing so the gate's own mechanics can be tested both ways.
+# With `stale = TRUE` the committed copy holds a value the CSV no longer
+# produces, which is exactly the drift #384 is about. It lives in a temp dir
+# tied to the calling test's frame, so nothing here touches this repo.
+.toy_builder_repo <- function(stale) {
+  root <- withr::local_tempdir(.local_envir = parent.frame())
+  dir.create(file.path(root, "data-raw"))
+  dir.create(file.path(root, "data"))
+  writeLines(
+    c(
+      'toy_table <- readr::read_csv("toy.csv", show_col_types = FALSE)',
+      "usethis::use_data(toy_table, overwrite = TRUE)"
+    ),
+    file.path(root, "data-raw", "toy.R")
+  )
+  readr::write_csv(tibble::tibble(value = c(1, 2)), file.path(root, "toy.csv"))
+  toy_table <- tibble::tibble(value = if (stale) c(1, 99) else c(1, 2))
+  save(toy_table, file = file.path(root, "data", "toy_table.rda"))
+  root
+}
+
+# Tests ------------------------------------------------------------------
+
+testthat::test_that("every data/*.rda is either rebuilt here or excluded", {
+  root <- .skip_without_data_raw()
+  rebuilt <- .offline_data_builders() |>
+    purrr::map(\(builder) .builder_object_names(builder, root)) |>
+    purrr::list_c()
+  excluded <- .externally_built_datasets()$dataset
+
+  testthat::expect_length(intersect(rebuilt, excluded), 0)
+  testthat::expect_equal(
+    sort(c(rebuilt, excluded)),
+    sort(.shipped_datasets(root))
+  )
+})
+
+purrr::walk(.offline_data_builders(), function(builder) {
+  testthat::test_that(paste(builder, "reproduces the .rda it writes"), {
+    root <- .skip_without_data_raw()
+    rebuilt <- .rebuild_data_objects(builder, root)
+
+    testthat::expect_gt(length(rebuilt), 0)
+    purrr::iwalk(rebuilt, function(object, dataset) {
+      testthat::expect_equal(
+        .drop_readr_bookkeeping(object),
+        .drop_readr_bookkeeping(.committed_data_object(dataset, root)),
+        label = paste0("data-raw/", builder, " rebuild of ", dataset),
+        expected.label = paste0("committed data/", dataset, ".rda")
+      )
+    })
+  })
+})
+
+testthat::test_that("a data/*.rda lagging its inputs is reported", {
+  root <- .toy_builder_repo(stale = TRUE)
+  rebuilt <- .rebuild_data_objects("toy.R", root)
+
+  testthat::expect_named(rebuilt, "toy_table")
+  testthat::expect_failure(testthat::expect_equal(
+    .drop_readr_bookkeeping(rebuilt$toy_table),
+    .drop_readr_bookkeeping(.committed_data_object("toy_table", root))
+  ))
+  # Dropping the use_data() calls is what keeps the gate read-only: the stale
+  # copy must still be stale after the rebuild.
+  testthat::expect_equal(
+    .committed_data_object("toy_table", root)$value,
+    c(1, 99)
+  )
+})
+
+testthat::test_that("a data/*.rda built from its inputs passes", {
+  root <- .toy_builder_repo(stale = FALSE)
+  rebuilt <- .rebuild_data_objects("toy.R", root)
+
+  testthat::expect_equal(
+    .drop_readr_bookkeeping(rebuilt$toy_table),
+    .drop_readr_bookkeeping(.committed_data_object("toy_table", root))
+  )
+})


### PR DESCRIPTION
## What was wrong

`data/*.rda` is a committed build product of the `data-raw/` scripts, and no
check asserted that it still matched what its builder emits from the inputs
currently in the repo. An edited `inst/extdata` CSV that was never followed by
`Rscript data-raw/<builder>.R` therefore shipped a table disagreeing with its
own source, and a stale copy was indistinguishable from a fresh one until
someone happened to re-run the builder — which is how `regions_full` and
`polities_cats` came to resolve eight areas to polities upstream had retired or
superseded (#382).

Confirmed still present on `origin/main`: nothing under `tests/` parses or runs
a `data-raw/` builder. `tests/testthat/test_polities_cats_vs_regions_full.R`
says so in its own header — *"Tested on the shipped datasets rather than on the
builder, because the builder lives in `data-raw/` and is not loadable from
tests"* — and every other data test asserts invariants on the shipped `.rda`,
never on the builder's output.

## What changed

One new test file, `tests/testthat/test_data_raw_freshness.R`, plus a paragraph
in CLAUDE.md's *Package data updates* section pointing at it.

The gate re-runs each builder in a private environment with its
`usethis::use_data()` calls **removed**, so the committed `.rda` files are read
but never rewritten, and compares each rebuilt object with the committed one by
content. Content and not bytes, as #384 notes: `save()` output is not
byte-reproducible, and re-running one builder rewrites several unrelated `.rda`
files with identical content, so a hash comparison would be pure noise. readr's
`spec` attribute, `problems` external pointer and `spec_tbl_df` class are
dropped before comparing — none of that is data, and the pointer does not
survive `save()`/`load()`, so keeping it would make the gate fail on a readr
upgrade instead of on stale data.

### Coverage is partial, and the partition is asserted

**Checked — 49 of the 56 tables, from 7 builders** (they read only
`inst/extdata/`, `data-raw/` and committed `data/*.rda`, so no network, no pin,
no `WHEP_*` path):

| builder | tables |
|---|---|
| `harmonization_tables.R` | 12 |
| `balance_coefficients.R` | 23 |
| `feed_coefficients.R` | 4 |
| `nitrogen_refs.R` | 4 |
| `sjos_n_coefficients.R` | 4 |
| `cft_mapping.R` | 1 |
| `whep_inputs.R` | 1 |

**Excluded — 7 tables**, each listed in the test with the input that blocks it:

| table(s) | builder | blocked by |
|---|---|---|
| `items_cbs`, `items_prod`, `polities`, `polity_area_crosswalk`, `polity_label_aliases` | `table_mappings.R` | `sf::st_read()` on the whep-polities GeoPackage (`WHEP_POLITIES_GPKG`), which no clone has |
| `coello_synthetic_n` | `coello_synthetic_n.R` | off-repo >50 MB CSV (`WHEP_COELLO_DIR`) |
| `livestock_coefs` | `livestock_coefficients.R` | needs `openxlsx`, which the package does not declare, and writes with `save()` from inside `main()` rather than through `use_data()`, so this mechanism does not reach it at all |

`table_mappings.R` does read `items_cbs` and `items_prod` verbatim from CSVs
before it touches the GeoPackage, but only the whole script is a builder;
re-implementing those two reads in the test would just add the second,
uncheckable copy the gate exists to prevent. `R/sysdata.rda` (one constant,
from `data-raw/constants.R`) is internal data rather than a `data/*.rda` and is
out of scope.

A test asserts the checked set and the excluded list are **exactly** the
complement of `data/*.rda`, in both directions, so a new dataset cannot arrive
both unchecked and unexcluded, and dropping an external dependency forces the
exclusion list to be updated rather than silently shrinking the gate.

### What the gate does not prove

That each table matches its builder's output from the inputs **currently in the
repo** — not that those inputs are current against their upstream source.
`polity_area_crosswalk` is excluded and `harmonization_tables.R` reads it, so a
crosswalk lagging whep-polities stays invisible here;
`test_polity_output_coverage.R` remains the narrow backstop for that.

## What I verified

- **The gate is green on `main` as it stands**:
  `devtools::test(filter = "data_raw_freshness")` → `FAIL 0 | SKIP 0 | PASS 62`
  in **1.6 s**. All 49 tables already agree with their builders, so this lands
  as a gate, not a repair.
- **It fails on real drift.** Changed one cell of `inst/extdata/cft_mapping.csv`
  (`"Wheat"` → `"DRIFT"`) without rebuilding, and the gate failed with the
  offending column named:

  ```
  x | 1       61 | data_raw_freshness [1.6s]
  Error ('test_data_raw_freshness.R:206:7'): cft_mapping.R reproduces the .rda it writes
  ! data-raw/cft_mapping.R rebuild of cft_mapping (`actual`) not equal to
    committed data/cft_mapping.rda (`expected`).
  - actual[1, ]     DRIFT
  + expected[1, ]   Wheat
  ```

  CSV restored afterwards; `git status` clean.
- **The partition test fails on an unaccounted dataset.** Dropped a throwaway
  `data/zzz_probe.rda` in place and the gate reported
  `- "zzz_probe" [57]` as present in `data/` but neither rebuilt nor excluded.
  Probe removed afterwards.
- **The gate is read-only.** A negative control builds a throwaway one-builder
  repo in `tempdir()` with a deliberately stale committed `.rda`, and asserts
  both that the drift is reported and that the stale copy is *still stale* after
  the rebuild — i.e. stripping the `use_data()` calls really does keep the gate
  from rewriting `data/`. A second control does the matching case.
- **Full suite**: `devtools::test()` → `FAIL 0 | WARN 11 | SKIP 8 | PASS 6005`,
  208 s. The 8 skips are the pre-existing `WHEP_*`/local-file real-data guards
  (CRU, HWSD, LPJmL, wind), unchanged by this PR.
- **It skips cleanly in a built tarball.** `R CMD build` on a `git archive`
  export, then running the file from the extracted package:
  `SKIP 8 | PASS 4` — the 8 repo-dependent tests skip with
  *"data-raw/ is not in the built package (.Rbuildignore)"*, while the 4
  temp-dir control expectations still run. So `R CMD check` neither errors nor
  is silently vacuous, and `offline-tests` (which runs `devtools::test()` on the
  checkout, where `data-raw/` is present) is where the gate bites on every push
  and pull request.
- `air format` → no changes (`--check` exit 0); `lintr` with the project's
  disabled linters → *No lints found*; max line width 80; every `man/*.Rd`
  topic still present in `_pkgdown.yml` (0 missing).

## Left undone

- No new CI workflow: `offline-tests` already runs `devtools::test()` on the
  checkout on every push and PR, which is exactly the condition the gate needs.
  A dedicated job would only duplicate it.
- I did not run a full `rcmdcheck()`: this PR touches no `R/`, `DESCRIPTION`,
  `NAMESPACE`, `man/` or examples, and the tarball run above covers the only
  new behaviour `R CMD check` would see.
- The 7 excluded tables stay unchecked. Closing that gap needs the
  whep-polities GeoPackage, the Coello CSV and an `openxlsx`-shaped rework of
  `livestock_coefficients.R`, all of which are their own decisions rather than
  part of this gate.

Classification: **mechanical** — a test-only gate, no methodological choice and
no published value changes (no `NEWS.md` entry per CLAUDE.md's rule for
tests/CI work).

Closes #384

🤖 Generated with [Claude Code](https://claude.com/claude-code)
