### PR TITLE
test(typologies): cover the 0% files to lift coverage past the gate

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -440,6 +440,14 @@
   alongside it, and the package gained a
   [code of conduct](https://ropensci.org/code-of-conduct/) and a link from the
   README to the contributing guide. Groundwork for rOpenSci peer review (#75).
+* A failed Natural Earth download now reports how to recover instead of dying
+  on its own error message. The abort interpolated the layer URL as
+  `{.url {.natural_earth_url(layer)}}`, and cli >= 3.4.0 reads a `{}`
+  expression starting with a dot as a style name, so the branch raised
+  `Invalid cli literal` and the instructions never reached the user. The
+  province typologies (`create_typologies_grafs_spain()`,
+  `create_typologies_of_josette()`) are the callers that reach it. No published
+  value changes (#594).
 
 # whep 0.3.0
 

--- a/R/natural_earth.R
+++ b/R/natural_earth.R
@@ -54,12 +54,17 @@
   }
 
   zip <- file.path(dir, paste0(layer, ".zip"))
+  # Resolved into a local rather than interpolated inline: cli >= 3.4.0 reads
+  # a `{}` expression starting with a dot as a style name, so
+  # `{.url {.natural_earth_url(layer)}}` aborted with "Invalid cli literal"
+  # instead of showing this function's own recovery instructions.
+  url <- .natural_earth_url(layer)
   cli::cli_alert_info("Downloading {layer} from Natural Earth...")
 
   ok <- tryCatch(
     {
       utils::download.file(
-        .natural_earth_url(layer),
+        url,
         zip,
         mode = "wb",
         quiet = TRUE
@@ -78,7 +83,7 @@
     cli::cli_abort(c(
       "Could not download the Natural Earth layer {.val {layer}}.",
       x = if (inherits(ok, "error")) conditionMessage(ok),
-      i = "Download {.url {.natural_earth_url(layer)}} manually and pass the
+      i = "Download {.url {url}} manually and pass the
            unzipped {.file .shp} via {.arg shapefile_path}, or set
            {.code options(whep.provinces_shapefile = \"<path>\")}."
     ))

--- a/tests/testthat/test_Typologies_Josette.R
+++ b/tests/testthat/test_Typologies_Josette.R
@@ -1,3 +1,248 @@
+# test_Typologies_Josette.R — tests for R/Typologies_Josette.R
+#
+# Every helper takes its inputs as arguments, so the indicator chain and the
+# decision tree run offline from tribble fixtures.
+
+# N flows in the legacy vocabulary the helpers consume. "Seed" is a destiny the
+# production identity does not know about, and is there to be excluded.
+josette_flows_fixture <- function() {
+  tibble::tribble(
+    ~Province_name, ~Box,       ~Destiny,     ~MgN,
+    "Lugo",         "Cropland", "Food",       30,
+    "Lugo",         "Cropland", "Feed",       20,
+    "Lugo",         "Cropland", "Other_uses", 5,
+    "Lugo",         "Cropland", "Export",     10,
+    "Lugo",         "Cropland", "Import",     15,
+    "Lugo",         "Cropland", "Seed",       100,
+    "Lugo",         "Semi_nat", "Feed",       8,
+    "Soria",        "Cropland", "Food",       10
+  ) |>
+    dplyr::mutate(
+      Year = 2000,
+      Item = "Wheat",
+      Box = dplyr::if_else(
+        Box == "Semi_nat",
+        "Semi_natural_agroecosystems",
+        Box
+      )
+    )
+}
+
+# .calculate_consumption_prod -------------------------------------------------
+
+test_that(".calculate_consumption_prod nets imports out of production", {
+  out <- whep:::.calculate_consumption_prod(josette_flows_fixture())
+
+  expect_named(out, c("food_consumption", "production"))
+  expect_equal(
+    out$food_consumption |>
+      dplyr::filter(Province_name == "Lugo") |>
+      dplyr::pull(Food_Consumption_MgN),
+    30
+  )
+  # Production is Food + Feed + Other_uses + Export - Import, over every box:
+  # (30 + 28 + 5 + 10) - 15. The 100 MgN of "Seed" is not in the identity.
+  expect_equal(
+    out$production |>
+      dplyr::filter(Province_name == "Lugo") |>
+      dplyr::pull(Production_MgN),
+    58
+  )
+  expect_equal(
+    out$production |>
+      dplyr::filter(Province_name == "Soria") |>
+      dplyr::pull(Production_MgN),
+    10
+  )
+})
+
+# .calculate_crop_prod_feed ---------------------------------------------------
+
+test_that(".calculate_crop_prod_feed separates cropland from all feed", {
+  out <- whep:::.calculate_crop_prod_feed(josette_flows_fixture())
+
+  expect_named(out, c("cropland_prod", "animal_ingestion"))
+  # Cropland only, so the 8 MgN of semi-natural feed is out: 30+20+5+10-15.
+  expect_equal(
+    out$cropland_prod |>
+      dplyr::filter(Province_name == "Lugo") |>
+      dplyr::pull(Cropland_Production_MgN),
+    50
+  )
+  # Animal ingestion is every Feed row, both boxes included.
+  expect_equal(
+    out$animal_ingestion |>
+      dplyr::filter(Province_name == "Lugo") |>
+      dplyr::pull(Animal_Ingestion_MgN),
+    28
+  )
+  # Soria has a Food row only, so the missing destinies are filled with zero
+  # rather than dropping the province.
+  expect_equal(
+    out$cropland_prod |>
+      dplyr::filter(Province_name == "Soria") |>
+      dplyr::pull(Cropland_Production_MgN),
+    10
+  )
+})
+
+# .calculate_natural_feed_share -----------------------------------------------
+
+test_that(".calculate_natural_feed_share shares over all feed", {
+  out <- whep:::.calculate_natural_feed_share(josette_flows_fixture())
+
+  expect_equal(out$Province_name, "Lugo")
+  expect_equal(out$SemiNatural_feed_MgN, 8)
+  expect_equal(out$Total_feed_MgN, 28)
+  expect_equal(out$SemiNatural_feed_share, 8 / 28)
+  # A province with no semi-natural feed is absent rather than zero, because
+  # the semi-natural table is the left-hand side of the join.
+  expect_false("Soria" %in% out$Province_name)
+})
+
+# .calculate_manure_share -----------------------------------------------------
+
+test_that(".calculate_manure_share uses cropland inputs only", {
+  n_input_df <- tibble::tribble(
+    ~Province_name, ~Box,       ~MgN_dep, ~MgN_fix, ~MgN_syn, ~MgN_manure,
+    "Lugo",         "Cropland", 1,        2,        3,        4,
+    "Lugo",         "Cropland", 1,        0,        0,        1,
+    "Lugo",         "Pasture",  100,      100,      100,      100,
+    "Soria",        "Cropland", 0,        0,        5,        5
+  ) |>
+    dplyr::mutate(Year = 2000, MgN_urban = 0)
+
+  out <- whep:::.calculate_manure_share(n_input_df)
+
+  # Lugo's two cropland rows sum to 2 + 2 + 3 + 5 + 0 = 12 MgN of input, of
+  # which 5 is manure. The pasture row would have swamped both.
+  lugo <- out |> dplyr::filter(Province_name == "Lugo")
+  expect_equal(lugo$MgN_total, 12)
+  expect_equal(lugo$Manure_share, 5 / 12)
+  expect_equal(
+    out |> dplyr::filter(Province_name == "Soria") |> dplyr::pull(Manure_share),
+    0.5
+  )
+})
+
+# .assign_typologies ----------------------------------------------------------
+
+test_that(".assign_typologies reaches every typology in order", {
+  # One province per branch, named after the branch it should take. The tree is
+  # ordered, so each province must also fail every earlier test.
+  indicators <- tibble::tribble(
+    ~Province_name, ~Food_Consumption_MgN, ~Production_MgN,
+    "Urban",        100,                   50,
+    "Stockless",    10,                    100,
+    "SpecLivest",   10,                    100,
+    "Grass",        10,                    100,
+    "Forage",       10,                    100,
+    "Disconnected", 10,                    100
+  ) |>
+    dplyr::mutate(
+      Year = 2000,
+      Cropland_Production_MgN = c(0, 100, 10, 10, 10, 10),
+      Animal_Ingestion_MgN = c(10, 10, 100, 100, 100, 100),
+      Livestock_density = c(0, 0, 2, 2, 0, 0),
+      Imported_feed_share = c(0, 0, 0.5, 0.1, 0, 0),
+      SemiNatural_feed_share = c(0, 0, 0.8, 0.8, 0.2, 0.2),
+      local_feed_share = c(0, 0, 0.5, 0.5, 0.5, 0),
+      Manure_share = c(0, 0, 0.5, 0.5, 0.5, 0)
+    )
+
+  out <- whep:::.assign_typologies(indicators)
+
+  expect_named(out, c("Year", "Province_name", "Typology"))
+  expect_equal(
+    out$Typology,
+    c(
+      "Urban system",
+      "Specialized stockless cropping system",
+      "Specialized livestock system",
+      "Grass-based crop & livestock system",
+      "Forage-based crop & livestock system",
+      "Disconnected crop & livestock system"
+    )
+  )
+})
+
+test_that(".assign_typologies puts the stockless test above livestock", {
+  # Cropland production above 1.5x ingestion wins even when the province also
+  # looks like a specialized livestock system.
+  indicators <- tibble::tibble(
+    Year = 2000,
+    Province_name = "Both",
+    Food_Consumption_MgN = 10,
+    Production_MgN = 100,
+    Cropland_Production_MgN = 100,
+    Animal_Ingestion_MgN = 10,
+    Livestock_density = 2,
+    Imported_feed_share = 0.9,
+    SemiNatural_feed_share = 0.9,
+    local_feed_share = 0.9,
+    Manure_share = 0.9
+  )
+
+  expect_equal(
+    whep:::.assign_typologies(indicators)$Typology,
+    "Specialized stockless cropping system"
+  )
+})
+
+# .calculate_imported_feed ----------------------------------------------------
+
+test_that(".calculate_imported_feed chains LU, density and import share", {
+  livestock_df <- tibble::tribble(
+    ~Province_name, ~Livestock_cat,  ~Stock_Number,
+    "Lugo",         "Dairy_cattle",  600,
+    "Soria",        "Dairy_cattle",  200
+  ) |>
+    dplyr::mutate(Year = 2000)
+  livestock_units_df <- tibble::tribble(
+    ~Livestock_cat,  ~Animal_class, ~LU_head,
+    "Dairy_cattle",  "Cattle",      1
+  )
+  npp_df <- tibble::tribble(
+    ~Province_name, ~LandUse,   ~Area_ygpit_ha,
+    "Lugo",         "Cropland", 300,
+    "Soria",        "Cropland", 400
+  ) |>
+    dplyr::mutate(Year = 2000)
+  feed_df <- tibble::tribble(
+    ~Element,  ~Destiny, ~Value_destiny,
+    "Import",  "Feed",   400,
+    "Import",  "Food",   9000
+  ) |>
+    dplyr::mutate(Year = 2000, Item = "Soy")
+
+  out <- whep:::.calculate_imported_feed(
+    livestock_df,
+    livestock_units_df,
+    npp_df,
+    feed_df,
+    josette_flows_fixture()
+  )
+
+  expect_named(
+    out,
+    c("lu_totals", "livestock_density_df", "imported_feed_share_df")
+  )
+  # 600 LU over 300 ha of agricultural area.
+  expect_equal(
+    out$livestock_density_df |>
+      dplyr::filter(Province_name == "Lugo") |>
+      dplyr::pull(Livestock_density),
+    2
+  )
+  # Lugo holds 600 of the 800 national LU, so 75% of the 400 MgN of imported
+  # feed. Its domestic feed here is cropland feed only, 20 MgN.
+  share <- out$imported_feed_share_df |>
+    dplyr::filter(Province_name == "Lugo")
+  expect_equal(share$Feed_import_MgN, 300)
+  expect_equal(share$Domestic_feed_MgN, 20)
+  expect_equal(share$Imported_feed_share, 300 / 320)
+})
+
 # .calculate_feed_domestic_share -----------------------------------------------
 
 test_that(".calculate_feed_domestic_share returns one row per year-province", {

--- a/tests/testthat/test_Typologies_Julia.R
+++ b/tests/testthat/test_Typologies_Julia.R
@@ -1,0 +1,504 @@
+# test_Typologies_Julia.R — tests for R/Typologies_Julia.R
+#
+# Every helper here takes its inputs as arguments, so the whole decision chain
+# (livestock units -> density -> feed shares -> decision tree) is reachable
+# offline from tribble fixtures. No pin read, no shapefile download.
+
+# Flows in the schema `create_n_prov_destiny()` emits, i.e. the input
+# `.grafs_prod_destiny_legacy()` translates. Kept narrow so the interesting
+# columns fit on one line.
+julia_prov_destiny_fixture <- function() {
+  tibble::tribble(
+    ~item,       ~box,                          ~origin,      ~destiny,
+    "Wheat",     "Cropland",                    "Cropland",   "population_food",
+    "Wheat",     "Cropland",                    "Cropland",   "population_food",
+    "Barley",    "Cropland",                    "Cropland",   "livestock_rum",
+    "Barley",    "Cropland",                    "Cropland",   "livestock_mono",
+    "Grassland", "semi_natural_agroecosystems", "semi_nat",   "livestock_rum",
+    "Soy",       "Cropland",                    "Outside",    "livestock_mono",
+    "Olives",    "Cropland",                    "Cropland",   "export",
+    "Wheat",     "Cropland",                    "Synthetic",  "Cropland"
+  ) |>
+    dplyr::mutate(
+      mg_n = c(10, 5, 7, 3, 4, 6, 8, 99),
+      year = 2000,
+      province_name = "Lugo",
+      irrig_cat = "rainfed"
+    )
+}
+
+# The legacy-vocabulary view the aggregation helpers consume.
+julia_legacy_feed_fixture <- function() {
+  tibble::tribble(
+    ~Province_name, ~Box,                          ~Destiny, ~MgN,
+    "Lugo",         "Semi_natural_agroecosystems", "Feed",   30,
+    "Lugo",         "Cropland",                    "Feed",   10,
+    "Lugo",         "Cropland",                    "Food",   77,
+    "Lugo",         "Agro-industry",               "Feed",   5,
+    "Soria",        "Cropland",                    "Feed",   40
+  ) |>
+    dplyr::mutate(Year = 2000)
+}
+
+# .prepare_lu_coefs ------------------------------------------------------------
+
+test_that(".prepare_lu_coefs keeps one row per livestock category", {
+  livestock_units <- tibble::tribble(
+    ~Livestock_cat,  ~Animal_class, ~LU_head, ~Region,
+    "Dairy_cattle",  "Cattle",      1.0,      "north",
+    "Dairy_cattle",  "Cattle",      1.0,      "south",
+    "Sheep",         "Small_rum",   0.1,      "north"
+  )
+
+  out <- whep:::.prepare_lu_coefs(livestock_units)
+
+  # Only the three coefficient columns survive, so the duplicated pair of
+  # Dairy_cattle rows collapses instead of fanning the later join out.
+  expect_equal(names(out), c("Livestock_cat", "Animal_class", "LU_head"))
+  expect_equal(nrow(out), 2)
+  expect_equal(
+    out |> dplyr::filter(Livestock_cat == "Sheep") |> dplyr::pull(LU_head),
+    0.1
+  )
+})
+
+# .calculate_lu_totals --------------------------------------------------------
+
+test_that(".calculate_lu_totals multiplies heads by the LU coefficient", {
+  livestock_df <- tibble::tribble(
+    ~Year, ~Province_name, ~Livestock_cat,  ~Stock_Number, ~Source,
+    2000,  "Lugo",         "Dairy_cattle",  100,           "census",
+    2000,  "Lugo",         "Sheep",         200,           "census",
+    2000,  "Lugo",         "Horses",        10,            "census"
+  )
+  lu_coefs_df <- tibble::tribble(
+    ~Livestock_cat,  ~Animal_class, ~LU_head,
+    "Dairy_cattle",  "Cattle",      1.0,
+    "Sheep",         "Small_rum",   0.1
+  )
+
+  out <- whep:::.calculate_lu_totals(livestock_df, lu_coefs_df)
+
+  expect_equal(
+    out |>
+      dplyr::filter(Livestock_cat == "Dairy_cattle") |>
+      dplyr::pull(LU_total),
+    100
+  )
+  expect_equal(
+    out |> dplyr::filter(Livestock_cat == "Sheep") |> dplyr::pull(LU_total),
+    20
+  )
+  # A category with no coefficient keeps its heads but gets no LU. It is left
+  # as NA rather than dropped, so the row stays visible downstream.
+  expect_true(
+    out |>
+      dplyr::filter(Livestock_cat == "Horses") |>
+      dplyr::pull(LU_total) |>
+      is.na()
+  )
+  expect_false("Source" %in% names(out))
+})
+
+# .aggregate_lu_totals / .aggregate_area_aa -----------------------------------
+
+test_that(".aggregate_lu_totals sums categories and sorts by year-province", {
+  lu_detailed <- tibble::tribble(
+    ~Year, ~Province_name, ~LU_total,
+    2001,  "Soria",        5,
+    2000,  "Lugo",         100,
+    2000,  "Lugo",         20,
+    2000,  "Soria",        NA
+  )
+
+  out <- whep:::.aggregate_lu_totals(lu_detailed)
+
+  expect_equal(out$Year, c(2000, 2000, 2001))
+  expect_equal(out$Province_name, c("Lugo", "Soria", "Soria"))
+  # NA-only groups sum to 0 because na.rm = TRUE, not to NA.
+  expect_equal(out$LU_total, c(120, 0, 5))
+})
+
+test_that(".aggregate_area_aa sums every land use in the province", {
+  npp_df <- tibble::tribble(
+    ~Year, ~Province_name, ~LandUse,            ~Area_ygpit_ha,
+    2000,  "Lugo",         "Cropland",          200,
+    2000,  "Lugo",         "Pasture_Shrubland", 300,
+    2000,  "Soria",        "Cropland",          50
+  )
+
+  out <- whep:::.aggregate_area_aa(npp_df)
+
+  expect_equal(
+    out |> dplyr::filter(Province_name == "Lugo") |> dplyr::pull(Area_ha),
+    500
+  )
+  expect_equal(nrow(out), 2)
+})
+
+# .calculate_livestock_density ------------------------------------------------
+
+test_that(".calculate_livestock_density divides LU by agricultural area", {
+  lu_totals_df <- tibble::tribble(
+    ~Year, ~Province_name, ~LU_total,
+    2000,  "Lugo",         120,
+    2000,  "Soria",        10
+  )
+  area_df <- tibble::tribble(
+    ~Year, ~Province_name, ~Area_ha,
+    2000,  "Lugo",         600
+  )
+
+  out <- whep:::.calculate_livestock_density(lu_totals_df, area_df)
+
+  expect_equal(
+    out |>
+      dplyr::filter(Province_name == "Lugo") |>
+      dplyr::pull(Livestock_density),
+    0.2
+  )
+  # A province with no area row keeps its LU but has no density.
+  expect_true(
+    out |>
+      dplyr::filter(Province_name == "Soria") |>
+      dplyr::pull(Livestock_density) |>
+      is.na()
+  )
+})
+
+# .aggregate_crop_productivity ------------------------------------------------
+
+test_that(".aggregate_crop_productivity uses cropland only, in kgN per ha", {
+  npp_df <- tibble::tribble(
+    ~Year, ~Province_name, ~LandUse,            ~Prod_MgN, ~Area_ygpit_ha,
+    2000,  "Lugo",         "Cropland",          8,         100,
+    2000,  "Lugo",         "Cropland",          4,         100,
+    2000,  "Lugo",         "Pasture_Shrubland", 500,       900
+  )
+
+  out <- whep:::.aggregate_crop_productivity(npp_df)
+
+  expect_equal(out$Prod_MgN_total, 12)
+  expect_equal(out$Area_ha_cropland, 200)
+  # 12 MgN over 200 ha is 0.06 MgN/ha, i.e. 60 kgN/ha. The pasture row, which
+  # would have swamped both totals, must not be in there.
+  expect_equal(out$Productivity_kgN_ha, 60)
+})
+
+# feed aggregation ------------------------------------------------------------
+
+test_that("feed aggregation splits semi-natural from cropland", {
+  df <- julia_legacy_feed_fixture()
+
+  semi_nat <- whep:::.aggregate_semi_nat_feed_mgn(df)
+  cropland <- whep:::.aggregate_cropland_feed_mgn(df)
+  total <- whep:::.aggregate_total_feed_mgn(df)
+
+  # Only Lugo has semi-natural feed, so Soria is absent rather than zero.
+  expect_equal(semi_nat$Province_name, "Lugo")
+  expect_equal(semi_nat$Semi_nat_feed_MgN, 30)
+  expect_equal(
+    cropland |>
+      dplyr::filter(Province_name == "Lugo") |>
+      dplyr::pull(Cropland_feed_MgN),
+    10
+  )
+  # The Food row and the Agro-industry box are both outside the total: it is
+  # semi-natural + cropland feed only.
+  expect_equal(
+    total |>
+      dplyr::filter(Province_name == "Lugo") |>
+      dplyr::pull(Total_feed_MgN),
+    40
+  )
+})
+
+test_that(".calculate_semi_nat_feed_share treats no semi-natural as zero", {
+  out <- whep:::.calculate_semi_nat_feed_share(julia_legacy_feed_fixture())
+
+  expect_equal(
+    out |>
+      dplyr::filter(Province_name == "Lugo") |>
+      dplyr::pull(Semi_nat_share),
+    30 / 40
+  )
+  # Soria has cropland feed only. The share is 0, not a missing value, which
+  # is what the decision tree's `Semi_nat_share > 0.6` test relies on.
+  expect_equal(
+    out |>
+      dplyr::filter(Province_name == "Soria") |>
+      dplyr::pull(Semi_nat_share),
+    0
+  )
+})
+
+# .calculate_feed_domest_supply -----------------------------------------------
+
+test_that(".calculate_feed_domest_supply totals feed and attaches LU", {
+  lu_df <- tibble::tribble(
+    ~Year, ~Province_name, ~LU_total, ~Area_ha,
+    2000,  "Lugo",         120,       600
+  )
+
+  out <- whep:::.calculate_feed_domest_supply(
+    julia_legacy_feed_fixture(),
+    lu_df
+  )
+
+  # Every Feed row counts here, including the Agro-industry box that
+  # .aggregate_total_feed_mgn() excludes: 30 + 10 + 5.
+  expect_equal(
+    out |>
+      dplyr::filter(Province_name == "Lugo") |>
+      dplyr::pull(Domestic_feed_MgN),
+    45
+  )
+  expect_equal(
+    out |> dplyr::filter(Province_name == "Lugo") |> dplyr::pull(LU_total),
+    120
+  )
+  expect_false("Area_ha" %in% names(out))
+})
+
+# .calculate_feed_import_share ------------------------------------------------
+
+test_that(".calculate_feed_import_share splits imports by LU share", {
+  feed_df <- tibble::tribble(
+    ~Year, ~Item,    ~Element,     ~Destiny, ~Value_destiny,
+    2000,  "Soy",    "Import",     "Feed",   800,
+    2000,  "Maize",  "Import",     "Feed",   200,
+    2000,  "Maize",  "Import",     "Food",   5000,
+    2000,  "Maize",  "Production", "Feed",   5000
+  )
+  lu_df <- tibble::tribble(
+    ~Year, ~Province_name, ~LU_total,
+    2000,  "Lugo",         750,
+    2000,  "Soria",        250
+  )
+
+  out <- whep:::.calculate_feed_import_share(feed_df, lu_df)
+
+  # Shares are a partition of national LU.
+  expect_equal(sum(out$LU_share), 1)
+  # Only Element == "Import" & Destiny == "Feed" is the national pool: 1000,
+  # not the 5000 Food import nor the 5000 Production.
+  expect_equal(sum(out$Feed_import_MgN), 1000)
+  expect_equal(
+    out |>
+      dplyr::filter(Province_name == "Lugo") |>
+      dplyr::pull(Feed_import_MgN),
+    750
+  )
+})
+
+# .calculate_imported_feed_share ----------------------------------------------
+
+test_that(".calculate_imported_feed_share keeps a single LU_total column", {
+  # Both inputs carry LU_total from the same aggregated table. An unsuffixed
+  # join would leave LU_total.x / LU_total.y and the select() would fail.
+  feed_import_by_province <- tibble::tribble(
+    ~Year, ~Province_name, ~LU_total, ~LU_share, ~Feed_import_MgN,
+    2000,  "Lugo",         750,       0.75,      750,
+    2000,  "Soria",        250,       0.25,      250
+  )
+  domestic_feed_by_province <- tibble::tribble(
+    ~Year, ~Province_name, ~LU_total, ~Domestic_feed_MgN,
+    2000,  "Lugo",         750,       250,
+    2000,  "Soria",        250,       750
+  )
+
+  out <- whep:::.calculate_imported_feed_share(
+    feed_import_by_province,
+    domestic_feed_by_province
+  )
+
+  expect_true("LU_total" %in% names(out))
+  expect_false(any(grepl("LU_total\\.", names(out))))
+  expect_equal(
+    out |> dplyr::filter(Province_name == "Lugo") |> dplyr::pull(LU_total),
+    750
+  )
+  expect_equal(
+    out |>
+      dplyr::filter(Province_name == "Lugo") |>
+      dplyr::pull(Imported_feed_share),
+    0.75
+  )
+  expect_equal(
+    out |>
+      dplyr::filter(Province_name == "Soria") |>
+      dplyr::pull(Imported_feed_share),
+    0.25
+  )
+})
+
+test_that(".calculate_imported_feed_share reports no feed at all as NA", {
+  feed_import_by_province <- tibble::tribble(
+    ~Year, ~Province_name, ~LU_total, ~LU_share, ~Feed_import_MgN,
+    2000,  "Lugo",         0,         0,         0
+  )
+  domestic_feed_by_province <- tibble::tribble(
+    ~Year, ~Province_name, ~Domestic_feed_MgN,
+    2000,  "Lugo",         0
+  )
+
+  out <- whep:::.calculate_imported_feed_share(
+    feed_import_by_province,
+    domestic_feed_by_province
+  )
+
+  # 0 / 0 would be NaN, which compares FALSE against every threshold without
+  # saying so. It is turned into NA instead.
+  expect_true(is.na(out$Imported_feed_share))
+  expect_false(is.nan(out$Imported_feed_share))
+})
+
+# .grafs_prod_destiny_legacy --------------------------------------------------
+
+test_that(".grafs_prod_destiny_legacy maps to the legacy vocabulary", {
+  out <- whep:::.grafs_prod_destiny_legacy(julia_prov_destiny_fixture())
+
+  expect_setequal(
+    out$Destiny,
+    c("Food", "Feed", "Export", "Import")
+  )
+  # The two irrigation categories of Wheat collapse into one Food row.
+  expect_equal(
+    out |>
+      dplyr::filter(Item == "Wheat", Destiny == "Food") |>
+      dplyr::pull(MgN),
+    15
+  )
+  # Ruminant and monogastric feed become one "Feed" row.
+  expect_equal(
+    out |> dplyr::filter(Item == "Barley") |> dplyr::pull(MgN),
+    10
+  )
+  expect_equal(
+    out |> dplyr::filter(Item == "Grassland") |> dplyr::pull(Box),
+    "Semi_natural_agroecosystems"
+  )
+})
+
+test_that(".grafs_prod_destiny_legacy drops soil inputs, repeats imports", {
+  out <- whep:::.grafs_prod_destiny_legacy(julia_prov_destiny_fixture())
+
+  # The Synthetic -> Cropland soil-input row (99 MgN) was never in the legacy
+  # file, so it must not appear under any destiny.
+  expect_equal(sum(out$MgN), 15 + 10 + 4 + 6 + 8 + 6)
+  expect_false(any(out$MgN == 99))
+
+  # Imported flows are emitted twice, once under their real destiny and once
+  # as "Import", which is the legacy convention downstream code inverts by
+  # subtracting the import rows from the sum of the use rows.
+  imports <- out |> dplyr::filter(Destiny == "Import")
+  expect_equal(imports$Item, "Soy")
+  expect_equal(imports$MgN, 6)
+  expect_equal(
+    out |> dplyr::filter(Item == "Soy", Destiny == "Feed") |> dplyr::pull(MgN),
+    6
+  )
+})
+
+# .assign_decision_tree -------------------------------------------------------
+
+test_that(".assign_decision_tree reaches every typology branch", {
+  skip_if_not_installed("sf")
+  skip_if_not_installed("ggplot2")
+
+  # One province per branch of the tree, plus a province whose density is
+  # unknown so the fall-through NA is exercised too.
+  indicators <- tibble::tribble(
+    ~Province_name, ~Livestock_density, ~Productivity_kgN_ha,
+    "SpecCrop",     0.1,                90,
+    "ExtCrop",      0.1,                40,
+    "ExtMixed",     1.0,                50,
+    "IntMixed",     1.0,                50,
+    "SpecLivest",   1.0,                50,
+    "Unknown",      NA,                 50
+  ) |>
+    dplyr::mutate(
+      Year = 1980,
+      Semi_nat_share = c(0, 0, 0.8, 0.2, 0.2, 0.2),
+      Imported_feed_share = c(0, 0, 0.1, 0.1, 0.9, 0.1)
+    )
+
+  density <- indicators |>
+    dplyr::select(Year, Province_name, Livestock_density) |>
+    dplyr::mutate(LU_total = 1, Area_ha = 1)
+  productivity <- indicators |>
+    dplyr::select(Year, Province_name, Productivity_kgN_ha)
+  semi_nat <- indicators |>
+    dplyr::select(Year, Province_name, Semi_nat_share)
+  imported <- indicators |>
+    dplyr::select(Year, Province_name, Imported_feed_share)
+
+  provinces <- sf::st_sf(
+    name = indicators$Province_name,
+    geometry = sf::st_sfc(lapply(
+      seq_len(nrow(indicators)),
+      function(i) sf::st_point(c(i, i))
+    ))
+  )
+
+  out <- whep:::.assign_decision_tree(
+    density,
+    productivity,
+    semi_nat,
+    imported,
+    sf_provinces = provinces,
+    year = 1980
+  )
+
+  expect_equal(
+    out$Typologies |> dplyr::arrange(Province_name) |> dplyr::pull(Typologie),
+    c(
+      "Extensive cropping system",
+      "Extensive mixed crop-livestock system",
+      "Intensive mixed crop-livestock system",
+      "Specialized cropping system",
+      "Specialized livestock-farming system",
+      NA
+    )
+  )
+  expect_s3_class(out$Typologies_map, "ggplot")
+})
+
+test_that(".assign_decision_tree filters the map year but keeps the series", {
+  skip_if_not_installed("sf")
+  skip_if_not_installed("ggplot2")
+
+  indicators <- tibble::tribble(
+    ~Year, ~Province_name, ~Livestock_density, ~Productivity_kgN_ha,
+    1980,  "Lugo",         0.1,                90,
+    2000,  "Lugo",         1.0,                50
+  ) |>
+    dplyr::mutate(Semi_nat_share = c(0, 0.8), Imported_feed_share = c(0, 0.1))
+
+  provinces <- sf::st_sf(
+    name = "Lugo",
+    geometry = sf::st_sfc(sf::st_point(c(0, 0)))
+  )
+
+  out <- whep:::.assign_decision_tree(
+    indicators |> dplyr::select(Year, Province_name, Livestock_density),
+    indicators |> dplyr::select(Year, Province_name, Productivity_kgN_ha),
+    indicators |> dplyr::select(Year, Province_name, Semi_nat_share),
+    indicators |> dplyr::select(Year, Province_name, Imported_feed_share),
+    sf_provinces = provinces,
+    year = 1980
+  )
+
+  expect_equal(nrow(out$Typologies), 1)
+  expect_equal(out$Typologies$Typologie, "Specialized cropping system")
+  # The all-years table is not filtered, and the same province changes class
+  # between the two years.
+  expect_equal(out$Typologies_all_years$Year, c(1980, 2000))
+  expect_equal(
+    out$Typologies_all_years$Typologie,
+    c(
+      "Specialized cropping system",
+      "Extensive mixed crop-livestock system"
+    )
+  )
+})

--- a/tests/testthat/test_alfredo_typologies.R
+++ b/tests/testthat/test_alfredo_typologies.R
@@ -1,0 +1,219 @@
+# test_alfredo_typologies.R — tests for R/alfredo_typologies.R
+#
+# `create_alfredos_typologies()` takes both of its inputs as arguments, so the
+# classification runs offline from tribble fixtures; nothing here touches
+# `create_n_soil_inputs()` or `create_n_prov_destiny()`.
+
+# One province per branch of the Category tree. `mg_n` is filled after the
+# tribble so the flow columns stay inside the line budget.
+alfredo_prod_destiny_fixture <- function() {
+  tibble::tribble(
+    ~province_name, ~item,       ~box,        ~origin,    ~destiny,
+    "Grass",        "Grassland", "semi_nat",  "semi_nat", "livestock_rum",
+    "Grass",        "Soy",       "Cropland",  "Outside",  "livestock_mono",
+    "Woody",        "Grassland", "semi_nat",  "semi_nat", "livestock_rum",
+    "Woody",        "Firewood",  "Cropland",  "Cropland", "population_food",
+    "Woody",        "Soy",       "Cropland",  "Outside",  "livestock_mono",
+    "Herb",         "Grassland", "semi_nat",  "semi_nat", "livestock_rum",
+    "Herb",         "Acorns",    "Cropland",  "Cropland", "population_food",
+    "Herb",         "Soy",       "Cropland",  "Outside",  "livestock_mono",
+    "Imported",     "Grassland", "semi_nat",  "semi_nat", "livestock_rum",
+    "Imported",     "Soy",       "Cropland",  "Outside",  "livestock_mono"
+  ) |>
+    dplyr::mutate(
+      mg_n = c(100, 5, 1, 10, 5, 10, 1, 5, 1, 50),
+      year = 2000,
+      box = dplyr::if_else(
+        box == "semi_nat",
+        "semi_natural_agroecosystems",
+        box
+      ),
+      origin = dplyr::if_else(
+        origin == "semi_nat",
+        "semi_natural_agroecosystems",
+        origin
+      )
+    )
+}
+
+alfredo_soil_inputs_fixture <- function() {
+  tibble::tribble(
+    ~year, ~province_name, ~synthetic,
+    2000,  "Grass",        10,
+    2000,  "Woody",        50,
+    2000,  "Herb",         50,
+    2000,  "Imported",     5
+  )
+}
+
+alfredo_categories <- function(...) {
+  whep::create_alfredos_typologies(...) |>
+    dplyr::arrange(province_name) |>
+    dplyr::select(province_name, Category)
+}
+
+# Category assignment ---------------------------------------------------------
+
+test_that("create_alfredos_typologies reaches all four categories", {
+  out <- alfredo_categories(
+    soil_inputs = alfredo_soil_inputs_fixture(),
+    prod_destiny = alfredo_prod_destiny_fixture(),
+    years = 2000
+  )
+
+  expect_equal(
+    out$province_name,
+    c("Grass", "Herb", "Imported", "Woody")
+  )
+  expect_equal(
+    out$Category,
+    c("Grassland", "Synthetic herbaceous", "Imported feed", "Synthetic woody")
+  )
+})
+
+test_that("create_alfredos_typologies reports the indicators it ranked", {
+  out <- whep::create_alfredos_typologies(
+    soil_inputs = alfredo_soil_inputs_fixture(),
+    prod_destiny = alfredo_prod_destiny_fixture(),
+    years = 2000
+  )
+
+  woody <- out |> dplyr::filter(province_name == "Woody")
+  # Grassland N is feed plus export from the semi-natural box only.
+  expect_equal(woody$grass_N, 1)
+  expect_equal(woody$fertiliser_N, 50)
+  # Imported feed is the "Outside" origin arriving at a livestock destiny.
+  expect_equal(woody$feed_import_N, 5)
+  # 10 MgN of firewood against 1 MgN of grassland herbage.
+  expect_equal(woody$woody, 10)
+  expect_equal(woody$herbaceous, 1)
+  expect_equal(woody$woody_share, 10 / 11)
+
+  herb <- out |> dplyr::filter(province_name == "Herb")
+  expect_equal(herb$woody_share, 1 / 11)
+})
+
+test_that("create_alfredos_typologies nets imports out of woody biomass", {
+  # The same item arriving from "Outside" is not local production, so it is
+  # subtracted before the woody/herbaceous split, and the result is floored at
+  # zero rather than going negative.
+  prod_destiny <- tibble::tribble(
+    ~province_name, ~item,       ~origin,    ~destiny,          ~mg_n,
+    "Net",          "Grassland", "semi_nat", "livestock_rum",   10,
+    "Net",          "Firewood",  "Cropland", "population_food", 10,
+    "Net",          "Firewood",  "Outside",  "population_food", 4,
+    "Over",         "Grassland", "semi_nat", "livestock_rum",   10,
+    "Over",         "Firewood",  "Cropland", "population_food", 3,
+    "Over",         "Firewood",  "Outside",  "population_food", 8
+  ) |>
+    dplyr::mutate(
+      year = 2000,
+      box = dplyr::if_else(
+        item == "Grassland",
+        "semi_natural_agroecosystems",
+        "Cropland"
+      ),
+      origin = dplyr::if_else(
+        origin == "semi_nat",
+        "semi_natural_agroecosystems",
+        origin
+      )
+    )
+
+  out <- whep::create_alfredos_typologies(
+    soil_inputs = tibble::tibble(
+      year = 2000,
+      province_name = c("Net", "Over"),
+      synthetic = 100
+    ),
+    prod_destiny = prod_destiny,
+    years = 2000
+  )
+
+  # The province-level import total (4) is subtracted from every firewood row:
+  # the domestic row contributes 10 - 4 = 6, the import row 4 - 4 = 0.
+  expect_equal(
+    out |> dplyr::filter(province_name == "Net") |> dplyr::pull(woody),
+    6
+  )
+  # Imports above local production would make the difference negative.
+  expect_equal(
+    out |> dplyr::filter(province_name == "Over") |> dplyr::pull(woody),
+    0
+  )
+})
+
+test_that("create_alfredos_typologies keeps only provinces with grassland", {
+  # The grassland table is the left-hand side of the join chain, so a province
+  # whose only flow is cropland feed never reaches the output at all.
+  prod_destiny <- tibble::tribble(
+    ~province_name, ~item,       ~box,       ~origin,    ~destiny,      ~mg_n,
+    "WithGrass",    "Grassland", "semi_nat", "semi_nat", "export",      7,
+    "NoGrass",      "Barley",    "Cropland", "Cropland", "livestock_rum", 7
+  ) |>
+    dplyr::mutate(
+      year = 2000,
+      box = dplyr::if_else(
+        box == "semi_nat",
+        "semi_natural_agroecosystems",
+        box
+      ),
+      origin = dplyr::if_else(
+        origin == "semi_nat",
+        "semi_natural_agroecosystems",
+        origin
+      )
+    )
+
+  out <- whep::create_alfredos_typologies(
+    soil_inputs = tibble::tibble(
+      year = 2000,
+      province_name = c("WithGrass", "NoGrass"),
+      synthetic = 1
+    ),
+    prod_destiny = prod_destiny,
+    years = 2000
+  )
+
+  expect_equal(out$province_name, "WithGrass")
+  # Exported grassland N counts towards grass_N alongside feed.
+  expect_equal(out$grass_N, 7)
+})
+
+test_that("create_alfredos_typologies honours the years argument", {
+  prod_destiny <- alfredo_prod_destiny_fixture() |>
+    dplyr::bind_rows(
+      alfredo_prod_destiny_fixture() |> dplyr::mutate(year = 1990)
+    )
+
+  out <- whep::create_alfredos_typologies(
+    soil_inputs = alfredo_soil_inputs_fixture(),
+    prod_destiny = prod_destiny,
+    years = 2000
+  )
+
+  expect_equal(unique(out$year), 2000)
+})
+
+# .plot_province_typologies ---------------------------------------------------
+
+test_that(".plot_province_typologies fills gaps and orders provinces", {
+  skip_if_not_installed("ggplot2")
+
+  typologies <- tibble::tribble(
+    ~year, ~province_name, ~fertiliser_N, ~feed_import_N, ~woody_share,
+    2000,  "Alava",        NA,            NA,             NA,
+    2000,  "Zamora",       10,            2,              0.3
+  ) |>
+    dplyr::mutate(Category = c("Grassland", "Synthetic herbaceous"))
+
+  plot <- whep:::.plot_province_typologies(typologies)
+
+  # A missing indicator is drawn as zero rather than silently dropping a tile.
+  expect_equal(plot$data$fertiliser_N, c(0, 10))
+  expect_equal(plot$data$feed_import_N, c(0, 2))
+  expect_equal(plot$data$woody_share, c(0, 0.3))
+  # Provinces are reversed so the y axis reads alphabetically top-to-bottom.
+  expect_equal(levels(plot$data$province_name), c("Zamora", "Alava"))
+  expect_s3_class(plot, "ggplot")
+})

--- a/tests/testthat/test_build_cache.R
+++ b/tests/testthat/test_build_cache.R
@@ -1,0 +1,86 @@
+# test_build_cache.R — tests for R/build_cache.R
+
+# The cache is session-level, so anything already in it is put back afterwards
+# rather than being wiped out from under the rest of the suite.
+local_isolated_build_cache <- function(envir = parent.frame()) {
+  cache <- whep:::.build_cache
+  saved <- as.list(cache, all.names = TRUE)
+  rm(list = ls(cache, all.names = TRUE), envir = cache)
+  withr::defer(
+    {
+      rm(list = ls(cache, all.names = TRUE), envir = cache)
+      list2env(saved, envir = cache)
+    },
+    envir = envir
+  )
+  cache
+}
+
+test_that(".cache_get evaluates the expression only on a miss", {
+  local_isolated_build_cache()
+
+  counter <- new.env(parent = emptyenv())
+  counter$n <- 0L
+  build <- function() {
+    counter$n <- counter$n + 1L
+    tibble::tibble(value = 1)
+  }
+
+  first <- whep:::.cache_get("coverage_probe", build())
+  second <- suppressMessages(whep:::.cache_get("coverage_probe", build()))
+
+  expect_equal(first, tibble::tibble(value = 1))
+  expect_equal(second, first)
+  # `expr` is a promise: on a hit it is returned from before it is forced, so
+  # the expensive build never runs a second time.
+  expect_equal(counter$n, 1L)
+})
+
+test_that(".cache_get says when it is serving a cached value", {
+  local_isolated_build_cache()
+
+  whep:::.cache_get("coverage_probe", 42)
+
+  expect_message(
+    whep:::.cache_get("coverage_probe", 42),
+    "Using cached coverage_probe"
+  )
+})
+
+test_that(".cache_get caches a NULL result by recomputing it", {
+  local_isolated_build_cache()
+
+  counter <- new.env(parent = emptyenv())
+  counter$n <- 0L
+  build <- function() {
+    counter$n <- counter$n + 1L
+    NULL
+  }
+
+  expect_null(whep:::.cache_get("coverage_probe", build()))
+  expect_null(whep:::.cache_get("coverage_probe", build()))
+  # The hit test is `!is.null(...)`, so a NULL payload is indistinguishable
+  # from an empty slot and is rebuilt every time.
+  expect_equal(counter$n, 2L)
+})
+
+test_that("whep_clear_cache empties the cache and returns NULL invisibly", {
+  cache <- local_isolated_build_cache()
+
+  whep:::.cache_get("coverage_probe", 42)
+  expect_equal(ls(cache), "coverage_probe")
+
+  expect_message(cleared <- whep::whep_clear_cache(), "Build cache cleared")
+
+  expect_equal(ls(cache), character(0))
+  expect_null(cleared)
+  # A rebuild is now a miss again.
+  expect_equal(whep:::.cache_get("coverage_probe", 7), 7)
+})
+
+test_that("whep_clear_cache is a no-op on an already empty cache", {
+  local_isolated_build_cache()
+
+  expect_message(whep::whep_clear_cache(), "Build cache cleared")
+  expect_equal(ls(whep:::.build_cache), character(0))
+})

--- a/tests/testthat/test_decomposition_analysis.R
+++ b/tests/testthat/test_decomposition_analysis.R
@@ -1,0 +1,129 @@
+# test_decomposition_analysis.R — tests for R/decomposition_analysis.R
+#
+# Both builders read national N flows plus a pinned population / crop-area
+# table. All three readers are stubbed, so the tests are offline.
+
+# National N flows: soil inputs into the two agricultural boxes, harvested
+# output leaving them, and one flow that is neither.
+lmdi_flows_fixture <- function() {
+  tibble::tribble(
+    ~year, ~origin,      ~destiny,                     ~mg_n,
+    1990,  "Synthetic",  "Cropland",                   10,
+    2000,  "Synthetic",  "Cropland",                   100,
+    2000,  "Deposition", "semi_natural_agroecosystems", 20,
+    2000,  "Cropland",   "population_food",            30,
+    2000,  "Cropland",   "export",                     10,
+    2000,  "semi_nat",   "livestock_rum",              5,
+    2000,  "Cropland",   "Losses",                     40,
+    2001,  "Synthetic",  "Cropland",                   200,
+    2001,  "Cropland",   "population_food",            50
+  ) |>
+    dplyr::mutate(
+      origin = dplyr::if_else(
+        origin == "semi_nat",
+        "semi_natural_agroecosystems",
+        origin
+      )
+    )
+}
+
+lmdi_population_fixture <- function() {
+  tibble::tribble(
+    ~Year, ~POP_MPEOP_YG,
+    2000,  15,
+    2000,  25,
+    2001,  50
+  )
+}
+
+lmdi_area_fixture <- function() {
+  tibble::tribble(
+    ~Year, ~Area_ygpit_ha,
+    2000,  40,
+    2000,  50,
+    2001,  100
+  )
+}
+
+local_mocked_lmdi_readers <- function() {
+  local_mocked_bindings(
+    create_n_nat_destiny = function(...) lmdi_flows_fixture(),
+    whep_read_file = function(name, ...) {
+      if (name == "population_yg") {
+        lmdi_population_fixture()
+      } else {
+        lmdi_area_fixture()
+      }
+    },
+    .env = parent.frame()
+  )
+}
+
+# prepare_lmdi_dataset --------------------------------------------------------
+
+test_that("prepare_lmdi_dataset nets harvested output out of soil inputs", {
+  local_mocked_lmdi_readers()
+
+  out <- prepare_lmdi_dataset()
+
+  expect_equal(
+    names(out),
+    c("year", "surplus", "population", "food", "A", "t_ratio")
+  )
+  expect_equal(out$year, c(1990, 2000, 2001))
+  # 2000: inputs 100 + 20 = 120, output 30 + 10 + 5 = 45. The 40 MgN going to
+  # "Losses" is neither an input to the boxes nor a harvested output.
+  expect_equal(out$surplus, c(10, 75, 150))
+  expect_equal(out$food, c(0, 30, 50))
+})
+
+test_that("prepare_lmdi_dataset derives per-capita food and the N ratio", {
+  local_mocked_lmdi_readers()
+
+  out <- prepare_lmdi_dataset()
+
+  # Population is summed over the sub-national rows of the pin.
+  expect_equal(out$population, c(0, 40, 50))
+  expect_equal(out$A, c(NA, 0.75, 1))
+  expect_equal(out$t_ratio, c(NA, 2.5, 3))
+})
+
+test_that("prepare_lmdi_dataset guards the divisions instead of emitting Inf", {
+  local_mocked_lmdi_readers()
+
+  out <- prepare_lmdi_dataset() |> dplyr::filter(year == 1990)
+
+  # 1990 has a soil input but no harvest and no population row. Both ratios
+  # come back NA rather than Inf or NaN.
+  expect_equal(out$surplus, 10)
+  expect_true(is.na(out$A))
+  expect_true(is.na(out$t_ratio))
+  expect_false(is.nan(out$A))
+})
+
+# prepare_lmdi_production_area ------------------------------------------------
+
+test_that("prepare_lmdi_production_area yields output per hectare", {
+  local_mocked_lmdi_readers()
+
+  out <- prepare_lmdi_production_area()
+
+  expect_equal(names(out), c("year", "surplus", "area", "yield", "intensity"))
+  expect_equal(out$year, c(1990, 2000, 2001))
+  # Cropland area is summed over the rows of the pin: 40 + 50 in 2000.
+  expect_equal(out$area, c(NA, 90, 100))
+  # Harvested output is 45 MgN in 2000 and 50 in 2001.
+  expect_equal(out$yield, c(NA, 45 / 90, 50 / 100))
+})
+
+test_that("prepare_lmdi_production_area totals every flow as `surplus`", {
+  local_mocked_lmdi_readers()
+
+  out <- prepare_lmdi_production_area()
+
+  # Unlike prepare_lmdi_dataset(), this builder's `surplus` column is the sum
+  # of *all* national flows, harvest and losses included, not inputs minus
+  # outputs: 100 + 20 + 30 + 10 + 5 + 40 in 2000.
+  expect_equal(out$surplus, c(10, 205, 250))
+  expect_equal(out$intensity, c(NA, 205 / 45, 5))
+})

--- a/tests/testthat/test_natural_earth.R
+++ b/tests/testthat/test_natural_earth.R
@@ -18,10 +18,15 @@ test_that(".natural_earth_cache_dir sits inside the whep user cache", {
   dir <- whep:::.natural_earth_cache_dir()
 
   expect_equal(basename(dir), "naturalearth")
-  # dirname() expands "~", so the expectation has to as well.
+  # dirname() expands "~" and returns forward slashes, while user_cache_dir()
+  # uses the platform separator, so both sides are normalised to compare.
   expect_equal(
-    dirname(dir),
-    path.expand(rappdirs::user_cache_dir("whep"))
+    stringr::str_replace_all(dirname(dir), "\\\\", "/"),
+    stringr::str_replace_all(
+      path.expand(rappdirs::user_cache_dir("whep")),
+      "\\\\",
+      "/"
+    )
   )
 })
 

--- a/tests/testthat/test_natural_earth.R
+++ b/tests/testthat/test_natural_earth.R
@@ -1,0 +1,109 @@
+# test_natural_earth.R — tests for R/natural_earth.R
+#
+# Nothing here reaches the network: the cache directory is redirected to a
+# temporary one, and the failure path is driven by an unsupported URL scheme
+# that libcurl rejects locally.
+
+test_that(".natural_earth_url points at the official Natural Earth CDN", {
+  expect_equal(
+    whep:::.natural_earth_url("ne_10m_admin_1_states_provinces"),
+    paste0(
+      "https://naciscdn.org/naturalearth/10m/cultural/",
+      "ne_10m_admin_1_states_provinces.zip"
+    )
+  )
+})
+
+test_that(".natural_earth_cache_dir sits inside the whep user cache", {
+  dir <- whep:::.natural_earth_cache_dir()
+
+  expect_equal(basename(dir), "naturalearth")
+  # dirname() expands "~", so the expectation has to as well.
+  expect_equal(
+    dirname(dir),
+    path.expand(rappdirs::user_cache_dir("whep"))
+  )
+})
+
+# .provinces_shapefile --------------------------------------------------------
+
+test_that(".provinces_shapefile returns an existing explicit path", {
+  shp <- withr::local_tempfile(fileext = ".shp")
+  file.create(shp)
+
+  expect_equal(whep:::.provinces_shapefile(shp), shp)
+})
+
+test_that(".provinces_shapefile honours the session-wide option", {
+  shp <- withr::local_tempfile(fileext = ".shp")
+  file.create(shp)
+  withr::local_options(whep.provinces_shapefile = shp)
+
+  # No argument, so resolution falls through to the option before any
+  # download is considered.
+  expect_equal(whep:::.provinces_shapefile(), shp)
+})
+
+test_that(".provinces_shapefile aborts on a path that does not exist", {
+  missing <- file.path(withr::local_tempdir(), "not_there.shp")
+
+  expect_error(
+    whep:::.provinces_shapefile(missing),
+    "Provinces shapefile not found"
+  )
+})
+
+test_that(".provinces_shapefile prefers the argument over the option", {
+  option_shp <- withr::local_tempfile(fileext = ".shp")
+  file.create(option_shp)
+  withr::local_options(whep.provinces_shapefile = option_shp)
+  missing <- file.path(withr::local_tempdir(), "not_there.shp")
+
+  # The argument wins, so an unusable argument aborts even though the option
+  # points at a readable file.
+  expect_error(
+    whep:::.provinces_shapefile(missing),
+    "Provinces shapefile not found"
+  )
+})
+
+# .download_natural_earth -----------------------------------------------------
+
+test_that(".download_natural_earth reuses a cached layer without fetching", {
+  cache <- withr::local_tempdir()
+  local_mocked_bindings(
+    .natural_earth_cache_dir = function() cache,
+    .natural_earth_url = function(layer) {
+      cli::cli_abort("The cached layer must be used without a download.")
+    }
+  )
+  shp <- file.path(cache, "test_layer.shp")
+  file.create(shp)
+
+  expect_equal(whep:::.download_natural_earth("test_layer"), shp)
+})
+
+test_that(".download_natural_earth aborts with recovery instructions", {
+  cache <- file.path(withr::local_tempdir(), "nested")
+  local_mocked_bindings(
+    .natural_earth_cache_dir = function() cache,
+    # An unsupported scheme is rejected by libcurl locally, so the failure
+    # branch is exercised without touching the network.
+    .natural_earth_url = function(layer) "whepnoproto://test_layer.zip"
+  )
+
+  err <- expect_error(
+    suppressWarnings(whep:::.download_natural_earth("test_layer")),
+    "Could not download the Natural Earth layer"
+  )
+  # The instruction interpolates the layer URL. cli >= 3.4.0 reads a `{}`
+  # expression starting with a dot as a style name, so interpolating
+  # `.natural_earth_url(layer)` inline made this branch abort with
+  # "Invalid cli literal" and swallowed the instructions.
+  expect_match(conditionMessage(err), "whepnoproto", fixed = TRUE)
+  expect_match(conditionMessage(err), "shapefile_path", fixed = TRUE)
+  # The cache directory is created on the way, and the partial archive is
+  # removed rather than left behind to be mistaken for a good download.
+  expect_true(dir.exists(cache))
+  expect_false(file.exists(file.path(cache, "test_layer.zip")))
+})

--- a/tests/testthat/test_production.R
+++ b/tests/testthat/test_production.R
@@ -71,3 +71,77 @@ testthat::test_that(".warn_residues_no_area stays quiet when every row resolved"
 
   testthat::expect_no_warning(.warn_residues_no_area(dt))
 })
+
+# get_primary_production / get_primary_residues --------------------------------
+
+testthat::test_that("get_primary_production(example = TRUE) needs no remote", {
+  out <- whep::get_primary_production(example = TRUE)
+
+  testthat::expect_s3_class(out, "tbl_df")
+  testthat::expect_true(nrow(out) > 0)
+  testthat::expect_true(
+    all(
+      c("year", "area_code", "item_prod_code", "unit", "value") %in%
+        names(out)
+    )
+  )
+})
+
+# The `crop_residues` pin, in the mixed-case schema the builder lowercases.
+# "Tanzania" is deliberately a label the polity crosswalk does not hold, which
+# is how the unresolved-area branch is reached.
+residues_pin_fixture <- function() {
+  tibble::tribble(
+    ~Area,      ~Product_residue, ~Item_cbs,             ~Prod_ygpit_Mg,
+    "Spain",    "Residue",        "Straw",               100,
+    "Spain",    "Residue",        "Straw",               50,
+    "Spain",    "Product",        "Straw",               999,
+    "Spain",    "Residue",        "Other crop residues", 0,
+    "Tanzania", "Residue",        "Straw",               7
+  ) |>
+    dplyr::mutate(Year = 2000L, Item_cbs_crop = "Wheat and products")
+}
+
+testthat::test_that("get_primary_residues aggregates residues on codes", {
+  local_mocked_bindings(whep_read_file = function(name, ...) {
+    residues_pin_fixture()
+  })
+
+  testthat::expect_warning(
+    out <- whep::get_primary_residues(),
+    "crop-residue"
+  )
+
+  spain <- out |> dplyr::filter(area_code == 203L)
+  # The two Spanish straw rows are summed, the "Product" row (999) is not a
+  # residue and the zero-tonne residue row is dropped.
+  testthat::expect_equal(nrow(spain), 1)
+  testthat::expect_equal(spain$value, 150)
+  testthat::expect_equal(spain$item_cbs_code_crop, 2511)
+  testthat::expect_equal(spain$item_cbs_code_residue, 2105)
+  testthat::expect_false(any(out$value == 999))
+})
+
+testthat::test_that("get_primary_residues keeps unresolved areas visible", {
+  local_mocked_bindings(whep_read_file = function(name, ...) {
+    residues_pin_fixture()
+  })
+
+  out <- suppressWarnings(whep::get_primary_residues())
+
+  # The row whose area label did not resolve is reported, not dropped, so the
+  # gap stays visible downstream instead of silently shrinking the totals.
+  unresolved <- out |> dplyr::filter(is.na(area_code))
+  testthat::expect_equal(unresolved$value, 7)
+  testthat::expect_true(is.na(unresolved$reporting_polity_code))
+  testthat::expect_equal(sum(out$value), 157)
+})
+
+testthat::test_that("get_primary_residues(example = TRUE) needs no remote", {
+  out <- whep::get_primary_residues(example = TRUE)
+
+  testthat::expect_s3_class(out, "tbl_df")
+  testthat::expect_true(
+    all(c("year", "area_code", "item_cbs_code_crop", "value") %in% names(out))
+  )
+})

--- a/tests/testthat/test_typologies_kgN_ha.R
+++ b/tests/testthat/test_typologies_kgN_ha.R
@@ -1,0 +1,220 @@
+# test_typologies_kgN_ha.R — tests for R/typologies_kgN_ha.R
+#
+# The two entry points read `npp_ygpit` / `n_balance_ygpit_all` and the
+# typology time series. Both readers are stubbed here, so the tests are
+# offline; the plots the functions print go to a null device.
+
+# Four provinces, two per typology family, so the standard deviation the
+# kgN/ha lines draw is defined.
+kgn_npp_fixture <- function() {
+  tibble::tribble(
+    ~Province_name, ~LandUse,            ~Area_ygpit_ha,
+    "Lugo",         "Cropland",          200,
+    "Lugo",         "Pasture_Shrubland", 300,
+    "Ourense",      "Cropland",          100,
+    "Ourense",      "Forest",            100,
+    "Segovia",      "Cropland",          200,
+    "Soria",        "Cropland",          400,
+    "Soria",        "Forest",            100
+  ) |>
+    dplyr::mutate(Year = 2000)
+}
+
+kgn_typologies_fixture <- function() {
+  tibble::tribble(
+    ~province_name, ~Typology_base,
+    "Lugo",         "Semi-natural agroecosystems",
+    "Ourense",      "Semi-natural agroecosystems",
+    "Segovia",      "Specialized cropping systems (extensive)",
+    "Soria",        "Specialized cropping systems (intensive)"
+  ) |>
+    dplyr::mutate(year = 2000)
+}
+
+kgn_typology_colors <- function() {
+  c(
+    "Semi-natural agroecosystems" = "#66a61e",
+    "Specialized cropping systems (extensive)" = "#FFF7C2",
+    "Specialized cropping systems (intensive)" = "#F7DD5A"
+  )
+}
+
+# .sum_area_by_prov -----------------------------------------------------------
+
+test_that(".sum_area_by_prov totals every land use by default", {
+  out <- whep:::.sum_area_by_prov(kgn_npp_fixture())
+
+  expect_equal(out$Province_name, c("Lugo", "Ourense", "Segovia", "Soria"))
+  expect_equal(out$Area_ha, c(500, 200, 200, 500))
+})
+
+test_that(".sum_area_by_prov restricts to the land uses it is given", {
+  out <- whep:::.sum_area_by_prov(
+    kgn_npp_fixture(),
+    land_uses = c("Cropland", "Pasture_Shrubland")
+  )
+
+  # The forest hectares of Ourense and Soria drop out; Lugo's pasture does not.
+  expect_equal(out$Area_ha, c(500, 100, 200, 400))
+})
+
+# .build_area_totals ----------------------------------------------------------
+
+test_that(".build_area_totals converts to Mha and shares of the year", {
+  colors <- kgn_typology_colors()
+
+  out <- whep:::.build_area_totals(
+    whep:::.sum_area_by_prov(kgn_npp_fixture()),
+    kgn_typologies_fixture() |> dplyr::rename(Typology = Typology_base),
+    colors
+  )
+
+  expect_equal(as.character(out$Typology), names(colors))
+  # Lugo + Ourense are semi-natural, Segovia extensive, Soria intensive.
+  expect_equal(out$Total_ha, c(700, 200, 500))
+  expect_equal(out$Mha, c(700, 200, 500) / 1e6)
+  # Percentages are taken within the year, so they add up to 100.
+  expect_equal(sum(out$Percent_ha), 100)
+  expect_equal(out$Percent_ha[[1]], 50)
+  # The typology becomes a factor over the supplied palette, which is what
+  # keeps the fill scale stable in a year where a class is absent.
+  expect_equal(levels(out$Typology), names(colors))
+})
+
+test_that(".build_area_totals keeps unmatched provinces as an NA typology", {
+  out <- whep:::.build_area_totals(
+    whep:::.sum_area_by_prov(kgn_npp_fixture()),
+    kgn_typologies_fixture() |>
+      dplyr::filter(province_name == "Lugo") |>
+      dplyr::rename(Typology = Typology_base),
+    kgn_typology_colors()
+  )
+
+  # The three provinces with no typology keep their area under NA instead of
+  # vanishing, so the total is still the whole country.
+  expect_equal(nrow(out), 2)
+  expect_true(any(is.na(out$Typology)))
+  expect_equal(sum(out$Total_ha), 1400)
+  expect_equal(sum(out$Percent_ha), 100)
+})
+
+# .plot_area_stacked ----------------------------------------------------------
+
+test_that(".plot_area_stacked plots the column it was asked for", {
+  skip_if_not_installed("ggplot2")
+
+  colors <- c("Semi-natural agroecosystems" = "#66a61e")
+  df <- tibble::tibble(
+    Year = c(2000, 2020),
+    Typology = factor("Semi-natural agroecosystems", levels = names(colors)),
+    Mha = c(1, 2),
+    Percent_ha = c(40, 60)
+  )
+
+  plot <- whep:::.plot_area_stacked(
+    df,
+    year_breaks = 2020,
+    y_var = "Percent_ha",
+    title = "Land area by typology (%)",
+    y_label = "Share of total area (%)",
+    colors = colors
+  )
+
+  expect_s3_class(plot, "ggplot")
+  expect_equal(plot$labels$title, "Land area by typology (%)")
+  expect_equal(plot$labels$y, "Share of total area (%)")
+  # `y_var` selects the column, so the percentage series is drawn, not Mha.
+  expect_equal(ggplot2::layer_data(plot)$y, c(40, 60))
+})
+
+# typology_area_stacked_bars --------------------------------------------------
+
+test_that("typology_area_stacked_bars returns both totals and shares", {
+  skip_if_not_installed("ggplot2")
+  withr::local_pdf(nullfile())
+
+  local_mocked_bindings(
+    create_typo_ts_plot = function(...) kgn_typologies_fixture(),
+    whep_read_file = function(name, ...) kgn_npp_fixture()
+  )
+
+  out <- typology_area_stacked_bars()
+
+  expect_named(out, c("df", "p_total", "p_pct"))
+  expect_equal(sum(out$df$Total_ha), 1400)
+  expect_equal(sum(out$df$Percent_ha), 100)
+  expect_setequal(as.character(out$df$Typology), names(kgn_typology_colors()))
+  expect_s3_class(out$p_total, "ggplot")
+  expect_s3_class(out$p_pct, "ggplot")
+})
+
+# typology_kgha_lines ---------------------------------------------------------
+
+test_that("typology_kgha_lines reports N inputs per hectare by typology", {
+  skip_if_not_installed("ggplot2")
+  withr::local_pdf(nullfile())
+
+  n_balance <- tibble::tribble(
+    ~Province_name, ~LandUse,   ~Deposition, ~BNF, ~Synthetic,
+    "Lugo",         "Cropland", 1,           2,    3,
+    "Lugo",         "Forest",   10,          10,   10,
+    "Ourense",      "Cropland", 1,           1,    0,
+    "Segovia",      "Cropland", 1,           1,    0,
+    "Soria",        "Cropland", 2,           4,    6
+  ) |>
+    dplyr::mutate(Year = 2000, Solid = 0, Liquid = 0, Urban = 0)
+
+  local_mocked_bindings(
+    create_typo_ts_plot = function(...) kgn_typologies_fixture(),
+    whep_read_file = function(name, ...) {
+      if (name == "npp_ygpit") kgn_npp_fixture() else n_balance
+    }
+  )
+
+  out <- typology_kgha_lines()
+
+  expect_named(out, c("p1", "p2", "agricultural_land", "total_land"))
+  # The intensive/extensive qualifier is stripped before grouping, so the two
+  # specialized cropping classes are averaged together.
+  expect_setequal(
+    as.character(out$agricultural_land$Typology),
+    c("Semi-natural agroecosystems", "Specialized cropping systems")
+  )
+
+  # Agricultural land only: Lugo 6 MgN over 500 ha (12 kgN/ha) and Ourense
+  # 2 MgN over 100 ha (20), so their mean is 16.
+  expect_equal(
+    out$agricultural_land |>
+      dplyr::filter(Typology == "Semi-natural agroecosystems") |>
+      dplyr::pull(mean_kgN),
+    16
+  )
+  # Soria 12 MgN over 400 ha (30) against Segovia 2 over 200 (10).
+  expect_equal(
+    out$agricultural_land |>
+      dplyr::filter(Typology == "Specialized cropping systems") |>
+      dplyr::pull(mean_kgN),
+    20
+  )
+  expect_equal(
+    out$agricultural_land |>
+      dplyr::filter(Typology == "Specialized cropping systems") |>
+      dplyr::pull(sd_kgN),
+    stats::sd(c(30, 10))
+  )
+
+  # Total land adds Lugo's 30 MgN of forest inputs over 500 ha (72 kgN/ha)
+  # and spreads Soria's cropland N over its forest hectares too (24).
+  expect_equal(
+    out$total_land |>
+      dplyr::filter(Typology == "Semi-natural agroecosystems") |>
+      dplyr::pull(mean_kgN),
+    41
+  )
+  expect_equal(
+    out$total_land |>
+      dplyr::filter(Typology == "Specialized cropping systems") |>
+      dplyr::pull(mean_kgN),
+    17
+  )
+})

--- a/tests/testthat/test_whep_typologies_spain.R
+++ b/tests/testthat/test_whep_typologies_spain.R
@@ -1,0 +1,190 @@
+# test_whep_typologies_spain.R — tests for R/whep_typologies_spain.R
+#
+# `create_typologies_whep()` takes both of its inputs as arguments, so the
+# whole decision chain runs offline from tribble fixtures.
+
+whep_semi_natural <- "semi_natural_agroecosystems"
+
+# One province per branch of the Category tree. `box` and `origin` follow from
+# the item, which keeps the fixture readable.
+whep_typo_flows_fixture <- function() {
+  tibble::tribble(
+    ~province_name, ~item,       ~destiny,                ~mg_n,
+    "Urban",        "Wheat",     "population_food",       100,
+    "Woody",        "Wheat",     "population_food",       10,
+    "Woody",        "Firewood",  "population_other_uses", 5,
+    "Import",       "Wheat",     "population_food",       10,
+    "Import",       "Soy",       "livestock_mono",        8,
+    "Import",       "Barley",    "livestock_rum",         2,
+    "Crop",         "Wheat",     "population_food",       10,
+    "Crop",         "Barley",    "livestock_rum",         2,
+    "Grass",        "Wheat",     "population_food",       10,
+    "Grass",        "Grassland", "livestock_rum",         20,
+    "Grass",        "Barley",    "livestock_rum",         2,
+    "CropFeed",     "Wheat",     "population_food",       10,
+    "CropFeed",     "Grassland", "livestock_rum",         2,
+    "CropFeed",     "Barley",    "livestock_rum",         20
+  ) |>
+    dplyr::mutate(
+      year = 2020,
+      box = dplyr::if_else(item == "Grassland", whep_semi_natural, "Cropland"),
+      origin = dplyr::if_else(item == "Soy", "Outside", box)
+    )
+}
+
+whep_typo_prod_fixture <- function() {
+  tibble::tribble(
+    ~province_name, ~box,        ~production_n,
+    "Urban",        "Cropland",  50,
+    "Woody",        "Cropland",  100,
+    "Import",       "Cropland",  100,
+    "Crop",         "Cropland",  100,
+    "Grass",        "Cropland",  5,
+    "Grass",        "semi_nat",  20,
+    "CropFeed",     "Cropland",  5,
+    "CropFeed",     "semi_nat",  20
+  ) |>
+    dplyr::mutate(
+      year = 2020,
+      box = dplyr::if_else(box == "semi_nat", whep_semi_natural, box)
+    )
+}
+
+# Category assignment ---------------------------------------------------------
+
+test_that("create_typologies_whep reaches all six categories", {
+  out <- whep::create_typologies_whep(
+    prod_destiny = whep_typo_flows_fixture(),
+    prod_n = whep_typo_prod_fixture(),
+    years = 2020
+  ) |>
+    dplyr::arrange(province_name)
+
+  expect_equal(
+    out$province_name,
+    c("Crop", "CropFeed", "Grass", "Import", "Urban", "Woody")
+  )
+  expect_equal(
+    out$Category,
+    c(
+      "Cropland-based system",
+      "Local crop-based livestock system",
+      "Local grass-based livestock system",
+      "Imported feed-based system",
+      "Urban System",
+      "Woody-based system"
+    )
+  )
+})
+
+test_that("create_typologies_whep computes the decision variables", {
+  out <- whep::create_typologies_whep(
+    prod_destiny = whep_typo_flows_fixture(),
+    prod_n = whep_typo_prod_fixture(),
+    years = 2020
+  )
+
+  urban <- out |> dplyr::filter(province_name == "Urban")
+  # Consumption above own production is what makes a province "urban" here.
+  expect_equal(urban$food_consumption, 100)
+  expect_equal(urban$production, 50)
+  expect_equal(urban$human_share, 2)
+
+  woody <- out |> dplyr::filter(province_name == "Woody")
+  # Food consumption spans both population destinies, food and other uses.
+  expect_equal(woody$food_consumption, 15)
+  expect_equal(woody$woody_prod, 5)
+  expect_equal(woody$woody_share, 5 / 15)
+
+  import <- out |> dplyr::filter(province_name == "Import")
+  expect_equal(import$feed_import, 8)
+  expect_equal(import$animal_ingestion, 10)
+  expect_equal(import$import_share, 0.8)
+
+  grass <- out |> dplyr::filter(province_name == "Grass")
+  expect_equal(grass$grass_feed_N, 20)
+  expect_equal(grass$crop_feed_N, 2)
+  # Production spans every box, cropland production only the cropland one.
+  expect_equal(grass$production, 25)
+  expect_equal(grass$crop_prod, 5)
+})
+
+test_that("create_typologies_whep ranks imported feed above cropland", {
+  # "Import" has crop_prod 100 against an animal ingestion of 10, so the
+  # cropland branch would fire; the import branch comes first in the tree.
+  out <- whep::create_typologies_whep(
+    prod_destiny = whep_typo_flows_fixture(),
+    prod_n = whep_typo_prod_fixture(),
+    years = 2020
+  ) |>
+    dplyr::filter(province_name == "Import")
+
+  expect_gt(out$crop_prod, out$animal_ingestion)
+  expect_equal(out$Category, "Imported feed-based system")
+})
+
+test_that("create_typologies_whep drops Sea, Fish and Agro-industry", {
+  flows <- whep_typo_flows_fixture() |>
+    dplyr::bind_rows(
+      tibble::tribble(
+        ~province_name, ~item,   ~box,             ~origin,    ~destiny,
+        "Sea",          "Hake",  "Fish",           "Fish",     "population_food",
+        "Crop",         "Hake",  "Fish",           "Fish",     "population_food",
+        "Crop",         "Sugar", "Agro-industry",  "Cropland", "population_food"
+      ) |>
+        dplyr::mutate(year = 2020, mg_n = 1000)
+    )
+
+  out <- whep::create_typologies_whep(
+    prod_destiny = flows,
+    prod_n = whep_typo_prod_fixture(),
+    years = 2020
+  )
+
+  expect_false("Sea" %in% out$province_name)
+  # The fish and agro-industry boxes would have multiplied Crop's food
+  # consumption by 200 and turned it into an urban system.
+  expect_equal(
+    out |>
+      dplyr::filter(province_name == "Crop") |>
+      dplyr::pull(food_consumption),
+    10
+  )
+})
+
+test_that("create_typologies_whep honours the years argument", {
+  flows <- whep_typo_flows_fixture() |>
+    dplyr::bind_rows(
+      whep_typo_flows_fixture() |> dplyr::mutate(year = 1990)
+    )
+
+  out <- whep::create_typologies_whep(
+    prod_destiny = flows,
+    prod_n = whep_typo_prod_fixture(),
+    years = 2020
+  )
+
+  expect_equal(unique(out$year), 2020)
+})
+
+# .plot_whep_typologies -------------------------------------------------------
+
+test_that(".plot_whep_typologies fills gaps and orders provinces", {
+  skip_if_not_installed("ggplot2")
+
+  typologies <- tibble::tribble(
+    ~year, ~province_name, ~human_share, ~woody_share, ~Category,
+    2020,  "Alava",        NA,           NA,           "Urban System",
+    2020,  "Sea",          0.5,          0.5,          "Urban System",
+    2000,  "Zamora",       0.2,          0.3,          "Woody-based system"
+  )
+
+  plot <- whep:::.plot_whep_typologies(typologies)
+
+  # "Sea" is not a province and is dropped before plotting.
+  expect_false("Sea" %in% as.character(plot$data$province_name))
+  expect_equal(plot$data$human_share, c(0, 0.2))
+  expect_equal(plot$data$woody_share, c(0, 0.3))
+  # Provinces are reversed so the y axis reads alphabetically top-to-bottom.
+  expect_equal(levels(plot$data$province_name), c("Zamora", "Alava"))
+})


### PR DESCRIPTION
## What was wrong

`pkgcheck` fails the package on its coverage gate, and 12 of the 128 files in
`R/` sat at exactly 0%.

## Evidence

Measured on `origin/main` (`f99bc575`) with `covr::package_coverage()` — tests
only, which is that function's default (`if (missing(type)) type <- "tests"`)
and so is what `pkgcheck` reads:

```
baseline: 29,964 / 40,327 relevant lines = 74.30%
```

Below the 75% threshold, so the issue's premise holds — the number has drifted
up from the 73.76% in the issue body but is still short. 12 files at 0%, with
1,737 of those lines in `R/intensification_specialization_plot.R` alone.

## What changed

The gap is concentrated in the typologies cluster, and almost all of that
cluster turns out to be reachable **offline**: the builders take their inputs as
arguments (`create_alfredos_typologies(soil_inputs =, prod_destiny =)`,
`create_typologies_whep(prod_destiny =, prod_n =)`) or are stateless helpers
that do (`Typologies_Julia.R`, `Typologies_Josette.R`, `typologies_kgN_ha.R`).
So they are driven from `tribble()` fixtures — no pin, no shapefile, no network,
no `WHEP_*` path. The entry points that do read something
(`decomposition_analysis.R`, and the two plot builders in `typologies_kgN_ha.R`)
have their readers stubbed with `local_mocked_bindings()`; the plots they
`print()` go to a null device via `withr::local_pdf(nullfile())`. `sf` and
`ggplot2` uses are guarded with `skip_if_not_installed()`.

Seven new test files, two extended:

| file | before | after |
| --- | --- | --- |
| `R/Typologies_Julia.R` | 0% | 77.7% |
| `R/typologies_kgN_ha.R` | 0% | 100% |
| `R/whep_typologies_spain.R` | 0% | 99.3% |
| `R/alfredo_typologies.R` | 0% | 98.4% |
| `R/decomposition_analysis.R` | 0% | 100% |
| `R/natural_earth.R` | 0% | 87% |
| `R/build_cache.R` | 0% | 100% |
| `R/Typologies_Josette.R` | 12.8% | 43% |
| `R/production.R` | 42.3% | 96.2% |

They assert behaviour, not absence of error — the branch each decision tree
takes and why it fails the earlier tests, the identities the code encodes
(`Food + Feed + Other_uses + Export - Import`, LU per ha, kgN per ha, shares
summing to 100), and the failure branches: an area label the crosswalk does not
hold, `0 / 0` reported as `NA` rather than `NaN`, a livestock category with no
LU coefficient left `NA` rather than dropped, a province with no typology
keeping its hectares under `NA`, `.cache_get()` not forcing its promise on a
hit. Several encode findings worth having written down, e.g. that
`prepare_lmdi_production_area()`'s `surplus` column is the sum of *all* national
flows rather than inputs minus outputs, and that
`.calculate_feed_domest_supply()` counts the `Agro-industry` box that
`.aggregate_total_feed_mgn()` excludes.

### One real defect fell out, and is fixed here

Reaching the download-failure branch of `.download_natural_earth()` for the
first time showed it could not run. The abort interpolated the layer URL as
`{.url {.natural_earth_url(layer)}}`, and cli >= 3.4.0 reads a `{}` expression
starting with a dot as a *style name*, so the branch raised

```
Error: ! Invalid cli literal: `{.natura...}` starts with a dot.
```

and the recovery instructions it exists to print never reached the user.
`.natural_earth_url(layer)` is now resolved into a local first.
`create_typologies_grafs_spain()` and `create_typologies_of_josette()` are the
callers that reach it. Mechanical; no published value changes. `NEWS.md` entry
added, and the test asserts the instructions are in the message, not just its
first line.

## Verified

* **Coverage, measured not estimated** — `covr::package_coverage()` on this
  branch: **31,061 / 40,328 = 77.02%**, up from 74.30%. Above the 75% gate with
  two points of margin.
* **Whole suite** — `devtools::test()`: **6,149 passing, 0 failures, 0 errors,
  8 skips** (all pre-existing).
* **lintr** on every changed file with the project's four disabled linters:
  clean (one `commented_code_linter` hit found and fixed).
* **`air format`** run with the binary on all changed files; no unrelated file
  touched.
* **`R CMD check`** on a clean `git archive` export
  (`--no-tests --ignore-vignettes --no-manual`): **0 errors, 0 warnings,
  1 NOTE**. The NOTE is `no visible binding for global variable 'key_row' /
  'canonical_area'` in `.canonicalise_gdp_pop_area()`, which lives in
  `R/build_cbs.R` — a file this PR does not touch (the only change under `R/` is
  the nine lines in `natural_earth.R`), so it is pre-existing on `main` and
  needs two entries appended to `utils::globalVariables()` in its own commit.
* **pkgdown** — no new documented topic, and the `man/*.Rd` vs `_pkgdown.yml`
  comparison is still empty.
* **Offline** — no test added here reads the network, a pin, a `WHEP_*` path or
  a raster. Readers are stubbed, or inputs injected.

## Left undone

Five files are still at 0%, 2,923 relevant lines between them:
`intensification_specialization_plot.R` (1,737), `typologies_spain_plot.R`
(405), `typologies_spain.R` (348), `land_use_typology_panel.R` (314),
`typologies_spain_stacked_bar.R` (119). They are not untestable — each is a
monolithic plot builder whose readers could be stubbed the same way — but that
is 18 large functions of chart assembly, well past what this issue needs, and
the gate is met without them. Worth a follow-up if the goal becomes "no file at
0%" rather than "above the gate".

The file-naming point in the issue (`Typologies_Julia.R`,
`Typologies_Josette.R`, `typologies_kgN_ha.R` all break the project's own
`snake_case` rule) is deliberately **not** addressed here: renaming them would
churn this diff and the matching `test_*.R` names for a cosmetic gain, and
`CLAUDE.md` already records those files as legacy exceptions. Better as its own
rename commit.

Closes #594

🤖 Generated with [Claude Code](https://claude.com/claude-code)
