### PR TITLE
fix(gapfilling): repair the weighted proxy growth aggregation

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,21 @@
 # whep (development version)
 
+* **`fill_proxy_growth()` weighted proxy specs work at all, and weight the
+  right period.** The documented `"var[weight]"` and `"var:group[weight]"`
+  forms both aborted with
+  `Items of 'old' not found in column names: [V1, V2]`: the weighted
+  aggregation renamed its output columns from `V1`/`V2`, but data.table names
+  them after the symbols in the returned `list()`. With the crash out of the
+  way, the weight lag proved wrong twice over — it was taken *after* the rows
+  without an individual growth rate had been dropped, and it was grouped by the
+  coarse aggregation group rather than by the individual series. The first
+  member of every group therefore lost its weight entirely and fell out of the
+  weighted mean, the next member picked up the previous member's weight, and a
+  member with an interior gap was weighted by the wrong year. The
+  previous-period weight is now carried alongside the value lag, over the full
+  series and within it. **No published values change**: no pipeline in the
+  package passes a weighted proxy spec, because until now any call that did
+  raised an error.
 * **An aggregation bucket now sums, and comes out under one name.** The reader
   aggregation grouped rows by the member's polity **name** as well as by
   `polity_area_code`, so a bucket folding members that resolve to different

--- a/R/gapfilling.R
+++ b/R/gapfilling.R
@@ -1252,7 +1252,7 @@ fill_proxy_growth <- function(
   }
 
   # 2. Compute Individual Row Growth (with Smoothing)
