### PR TITLE
docs(livestock): fix @format units and stale processing-coefs docs

### DIFF
--- a/R/build_cbs.R
+++ b/R/build_cbs.R
@@ -425,8 +425,10 @@ build_commodity_balances <- function(
 #' building pipeline. These can be used independently for footprint
 #' calculations.
 #'
-#' @param cbs A tibble of final CBS in wide format, as returned by
-#'   [build_commodity_balances()].
+#' @param cbs A tibble of final CBS in long format (one row per
+#'   `element`), as returned by [build_commodity_balances()]. The legacy
+#'   wide format, one column per element as returned by
+#'   [get_wide_cbs()], is still accepted.
 #' @param start_year Integer. First year to include. Default `1850`.
 #' @param end_year Integer. Last year to include. Default `2023`.
 #' @param example Logical. If `TRUE`, return a small hardcoded dataset
@@ -454,7 +456,8 @@ build_processing_coefs <- function(
   cb_proc <- .prepare_cb_processing_for_cbs(whep::cb_processing)
   years <- start_year:end_year
 
-  # Convert wide CBS (from build_commodity_balances()) back to long with names
+  # build_commodity_balances() is already long: this only adds item names
+  # (and still converts a legacy wide CBS if one is passed in).
   cbs <- .wide_cbs_to_long(cbs) |>
     .filter_years(years)
 

--- a/R/livestock_coefs.R
+++ b/R/livestock_coefs.R
@@ -419,13 +419,17 @@
 #' IPCC 2019 enteric EF for cattle.
 #'
 #' @description
-#' Table 10.10: Tier 1 enteric fermentation emission factors
-#' for cattle by region (kg CH4/head/yr).
+#' Tier 1 enteric fermentation emission factors for cattle by region
+#' (kg CH4/head/yr). Regional cattle factors are Table 10.11 in both
+#' the 2006 Guidelines and the 2019 Refinement; Table 10.10 holds the
+#' non-cattle species (see [ipcc_2019_enteric_ef_other]).
 #'
-#' @format A tibble with `region`, `category`,
-#'   `ef_kg_head_yr`, `source`.
+#' @format A tibble with `region`, `category`, `ef_kg_head_yr`.
 #'
-#' @source IPCC 2019 Refinement, Vol 4, Ch 10, Table 10.10.
+#' @source IPCC 2019 Refinement, Vol 4, Ch 10, Table 10.11. The stored
+#'   values are in fact the 2006 Guidelines defaults (128 and 53
+#'   kg CH4/head/yr for North American dairy and other cattle, where
+#'   the 2019 Refinement gives 138 and 64); tracked in whep#601.
 #'
 #' @examples
 #' ipcc_2019_enteric_ef_cattle
@@ -434,13 +438,16 @@
 #' IPCC 2019 enteric EF for non-cattle.
 #'
 #' @description
-#' Table 10.11: Tier 1 enteric fermentation emission factors
-#' for non-cattle species (kg CH4/head/yr).
+#' Tier 1 enteric fermentation emission factors for non-cattle species
+#' (kg CH4/head/yr). Non-cattle species are Table 10.10 in both the
+#' 2006 Guidelines and the 2019 Refinement; regional cattle factors are
+#' Table 10.11 (see [ipcc_2019_enteric_ef_cattle]).
 #'
-#' @format A tibble with `category`, `ef_kg_head_yr`,
-#'   `source`.
+#' @format A tibble with `category`, `ef_kg_head_yr`.
 #'
-#' @source IPCC 2019 Refinement, Vol 4, Ch 10, Table 10.11.
+#' @source IPCC 2019 Refinement, Vol 4, Ch 10, Table 10.10. The stored
+#'   values are in fact the 2006 Guidelines defaults, from its
+#'   developed-countries column; tracked in whep#601.
 #'
 #' @examples
 #' ipcc_2019_enteric_ef_other
@@ -478,11 +485,13 @@
 #' IPCC 2019 MCF for manure management.
 #'
 #' @description
-#' Table 10.17: Methane Conversion Factors by manure management
-#' system and annual average temperature.
+#' Table 10.17: methane conversion factors (percent) by manure
+#' management system and climate zone. The IPCC table resolves ten
+#' climate zones grouped under cool, temperate and warm; this table
+#' keeps the three groups, and uses `"All"` for the systems that take a
+#' single factor.
 #'
-#' @format A tibble with `system`, `annual_temp_c`,
-#'   `mcf_percent`.
+#' @format A tibble with `system`, `climate_zone`, `mcf_percent`.
 #'
 #' @source IPCC 2019 Refinement, Vol 4, Ch 10, Table 10.17.
 #'
@@ -493,13 +502,18 @@
 #' IPCC 2019 nitrogen excretion rates.
 #'
 #' @description
-#' Table 10.19: Daily N excretion rates by species and region
-#' (kg N/1000 kg animal mass/day).
+#' Default nitrogen excretion by animal category and region, stored as
+#' annual excretion per head (kg N/head/yr). That is the form the Tier 1
+#' manure N2O path consumes, and the same quantity the Tier 2 path
+#' derives from the energy balance.
 #'
-#' @format A tibble with `region`, `category`,
-#'   `nex_kg_per_1000kg_day`.
+#' @format A tibble with `region`, `category`, `nex_kg_n_head_yr`.
 #'
-#' @source IPCC 2019 Refinement, Vol 4, Ch 10, Table 10.19.
+#' @source IPCC 2019 Refinement, Vol 4, Ch 10, Table 10.19. That table
+#'   publishes the rate per 1000 kg animal mass per day (0.59 kg N for
+#'   North American dairy cattle); the annual per-head values stored
+#'   here (105 kg N for the same cell) do not follow from it by any
+#'   recorded conversion; tracked in whep#601.
 #'
 #' @examples
 #' ipcc_2019_n_excretion
@@ -508,13 +522,15 @@
 #' IPCC 2019 direct N2O emission factors.
 #'
 #' @description
-#' Table 10.21: EF3 values (kg N2O-N/kg N) by manure
+#' Table 10.21: EF3 values (kg N2O-N per kg N excreted) by manure
 #' management system.
 #'
-#' @format A tibble with `mms_type`, `ef3_kg_n2on_kg_n`,
-#'   `source`.
+#' @format A tibble with `system`, `ef_kg_n2o_n_per_kg_n`.
 #'
-#' @source IPCC 2019 Refinement, Vol 4, Ch 10, Table 10.21.
+#' @source IPCC 2019 Refinement, Vol 4, Ch 10, Table 10.21. Several rows
+#'   match neither the 2019 Refinement nor the 2006 Guidelines (daily
+#'   spread 0.010 against 0 in both, dry lot 0.005 against 0.02);
+#'   tracked in whep#601.
 #'
 #' @examples
 #' ipcc_2019_n2o_ef_direct

--- a/R/utils.R
+++ b/R/utils.R
@@ -1800,5 +1800,3 @@ utils::globalVariables(
     "region_weight"
   )
 )
-
-# -- Helpers for spatialize scripts -------------------------------------------

--- a/man/build_processing_coefs.Rd
+++ b/man/build_processing_coefs.Rd
@@ -12,8 +12,10 @@ build_processing_coefs(
 )
 }
 \arguments{
-\item{cbs}{A tibble of final CBS in wide format, as returned by
-\code{\link[=build_commodity_balances]{build_commodity_balances()}}.}
+\item{cbs}{A tibble of final CBS in long format (one row per
+\code{element}), as returned by \code{\link[=build_commodity_balances]{build_commodity_balances()}}. The legacy
+wide format, one column per element as returned by
+\code{\link[=get_wide_cbs]{get_wide_cbs()}}, is still accepted.}
 
 \item{start_year}{Integer. First year to include. Default \code{1850}.}
 

--- a/man/ipcc_2019_enteric_ef_cattle.Rd
+++ b/man/ipcc_2019_enteric_ef_cattle.Rd
@@ -5,18 +5,22 @@
 \alias{ipcc_2019_enteric_ef_cattle}
 \title{IPCC 2019 enteric EF for cattle.}
 \format{
-A tibble with \code{region}, \code{category},
-\code{ef_kg_head_yr}, \code{source}.
+A tibble with \code{region}, \code{category}, \code{ef_kg_head_yr}.
 }
 \source{
-IPCC 2019 Refinement, Vol 4, Ch 10, Table 10.10.
+IPCC 2019 Refinement, Vol 4, Ch 10, Table 10.11. The stored
+values are in fact the 2006 Guidelines defaults (128 and 53
+kg CH4/head/yr for North American dairy and other cattle, where
+the 2019 Refinement gives 138 and 64); tracked in whep#601.
 }
 \usage{
 ipcc_2019_enteric_ef_cattle
 }
 \description{
-Table 10.10: Tier 1 enteric fermentation emission factors
-for cattle by region (kg CH4/head/yr).
+Tier 1 enteric fermentation emission factors for cattle by region
+(kg CH4/head/yr). Regional cattle factors are Table 10.11 in both
+the 2006 Guidelines and the 2019 Refinement; Table 10.10 holds the
+non-cattle species (see \link{ipcc_2019_enteric_ef_other}).
 }
 \examples{
 ipcc_2019_enteric_ef_cattle

--- a/man/ipcc_2019_enteric_ef_other.Rd
+++ b/man/ipcc_2019_enteric_ef_other.Rd
@@ -5,18 +5,21 @@
 \alias{ipcc_2019_enteric_ef_other}
 \title{IPCC 2019 enteric EF for non-cattle.}
 \format{
-A tibble with \code{category}, \code{ef_kg_head_yr},
-\code{source}.
+A tibble with \code{category}, \code{ef_kg_head_yr}.
 }
 \source{
-IPCC 2019 Refinement, Vol 4, Ch 10, Table 10.11.
+IPCC 2019 Refinement, Vol 4, Ch 10, Table 10.10. The stored
+values are in fact the 2006 Guidelines defaults, from its
+developed-countries column; tracked in whep#601.
 }
 \usage{
 ipcc_2019_enteric_ef_other
 }
 \description{
-Table 10.11: Tier 1 enteric fermentation emission factors
-for non-cattle species (kg CH4/head/yr).
+Tier 1 enteric fermentation emission factors for non-cattle species
+(kg CH4/head/yr). Non-cattle species are Table 10.10 in both the
+2006 Guidelines and the 2019 Refinement; regional cattle factors are
+Table 10.11 (see \link{ipcc_2019_enteric_ef_cattle}).
 }
 \examples{
 ipcc_2019_enteric_ef_other

--- a/man/ipcc_2019_mcf_manure.Rd
+++ b/man/ipcc_2019_mcf_manure.Rd
@@ -5,8 +5,7 @@
 \alias{ipcc_2019_mcf_manure}
 \title{IPCC 2019 MCF for manure management.}
 \format{
-A tibble with \code{system}, \code{annual_temp_c},
-\code{mcf_percent}.
+A tibble with \code{system}, \code{climate_zone}, \code{mcf_percent}.
 }
 \source{
 IPCC 2019 Refinement, Vol 4, Ch 10, Table 10.17.
@@ -15,8 +14,11 @@ IPCC 2019 Refinement, Vol 4, Ch 10, Table 10.17.
 ipcc_2019_mcf_manure
 }
 \description{
-Table 10.17: Methane Conversion Factors by manure management
-system and annual average temperature.
+Table 10.17: methane conversion factors (percent) by manure
+management system and climate zone. The IPCC table resolves ten
+climate zones grouped under cool, temperate and warm; this table
+keeps the three groups, and uses \code{"All"} for the systems that take a
+single factor.
 }
 \examples{
 ipcc_2019_mcf_manure

--- a/man/ipcc_2019_n2o_ef_direct.Rd
+++ b/man/ipcc_2019_n2o_ef_direct.Rd
@@ -5,17 +5,19 @@
 \alias{ipcc_2019_n2o_ef_direct}
 \title{IPCC 2019 direct N2O emission factors.}
 \format{
-A tibble with \code{mms_type}, \code{ef3_kg_n2on_kg_n},
-\code{source}.
+A tibble with \code{system}, \code{ef_kg_n2o_n_per_kg_n}.
 }
 \source{
-IPCC 2019 Refinement, Vol 4, Ch 10, Table 10.21.
+IPCC 2019 Refinement, Vol 4, Ch 10, Table 10.21. Several rows
+match neither the 2019 Refinement nor the 2006 Guidelines (daily
+spread 0.010 against 0 in both, dry lot 0.005 against 0.02);
+tracked in whep#601.
 }
 \usage{
 ipcc_2019_n2o_ef_direct
 }
 \description{
-Table 10.21: EF3 values (kg N2O-N/kg N) by manure
+Table 10.21: EF3 values (kg N2O-N per kg N excreted) by manure
 management system.
 }
 \examples{

--- a/man/ipcc_2019_n_excretion.Rd
+++ b/man/ipcc_2019_n_excretion.Rd
@@ -5,18 +5,23 @@
 \alias{ipcc_2019_n_excretion}
 \title{IPCC 2019 nitrogen excretion rates.}
 \format{
-A tibble with \code{region}, \code{category},
-\code{nex_kg_per_1000kg_day}.
+A tibble with \code{region}, \code{category}, \code{nex_kg_n_head_yr}.
 }
 \source{
-IPCC 2019 Refinement, Vol 4, Ch 10, Table 10.19.
+IPCC 2019 Refinement, Vol 4, Ch 10, Table 10.19. That table
+publishes the rate per 1000 kg animal mass per day (0.59 kg N for
+North American dairy cattle); the annual per-head values stored
+here (105 kg N for the same cell) do not follow from it by any
+recorded conversion; tracked in whep#601.
 }
 \usage{
 ipcc_2019_n_excretion
 }
 \description{
-Table 10.19: Daily N excretion rates by species and region
-(kg N/1000 kg animal mass/day).
+Default nitrogen excretion by animal category and region, stored as
+annual excretion per head (kg N/head/yr). That is the form the Tier 1
+manure N2O path consumes, and the same quantity the Tier 2 path
+derives from the energy balance.
 }
 \examples{
 ipcc_2019_n_excretion

--- a/tests/testthat/test_datasets.R
+++ b/tests/testthat/test_datasets.R
@@ -1077,3 +1077,90 @@ testthat::test_that("coello_synthetic_n has the expected schema + range", {
   testthat::expect_true(all(x$kg_n_ha <= 1000))
   testthat::expect_gt(nrow(x), 0L)
 })
+
+# -- Documented @format columns match the built data ---------------------------
+
+# Nothing checked a dataset's @format against the dataset itself, which is how
+# #173 happened: five documented datasets named columns that do not exist
+# (`nex_kg_per_1000kg_day`, `annual_temp_c`, `mms_type`, ...), and only one had
+# been spotted. Report the column names the \format section of one Rd topic
+# claims but its dataset does not have.
+format_column_mismatches <- function(rd_path, ignore) {
+  lines <- readLines(rd_path, warn = FALSE)
+  topic <- stringr::str_match(lines, "^\\\\name\\{(.+)\\}$")[, 2]
+  topic <- topic[!is.na(topic)][1]
+  obj <- tryCatch(
+    getExportedValue("whep", topic),
+    error = function(e) NULL
+  )
+  claimed <- rd_format_claims(lines)
+  if (!is.data.frame(obj) || length(claimed) == 0L) {
+    return(character(0))
+  }
+  missing <- setdiff(claimed, c(names(obj), ignore))
+  if (length(missing) == 0L) {
+    return(character(0))
+  }
+  paste0(
+    topic,
+    " @format names ",
+    paste(missing, collapse = ", "),
+    "; columns are ",
+    paste(names(obj), collapse = ", ")
+  )
+}
+
+# Column names claimed by the prose part of a \format section, i.e. the
+# "A tibble with \code{a}, \code{b}." form. Per-column \itemize / \describe
+# lists are left out: their bullets mix column names with the column's own
+# values and cross-references, so reading them as column names would flag
+# prose. Only snake_case tokens can be column names here.
+rd_format_claims <- function(lines) {
+  block <- rd_section_lines(lines, "format")
+  listed <- stringr::str_which(block, "\\\\(itemize|describe|tabular)\\{")
+  if (length(listed) > 0L) {
+    block <- block[seq_len(listed[1] - 1L)]
+  }
+  tokens <- stringr::str_match_all(block, "\\\\code\\{([^{}]+)\\}")
+  tokens <- unique(unlist(lapply(tokens, function(m) m[, 2])))
+  tokens[stringr::str_detect(tokens, "^[a-z][a-z0-9_]*$")]
+}
+
+# Lines of one Rd section, delimited by brace depth so nested environments
+# stay whole.
+rd_section_lines <- function(lines, tag) {
+  start <- which(stringr::str_detect(lines, paste0("^\\\\", tag, "\\{")))[1]
+  if (is.na(start)) {
+    return(character(0))
+  }
+  depth <- cumsum(
+    stringr::str_count(lines, stringr::fixed("{")) -
+      stringr::str_count(lines, stringr::fixed("}"))
+  )
+  end <- which(depth == 0L)
+  end <- end[end >= start][1]
+  if (is.na(end)) {
+    return(character(0))
+  }
+  lines[start:end]
+}
+
+testthat::test_that("documented @format columns exist in the dataset", {
+  man_dir <- testthat::test_path("..", "..", "man")
+  testthat::skip_if_not(
+    dir.exists(man_dir),
+    "man/ is only there when testing from the package source"
+  )
+  # A token naming another documented object is a cross-reference, not a
+  # column, and \code{tibble} is prose.
+  ignore <- c(
+    getNamespaceExports("whep"),
+    utils::data(package = "whep")$results[, "Item"],
+    "tibble"
+  )
+  mismatches <- list.files(man_dir, pattern = "\\.Rd$", full.names = TRUE) |>
+    lapply(format_column_mismatches, ignore = ignore) |>
+    unlist() |>
+    as.character()
+  testthat::expect_equal(mismatches, character(0))
+})


### PR DESCRIPTION
Documentation-only. **No dataset value and no code path changed** — see
"Where the code is wrong, not the docs" below, which is why.

## What was wrong

### 1. `ipcc_2019_n_excretion` — the unit trap the issue names

The `@format` claimed a column `nex_kg_per_1000kg_day` and the
`@description` claimed "kg N/1000 kg animal mass/day". The built column is
`nex_kg_n_head_yr` (`data-raw/livestock_coefficients.R:1272`) and the code
consumes it as kg N/head/yr:

```r
# R/livestock_manure.R — Tier 1 substitutes the table for the Tier 2 quantity
n_excretion = dplyr::coalesce(nex_kg_n_head_yr, nex_global)   # :81
manure_n2o_direct = n_animals * n_excretion * pasture_ef * n2o_to_n  # :516
# and the Tier 2 path derives the same variable as kg N/head/yr:
n_excretion = n_intake * (1 - n_retention_frac) * days_in_year # :485
```

Both tiers feed the same `n_excretion` to the same helpers, so per-head/yr is
the quantity the code needs. Editing the code to match the doc would have
been a ×365/÷1000 error, so the doc is what changed.

### 2. Four more `@format` mismatches the issue did not list

Found by the new invariant, not by reading:

| topic | `@format` claimed | actual columns |
|---|---|---|
| `ipcc_2019_enteric_ef_cattle` | ..., `source` | `region`, `category`, `ef_kg_head_yr` |
| `ipcc_2019_enteric_ef_other` | ..., `source` | `category`, `ef_kg_head_yr` |
| `ipcc_2019_mcf_manure` | `annual_temp_c` | `climate_zone` (`"Cool"`/`"Temperate"`/`"Warm"`/`"All"`) |
| `ipcc_2019_n2o_ef_direct` | `mms_type`, `ef3_kg_n2on_kg_n`, `source` | `system`, `ef_kg_n2o_n_per_kg_n` |

The two enteric datasets also cited each other's table. Verified in the
published chapters: Table 10.11 is the regional **cattle** table and Table
10.10 the **non-cattle** species, in both the 2006 Guidelines and the 2019
Refinement. `ipcc_2019_mcf_manure`'s description said "annual average
temperature"; Table 10.17 is organised by **climate zone** (ten zones grouped
under cool / temperate / warm), which is what the data holds.

### 3. `build_processing_coefs()` — stale since the long-format migration

`@param cbs` said "wide format, as returned by
[build_commodity_balances()]", but that function's own `@returns` says "a
tibble in long format", `get_wide_cbs()` is the wide accessor (it pivots the
long build via `.pivot_cbs_wide()`), and `.wide_cbs_to_long()` takes a long
CBS through unchanged, only adding item names. The internal comment
("Convert wide CBS ... back to long") was stale in the same way.

### 4. `R/utils.R` — confirmed complete, not truncated

The issue asked to confirm. `R/utils.R` legitimately ends with the
`utils::globalVariables()` call; the trailing
`# -- Helpers for spatialize scripts ---` heading is a leftover from
`8e21625f`, which removed the one helper under it (`.get_l_files_dir()`,
added with the heading in `580f6d76`) after its caller went away. Heading
removed. Nothing else belongs there: the shared helpers the issue expected
live in their own files (e.g. `.filter_years()` in `R/read_raw_inputs.R`),
and the current CLAUDE.md only claims the NSE globals list for this file, so
no instruction text needed changing.

## Where the code is wrong, not the docs

Verifying the units against the primary sources turned up value problems that
this PR deliberately does **not** touch — filed as **#601**
(`needs-expert`), with the doc now pointing there instead of asserting a
provenance that does not hold:

- `ipcc_2019_enteric_ef_cattle` holds the **2006** Guidelines' Table 10.11
  values (128 / 53 for North American dairy / other cattle); the 2019
  Refinement gives 138 / 64. All 14 cells shared with `ipcc_2006_enteric_ef`
  are identical.
- `ipcc_2019_enteric_ef_other` is the 2006 Table 10.10 developed-countries
  column exactly.
- `ipcc_2019_n2o_ef_direct` matches neither edition on several rows (daily
  spread 0.010 vs 0 in both; dry lot 0.005 vs 0.02 in both).
- `ipcc_2019_n_excretion`'s per-head annual values do not follow from Table
  10.19's published rate by any recorded conversion (0.59 kg N per 1000 kg
  animal mass per day × 604 kg TAM × 365 / 1000 = 130, not 105).

Sources, text-extracted from the published PDFs:
[2019 Refinement Vol 4 Ch 10](https://www.ipcc-nggip.iges.or.jp/public/2019rf/pdf/4_Volume4/19R_V4_Ch10_Livestock.pdf),
[2006 Guidelines Vol 4 Ch 10](https://www.ipcc-nggip.iges.or.jp/public/2006gl/pdf/4_Volume4/V4_10_Ch10_Livestock.pdf).

## Regression guard

`tests/testthat/test_datasets.R` now asserts that every snake_case column an
`@format` names in prose exists in its dataset, over all `man/*.Rd`. It reads
`man/`, so it skips under `R CMD check` (tests run from a copied directory
there) and runs under `devtools::test()` and covr. Per-column
`\itemize`/`\describe` bullets are deliberately out of scope: their bullets
mix column names with the column's own values and cross-references, so
reading them as column names flags prose.

Before the doc fix it fails with exactly the five topics above and no false
positives:

```
- "ipcc_2019_enteric_ef_cattle @format names source; columns are region, category, ef_kg_head_yr"
- "ipcc_2019_enteric_ef_other @format names source; columns are category, ef_kg_head_yr"
- "ipcc_2019_mcf_manure @format names annual_temp_c; columns are system, climate_zone, mcf_percent"
- "ipcc_2019_n2o_ef_direct @format names mms_type, ef3_kg_n2on_kg_n, source; ..."
- "ipcc_2019_n_excretion @format names nex_kg_per_1000kg_day; columns are region, category, nex_kg_n_head_yr"
[ FAIL 1 | WARN 0 | SKIP 0 | PASS 555 ]
```

## Verified

- `air format` on the four changed sources: clean (`--check` silent). No added
  R line exceeds 80 columns.
- `devtools::document()` (roxygen 7.3.2): rewrote only the six expected
  `man/*.Rd`; `DESCRIPTION`/`NAMESPACE` untouched.
- `lintr` with the project's four disabled linters, on all four changed files:
  "No lints found."
- `devtools::test(filter = "^datasets$")`: `[ FAIL 0 | WARN 0 | SKIP 0 | PASS
  556 ]`. Neighbouring files
  (`build_cbs|manure|livestock|utils|toy_examples|commodity_balance`):
  `[ FAIL 0 | WARN 1 | SKIP 0 | PASS 571 ]` — the one warning
  (`test_livestock_ghg_extension.R:181`) reproduces with my changes stashed,
  so it is pre-existing. Full suite result in the comment below.
- `R CMD check` on a clean `git archive` export (`--no-tests
  --ignore-vignettes --no-manual`, `_R_CHECK_FORCE_SUGGESTS_=false` because
  `archive`/`RSQLite` are missing locally): **0 errors, 0 warnings, 1 note**,
  byte-identical to the same check on `origin/main`. That note
  (`.canonicalise_gdp_pop_area`: no visible binding for `key_row`,
  `canonical_area`) is pre-existing — introduced by `8ff88042` in
  `R/build_cbs.R`, still unfixed on `main`, and out of scope here; it needs
  two entries in `utils::globalVariables()`.
- pkgdown: every `man/*.Rd` except `whep-package` still appears in
  `_pkgdown.yml` (0 missing). No topic was added or removed.

## Not done

- The #601 values. They are a science decision (revalue to the 2019
  Refinement, or rename to `ipcc_2006_*`, or keep both as selectable sets) and
  moving them moves published Tier 1 enteric CH4 and manure N2O.
- The pre-existing `key_row` / `canonical_area` check note above.
- No `NEWS.md` entry: no user-visible behaviour or value change.

Closes #173

🤖 Generated with [Claude Code](https://claude.com/claude-code)