-  prep <- .fg_growth_calc_individual(prep, spec, smooth_window, time_col)
+  prep <- .fg_growth_calc_individual(prep, spec, smooth_window, time_col, .by)
 
   # 3. Aggregate to Groups
   summary_dt <- .fg_growth_aggregate(
@@ -1286,8 +1286,7 @@ fill_proxy_growth <- function(
     return(data.frame())
   }
 
-  lag_vars <- unique(c(.by, spec$present_group_vars))
-  lag_vars <- lag_vars[lag_vars %in% names(data)]
+  lag_vars <- .fg_series_vars(spec, .by, names(data))
 
   cols <- unique(c(time_col, lag_vars, spec$source_var, spec$weight_col))
   cols <- cols[!is.na(cols)]
@@ -1302,7 +1301,7 @@ fill_proxy_growth <- function(
   as.data.frame(dt)
 }
 
-.fg_growth_calc_individual <- function(data, spec, window, time_col) {
+.fg_growth_calc_individual <- function(data, spec, window, time_col, .by) {
   # Helper to manage lag vars
   by_vars <- if (length(spec$present_group_vars) > 0) {
     spec$present_group_vars
@@ -1319,20 +1318,20 @@ fill_proxy_growth <- function(
   }
 
   # Create Lags and Calculate Growth
-  dt <- data.table::as.data.table(data)
-  if (length(by_vars) > 0) {
-    dt[,
-      `:=`(
-        lag_src = data.table::shift(get(val_col), 1L, type = "lag"),
-        lag_yr = data.table::shift(get(time_col), 1L, type = "lag")
-      ),
-      by = by_vars
-    ]
-  } else {
-    dt[, `:=`(
-      lag_src = data.table::shift(get(val_col), 1L, type = "lag"),
-      lag_yr = data.table::shift(get(time_col), 1L, type = "lag")
-    )]
+  dt <- .fg_lag_one_period(
+    data.table::as.data.table(data),
+    c(lag_src = val_col, lag_yr = time_col),
+    by_vars
+  )
+  # A weight belongs to the period the growth rate is measured from, so lag it
+  # here, while every period is still present, and within the individual series
+  # rather than within the coarser aggregation group.
+  if (!is.null(spec$weight_col)) {
+    dt <- .fg_lag_one_period(
+      dt,
+      c(lag_weight = spec$weight_col),
+      .fg_series_vars(spec, .by, names(data))
+    )
   }
   dt[,
     ind_growth := data.table::fifelse(
@@ -1362,56 +1361,59 @@ fill_proxy_growth <- function(
     by_vars <- time_col
   }
 
-  # Setup weights
-  has_w <- !is.null(spec$weight_col)
-
   dt <- data.table::as.data.table(data)
 
-  if (has_w) {
-    # Shift weights to align with growth period (previous year weight)
-    grp <- if (length(spec$present_group_vars) > 0) {
-      spec$present_group_vars
-    } else {
-      NULL
-    }
-
-    if (length(grp) > 0) {
-      dt[,
-        w := data.table::shift(get(spec$weight_col), 1L, type = "lag"),
-        by = grp
-      ]
-    } else {
-      dt[, w := data.table::shift(get(spec$weight_col), 1L, type = "lag")]
-    }
-
-    # Weighted aggregation
-    result <- dt[,
-      {
-        valid_w <- !is.na(w) & is.finite(w) & w > 0
-        g_val <- if (any(valid_w)) {
-          sum(ind_growth[valid_w] * w[valid_w]) / sum(w[valid_w])
-        } else {
-          mean(ind_growth)
-        }
-        o_val <- if (any(valid_w)) sum(valid_w) else .N
-        list(g_val, o_val)
-      },
-      by = by_vars
-    ]
-    data.table::setnames(result, c("V1", "V2"), c(growth_col, obs_col))
+  # `lag_weight` already holds the weight of the period each growth rate is
+  # measured from, carried over by .fg_growth_calc_individual().
+  result <- if (is.null(spec$weight_col)) {
+    dt[, .(g_val = mean(ind_growth), o_val = .N), by = by_vars]
   } else {
-    # Unweighted aggregation
-    result <- dt[,
-      .(
-        g_val = mean(ind_growth),
-        o_val = .N
-      ),
-      by = by_vars
-    ]
-    data.table::setnames(result, c("g_val", "o_val"), c(growth_col, obs_col))
+    dt[, .fg_weighted_growth(ind_growth, lag_weight), by = by_vars]
   }
 
+  data.table::setnames(result, c("g_val", "o_val"), c(growth_col, obs_col))
   as.data.frame(result)
+}
+
+# Weighted mean of one group's individual growth rates. Members whose weight is
+# missing, non-finite or non-positive cannot be weighted, so they are dropped;
+# if that leaves nothing, the group falls back to the unweighted mean.
+.fg_weighted_growth <- function(growth, weight) {
+  valid <- !is.na(weight) & is.finite(weight) & weight > 0
+  if (!any(valid)) {
+    return(list(g_val = mean(growth), o_val = length(growth)))
+  }
+  list(
+    g_val = sum(growth[valid] * weight[valid]) / sum(weight[valid]),
+    o_val = sum(valid)
+  )
+}
+
+# Lag a fixed set of columns by one period within `by_vars`. `lag_map` maps each
+# new column name to the column it lags, e.g. `c(lag_src = "gdp")`. Lagging them
+# in one pass keeps every lag pointing at the same source row.
+.fg_lag_one_period <- function(dt, lag_map, by_vars) {
+  new_cols <- names(lag_map)
+  src_cols <- unname(lag_map)
+  if (length(by_vars) > 0) {
+    dt[,
+      (new_cols) := data.table::shift(.SD, 1L, type = "lag"),
+      by = by_vars,
+      .SDcols = src_cols
+    ]
+  } else {
+    dt[,
+      (new_cols) := data.table::shift(.SD, 1L, type = "lag"),
+      .SDcols = src_cols
+    ]
+  }
+  dt
+}
+
+# Columns identifying an individual series: the caller's grouping plus the
+# proxy's own grouping columns, restricted to those the data actually carries.
+.fg_series_vars <- function(spec, .by, data_names) {
+  intersect(unique(c(.by, spec$present_group_vars)), data_names)
 }
 
 .fg_add_empty_cols <- function(data, g_col, o_col) {

--- a/R/utils.R
+++ b/R/utils.R
@@ -1797,7 +1797,9 @@ utils::globalVariables(
     "member_name",
     # feed_intake_build.R / feed_intake_redistribute.R (#467) — weight of each
     # Bouwman region in an aggregate reporting bucket's herd
-    "region_weight"
+    "region_weight",
+    # gapfilling.R (#324) — previous-period aggregation weight of a proxy series
+    "lag_weight"
   )
 )
 

--- a/tests/testthat/test_gapfilling.R
+++ b/tests/testthat/test_gapfilling.R
@@ -57,6 +57,24 @@ fill_sum_fixture <- function() {
   )
 }
 
+# Two regions, three countries, all with a 2000 anchor and later gaps. `gdp`
+# grows by a known factor per country and `pop` is the aggregation weight, so
+# every weighted growth rate below can be written out by hand.
+weighted_proxy_fixture <- function() {
+  tibble::tribble(
+    ~region, ~country, ~year, ~gdp, ~pop, ~value,
+    "eu",    "ESP",     2000,  100,   10,     50,
+    "eu",    "ESP",     2001,  110,   10,     NA,
+    "eu",    "ESP",     2002,  121,   10,     NA,
+    "eu",    "FRA",     2000,  200,   90,     80,
+    "eu",    "FRA",     2001,  200,   90,     NA,
+    "eu",    "FRA",     2002,  200,   90,     NA,
+    "am",    "USA",     2000,  300,   50,     30,
+    "am",    "USA",     2001,  360,   50,     NA,
+    "am",    "USA",     2002,  432,   50,     NA
+  )
+}
+
 # fill_linear ------------------------------------------------------------------
 
 testthat::test_that("fill_linear fills gaps and preserves originals", {
@@ -788,6 +806,174 @@ test_that("fill_proxy_growth groups proxy growth by region (var:group)", {
   # The region-grouped result must differ from ESP's own-gdp backfill, which
   # would give 500 / 1.25 for 2001. This confirms growth is grouped by region.
   expect_false(isTRUE(all.equal(esp$value[esp$year == 2001], 500 / 1.25)))
+})
+
+test_that("fill_proxy_growth accepts a weighted proxy spec", {
+  # Regression: the weighted branch of .fg_growth_aggregate() renamed the
+  # aggregated columns from "V1"/"V2", but data.table names them after the
+  # symbols in the `list()`, so every weighted spec aborted with
+  # "Items of 'old' not found in column names: [V1, V2]".
+  data <- weighted_proxy_fixture()
+
+  expect_no_error(
+    whep::fill_proxy_growth(
+      data,
+      value_col = value,
+      proxy_col = "gdp[pop]",
+      .by = "country",
+      verbose = FALSE
+    )
+  )
+  expect_no_error(
+    whep::fill_proxy_growth(
+      data,
+      value_col = value,
+      proxy_col = "gdp:region[pop]",
+      .by = "country",
+      verbose = FALSE
+    )
+  )
+
+  # "gdp[pop]" aggregates within `.by`, so each group holds a single member and
+  # the weight cannot change the result: it must match the unweighted spec.
+  weighted <- whep::fill_proxy_growth(
+    data,
+    value_col = value,
+    proxy_col = "gdp[pop]",
+    .by = "country",
+    verbose = FALSE
+  )
+  unweighted <- whep::fill_proxy_growth(
+    data,
+    value_col = value,
+    proxy_col = "gdp",
+    .by = "country",
+    verbose = FALSE
+  )
+
+  expect_equal(weighted$value, unweighted$value, tolerance = 1e-9)
+})
+
+test_that("fill_proxy_growth weights grouped growth by own-series weight", {
+  # Regression: the weight lag was taken after the rows without an individual
+  # growth had been dropped, and grouped by the coarse aggregation group. The
+  # first member of each group therefore lost its weight entirely and the next
+  # member picked up the previous member's weight.
+  result <- whep::fill_proxy_growth(
+    weighted_proxy_fixture(),
+    value_col = value,
+    proxy_col = "gdp:region[pop]",
+    .by = "country",
+    verbose = FALSE
+  )
+
+  # Weighted region growth, weights being the previous year's `pop`:
+  #   eu = (0.10 * 10 + 0.00 * 90) / 100 = 0.01 in both 2001 and 2002,
+  #   am = 0.20 in both years (USA is alone in its region).
+  expect_equal(
+    result |>
+      dplyr::filter(country == "ESP") |>
+      dplyr::arrange(year) |>
+      dplyr::pull(value),
+    c(50, 50 * 1.01, 50 * 1.01^2),
+    tolerance = 1e-9
+  )
+  expect_equal(
+    result |>
+      dplyr::filter(country == "FRA") |>
+      dplyr::arrange(year) |>
+      dplyr::pull(value),
+    c(80, 80 * 1.01, 80 * 1.01^2),
+    tolerance = 1e-9
+  )
+  expect_equal(
+    result |>
+      dplyr::filter(country == "USA") |>
+      dplyr::arrange(year) |>
+      dplyr::pull(value),
+    c(30, 36, 43.2),
+    tolerance = 1e-9
+  )
+
+  # Under the bug ESP's 2001 weight was NA, so its 0.10 growth dropped out of
+  # the region mean and eu grew by FRA's 0.00 alone, leaving 2001 at 50.
+  expect_gt(
+    result |>
+      dplyr::filter(country == "ESP", year == 2001) |>
+      dplyr::pull(value),
+    50
+  )
+})
+
+test_that("fill_proxy_growth weights an ungrouped proxy over all series", {
+  # The "var:[weight]" form has no grouping columns, so the weighted mean runs
+  # over every series in the year and must differ from the region-grouped one.
+  result <- whep::fill_proxy_growth(
+    weighted_proxy_fixture(),
+    value_col = value,
+    proxy_col = "gdp:[pop]",
+    .by = "country",
+    verbose = FALSE
+  )
+
+  # (0.10 * 10 + 0.00 * 90 + 0.20 * 50) / 150 = 11 / 150, in both years.
+  global_growth <- 1 + 11 / 150
+  expect_equal(
+    result |>
+      dplyr::filter(country == "ESP") |>
+      dplyr::arrange(year) |>
+      dplyr::pull(value),
+    c(50, 50 * global_growth, 50 * global_growth^2),
+    tolerance = 1e-9
+  )
+  expect_equal(
+    result |>
+      dplyr::filter(country == "USA") |>
+      dplyr::arrange(year) |>
+      dplyr::pull(value),
+    c(30, 30 * global_growth, 30 * global_growth^2),
+    tolerance = 1e-9
+  )
+})
+
+test_that("fill_proxy_growth takes the weight from the previous year", {
+  # ESP has no 2002 `gdp`, so it contributes a growth rate in 2001 and 2004
+  # only. Lagging the weight after the intervening rows were dropped handed
+  # 2004 the 2001 weight instead of the 2003 one.
+  data <- tibble::tribble(
+    ~region, ~country, ~year, ~gdp, ~pop, ~value,
+    "eu",    "ESP",     2000,  100,    1,     50,
+    "eu",    "ESP",     2001,  110,    2,     NA,
+    "eu",    "ESP",     2002,   NA,    3,     NA,
+    "eu",    "ESP",     2003,  130,    4,     NA,
+    "eu",    "ESP",     2004,  143,    5,     NA,
+    "eu",    "FRA",     2000,  100,   10,     80,
+    "eu",    "FRA",     2001,  100,   10,     NA,
+    "eu",    "FRA",     2002,  100,   10,     NA,
+    "eu",    "FRA",     2003,  100,   10,     NA,
+    "eu",    "FRA",     2004,  100,   10,     NA
+  )
+
+  esp <- whep::fill_proxy_growth(
+    data,
+    value_col = value,
+    proxy_col = "gdp:region[pop]",
+    .by = "country",
+    verbose = FALSE
+  ) |>
+    dplyr::filter(country == "ESP") |>
+    dplyr::arrange(year) |>
+    dplyr::pull(value)
+
+  # 2001 growth = (0.10 * 1 + 0.00 * 10) / 11; 2002 and 2003 have FRA only, so
+  # they grow by 0; 2004 growth = (0.10 * 4 + 0.00 * 10) / 14.
+  step_2001 <- 1 + 0.1 / 11
+  step_2004 <- 1 + 0.4 / 14
+  expect_equal(
+    esp,
+    50 * c(1, step_2001, step_2001, step_2001, step_2001 * step_2004),
+    tolerance = 1e-9
+  )
 })
 
 test_that("fill_proxy_growth extrapolates per group, not across groups", {


### PR DESCRIPTION
## What was wrong

`fill_proxy_growth()` documents two weighted proxy forms — `"var[weight]"` and
`"var:group[weight]"`. Neither worked, and behind the crash the weighting
itself was wrong.

**1. `setnames()` mismatch (a hard abort).** The weighted branch of
`.fg_growth_aggregate()` returned `list(g_val, o_val)` from a `{}` block and
then renamed `c("V1", "V2")`. data.table names such columns after the symbols
in the `list()`, not `V1`/`V2`, so *every* weighted spec aborted:

```
> fill_proxy_growth(data, value, proxy_col = "gdp[pop]", .by = "country")
Error in data.table::setnames(result, c("V1", "V2"), c(growth_col, obs_col)) :
  Items of 'old' not found in column names: [V1, V2]. Consider skip_absent=TRUE.
```

Confirmed on `origin/main` for both `"gdp[pop]"` and `"gdp:region[pop]"`.

**2. The weight lag was wrong twice over.** With (1) patched locally, the
weighted numbers came out wrong. The lag was taken inside
`.fg_growth_aggregate()`, i.e. *after* `.fg_growth_calc_individual()` had
dropped every row with no individual growth rate, and it was grouped by the
**coarse aggregation group** rather than by the individual series. Three
consequences, all reproduced:

- the first member of each group got `w = NA` and was excluded from the
  weighted mean entirely (and from `n_obs`);
- the next member picked up the **previous member's** weight — a cross-series
  leak;
- a member with an interior gap in the proxy was weighted by the **wrong
  year**, because `shift()` stepped over the dropped rows.

Evidence, with only the `setnames` line patched so the numbers are visible.
Fixture: region `eu` = ESP (`gdp` 100/110/121, `pop` 10) + FRA (`gdp` flat,
`pop` 90), region `am` = USA alone; `proxy_col = "gdp:region[pop]"`,
`.by = "country"`.

| series | year | on main (`setnames` patched) | correct |
| --- | --- | --- | --- |
| ESP | 2001 | 50.00 | 50.50 |
| ESP | 2002 | 50.50 | 51.005 |
| FRA | 2001 | 80.00 | 80.80 |
| FRA | 2002 | 80.80 | 81.608 |

The `eu` weighted growth should be `(0.10·10 + 0.00·90) / 100 = 0.01` in both
years; it came out as FRA's `0.00` in 2001, because ESP's weight was `NA` and
FRA had inherited ESP's `pop = 10`. The ungrouped `"gdp:[pop]"` form was off
by more: growth `0.18` in 2001 against the correct `11/150 ≈ 0.0733`. With an
interior gap in ESP's `gdp`, the 2004 weight was taken from 2001 (`pop = 2`)
instead of 2003 (`pop = 4`), giving `50.83` against the correct `51.90`.

## What changed

`R/gapfilling.R`

- `.fg_growth_aggregate()` names its aggregated columns explicitly in both
  branches, so the rename can no longer miss.
- The previous-period weight is now carried as `lag_weight` alongside
  `lag_src` in `.fg_growth_calc_individual()`, where every period is still
  present, and lagged **within the series** (`.by` plus the proxy's own
  grouping columns) rather than within the aggregation group.
- Three private helpers extracted so both call sites share one definition:
  `.fg_lag_one_period()` (lag a fixed set of columns in one pass, keeping
  every lag pointing at the same source row), `.fg_weighted_growth()` (the
  weighted mean, with its documented fallback to the unweighted mean when no
  member has a usable weight) and `.fg_series_vars()` (what a series is —
  `.fg_growth_prep()` now uses it too instead of its own copy).

`R/utils.R` — `lag_weight` appended to `utils::globalVariables()`.

`NEWS.md` — entry describing the defect and stating that no published values
change.

`tests/testthat/test_gapfilling.R` — one shared `weighted_proxy_fixture()`
tribble plus four tests: the crash regression (and that `"gdp[pop]"` matches
the unweighted `"gdp"` when each group has a single member), the grouped
weighted mean, the ungrouped `"var:[weight]"` branch, and a proxy series with
an interior gap.

**Classification: mechanical.** Nothing here is a methodological choice — the
weighted mean formula, the `w > 0` validity rule and the unweighted fallback
are all unchanged; only the column rename and which row the weight is read
from moved.

**No published values change.** Grepped every `proxy_col =` in `R/` — the
seven in `build_cbs.R` and three in `build_production.R` are all plain names
(`"pop"`, `"agriland"`, `"Cropland"`, `"yield"`, `"processing"`,
`"Palmkernel_Oil"`). None is weighted, which follows from the bug: any call
that was weighted raised an error.

## What I verified

- **Failing first.** With only the tests added, on unmodified code:
  `[ FAIL 6 | PASS 186 ]`, all six the `V1`/`V2` abort. With only the
  `setnames` line fixed: `[ FAIL 6 | PASS 190 ]`, now failing on the numbers
  in the table above — each one matching the value predicted by hand from the
  bug. With both fixes: `[ FAIL 0 | PASS 196 ]`.
- **Full suite**: `devtools::test()` → `[ FAIL 0 | WARN 11 | SKIP 8 | PASS
  5953 ]`. The 8 skips are the pre-existing `WHEP_*`/local-raster guards.
- **`R CMD check`** on a clean `git archive` export
  (`--no-tests --ignore-vignettes --no-manual`,
  `_R_CHECK_FORCE_SUGGESTS_=false` because `archive` and `RSQLite` are not
  installed here): `0 errors | 0 warnings | 1 note`. The note is
  `.canonicalise_gdp_pop_area: no visible binding for 'key_row' /
  'canonical_area'` — **byte-identical on an `origin/main` baseline export**,
  so pre-existing and untouched by this PR.
- **lint** on the three changed `.R` files with the project's disabled
  linters: no lints. All new lines ≤ 80 columns.
- **`air format`** run on the three changed files (`air.toml` keeps the
  `tribble` alignment). `devtools::document()` produced no diff — no roxygen
  was touched. Every `man/*.Rd` topic still appears in `_pkgdown.yml`
  (0 missing).

## Left undone (out of scope, filed separately)

The **value** lag in `.fg_growth_calc_individual()` is still grouped by the
coarse aggregation group, not by the series, and is protected only by the
`year == lag_yr + 1` adjacency guard. When two series in one group have
disjoint year coverage that happens to be adjacent, that guard passes and the
growth is computed across the series boundary. On `origin/main` and on this
branch alike, a region holding ESP (2000–2002) and FRA (2003–2004) gives FRA
2003 a growth of `7.264 = (1000 − 121) / 121` — FRA's `gdp` over **ESP's**.
That affects the unweighted path too, which #324 explicitly scopes out, so it
is not touched here; filed as #608.

Closes #324

🤖 Generated with [Claude Code](https://claude.com/claude-code)
