### PR TITLE
docs: give every exported function a runnable example

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,13 @@
 # whep (development version)
 
+* `create_typologies_of_josette()` and `create_typologies_grafs_spain()` gained
+  an `example = FALSE` argument, so both now have runnable examples like the
+  rest of the package's remote-data functions. Their documented `@return` was
+  also wrong and is corrected: `create_typologies_of_josette()` returns a named
+  list of three tibbles plus a `ggplot`, not a single tibble, and
+  `create_typologies_grafs_spain()` returns `Province_name` and `Typologie` for
+  `map_year` only, not a seven-column series over all years. No published value
+  changes — the only new code path is the `example = TRUE` early return.
 * **An aggregation bucket now sums, and comes out under one name.** The reader
   aggregation grouped rows by the member's polity **name** as well as by
   `polity_area_code`, so a bucket folding members that resolve to different

--- a/R/Typologies_Josette.R
+++ b/R/Typologies_Josette.R
@@ -15,14 +15,29 @@
 #'
 #' @param map_year The year for which the typology map is created.
 #'
-#' @return A tibble with the typology classification per year and province.
+#' @param example If `TRUE`, return a small example output without reading the
+#'   remote inputs or the Natural Earth layer. Default is `FALSE`. The example
+#'   output carries the three data elements only, not the `df_inputs_plots`
+#'   plot, so that it needs no plotting package.
+#'
+#' @return A named list with `typologies_df` (the typology classification per
+#'   year and province), `n_input_df` (the N soil inputs the classification
+#'   read), `imported_feed_share_df` (the imported-feed share per year and
+#'   province) and `df_inputs_plots` (a `ggplot` of N inputs by typology).
 #'
 #' @export
+#'
+#' @examples
+#' create_typologies_of_josette(example = TRUE)$typologies_df
 create_typologies_of_josette <- function(
   make_map = TRUE,
   shapefile_path = NULL,
-  map_year = 1980
+  map_year = 1980,
+  example = FALSE
 ) {
+  if (example) {
+    return(.example_typologies_josette())
+  }
   shapefile_path <- .provinces_shapefile(shapefile_path)
 
   # Load datasets

--- a/R/Typologies_Julia.R
+++ b/R/Typologies_Julia.R
@@ -15,34 +15,37 @@
 #'
 #' @param map_year The year for which the typology map is created.
 #'
+#' @param example If `TRUE`, return a small example output without reading the
+#'   remote inputs or the Natural Earth layer. Default is `FALSE`.
+#'
 #' @returns
-#' A tibble with the classification of Spanish provinces into typologies.
-#' It contains the following columns:
-#' - `year`: The year in which the classification is performed.
-#' - `province_name`: The name of the Spanish province.
-#' - `livestock_density`: Livestock units (LU) per hectare of agricultural area
-#'                        (UAA). Reflects the intensity of animal farming.
-#' - `productivity_kgN_ha`: Crop N productivity, in kilograms of N harvested
-#'                          per hectare of cropland.
-#' - `semi_nat_share`: Share of total feed coming from semi-natural
-#'                     agroecosystems. Expressed between 0 and 1.
-#' - `feed_imported_share`: Share of feed that is imported. Expressed between
-#'                          0 and 1.
-#' - `typology`: Assigned typology category for each province.
-#'               This is based on thresholds in livestock density, crop
-#'               productivity, and feed patterns. The typologies include:
-#'               - `Specialized cropping system`
-#'               - `Extensive cropping system`
-#'               - `Extensive mixed crop-livestock system`
-#'               - `Intensive mixed crop-livestock system`
-#'               - `Specialized livestock-farming system`
+#' A tibble with the classification of Spanish provinces into typologies for
+#' `map_year`. It contains the following columns:
+#' - `Province_name`: The name of the Spanish province.
+#' - `Typologie`: Assigned typology category for each province. This is based
+#'                on thresholds in livestock density (livestock units per
+#'                hectare of agricultural area), crop N productivity (kg N
+#'                harvested per hectare of cropland), and the semi-natural and
+#'                imported shares of feed. The typologies are:
+#'   - `Specialized cropping system`
+#'   - `Extensive cropping system`
+#'   - `Extensive mixed crop-livestock system`
+#'   - `Intensive mixed crop-livestock system`
+#'   - `Specialized livestock-farming system`
 #'
 #' @export
+#'
+#' @examples
+#' create_typologies_grafs_spain(example = TRUE)
 create_typologies_grafs_spain <- function(
   make_map = TRUE,
   shapefile_path = NULL,
-  map_year = 1980
+  map_year = 1980,
+  example = FALSE
 ) {
+  if (example) {
+    return(.ex_typologies_grafs_spain())
+  }
   shapefile_path <- .provinces_shapefile(shapefile_path)
 
   # Load datasets

--- a/R/alfredo_typologies.R
+++ b/R/alfredo_typologies.R
@@ -11,6 +11,43 @@
 #' fertilizer_N, feed_import_N, woody, herbaceous, woody_share, and Category.
 #'
 #' @export
+#'
+#' @examples
+#' # Minimal stand-ins for `create_n_prov_destiny()` and
+#' # `create_n_soil_inputs()`, carrying only the columns the classification
+#' # reads. One province of each of three categories: Lugo is dominated by
+#' # grassland N, Sevilla by synthetic N on herbaceous production, and Huelva
+#' # by synthetic N where the local production is woody (acorns).
+#' prod_destiny <- tibble::tribble(
+#'   ~year, ~province_name, ~box, ~item, ~origin, ~destiny, ~mg_n,
+#'   2000, "Lugo", "semi_natural_agroecosystems", "Grassland",
+#'   "semi_natural_agroecosystems", "livestock_rum", 900,
+#'   2000, "Sevilla", "semi_natural_agroecosystems", "Grassland",
+#'   "semi_natural_agroecosystems", "livestock_rum", 100,
+#'   2000, "Huelva", "semi_natural_agroecosystems", "Grassland",
+#'   "semi_natural_agroecosystems", "livestock_rum", 30,
+#'   2000, "Huelva", "semi_natural_agroecosystems", "Acorns",
+#'   "semi_natural_agroecosystems", "export", 200,
+#'   2000, "Lugo", "Cropland", "Maize and products",
+#'   "Outside", "livestock_mono", 20,
+#'   2000, "Sevilla", "Cropland", "Maize and products",
+#'   "Outside", "livestock_mono", 50,
+#'   2000, "Huelva", "Cropland", "Maize and products",
+#'   "Outside", "livestock_mono", 10
+#' )
+#'
+#' soil_inputs <- tibble::tribble(
+#'   ~year, ~province_name, ~synthetic,
+#'   2000, "Lugo", 10,
+#'   2000, "Sevilla", 400,
+#'   2000, "Huelva", 150
+#' )
+#'
+#' create_alfredos_typologies(
+#'   soil_inputs = soil_inputs,
+#'   prod_destiny = prod_destiny,
+#'   years = 2000
+#' )
 create_alfredos_typologies <- function(
   soil_inputs = NULL,
   prod_destiny = NULL,

--- a/R/footprint_paths.R
+++ b/R/footprint_paths.R
@@ -45,6 +45,31 @@
 #'   `target_fd`, `path_type`, and `value`.
 #'
 #' @export
+#'
+#' @examples
+#' # A two-sector economy: sector 1 (item 10) carries the whole extension and
+#' # supplies 50 of intermediate input to sector 2 (item 20). Its footprint
+#' # therefore splits into a direct final-demand path and a first-use path
+#' # through item 20.
+#' z_mat <- matrix(c(0, 50, 0, 0), nrow = 2, byrow = TRUE)
+#' x_vec <- c(100, 200)
+#' y_mat <- matrix(c(10, 100), nrow = 2)
+#' labels <- tibble::tibble(
+#'   area_code = c(1L, 1L),
+#'   item_cbs_code = c(10L, 20L)
+#' )
+#' fd_labels <- tibble::tibble(area_code = 2L, fd_col = "food")
+#'
+#' compute_footprint_paths(
+#'   z_mat = z_mat,
+#'   x_vec = x_vec,
+#'   y_mat = y_mat,
+#'   extensions = c(200, 0),
+#'   labels = labels,
+#'   fd_labels = fd_labels,
+#'   conserve_extensions = FALSE
+#' ) |>
+#'   dplyr::select(origin_item, use_item, target_area, path_type, value)
 compute_footprint_paths <- function(
   z_mat,
   x_vec,
@@ -477,6 +502,28 @@ compute_footprint_paths <- function(
 #'   `target_fd`, and `value`.
 #'
 #' @export
+#'
+#' @examples
+#' # Same two-sector economy as [compute_footprint_paths()], decomposed by the
+#' # product that reaches final demand instead of by the first intermediate
+#' # use. The path totals of the two functions agree with each other and with
+#' # [compute_footprint()] under a shared `max_column_sum`.
+#' z_mat <- matrix(c(0, 50, 0, 0), nrow = 2, byrow = TRUE)
+#' labels <- tibble::tibble(
+#'   area_code = c(1L, 1L),
+#'   item_cbs_code = c(10L, 20L)
+#' )
+#'
+#' compute_fp_product_paths(
+#'   z_mat = z_mat,
+#'   x_vec = c(100, 200),
+#'   y_mat = matrix(c(10, 100), nrow = 2),
+#'   extensions = c(200, 0),
+#'   labels = labels,
+#'   fd_labels = tibble::tibble(area_code = 2L, fd_col = "food"),
+#'   conserve_extensions = FALSE
+#' ) |>
+#'   dplyr::select(origin_item, product_area, product_item, value)
 compute_fp_product_paths <- function(
   z_mat,
   x_vec,
@@ -707,6 +754,30 @@ compute_fp_product_paths <- function(
 #'   split path value.
 #'
 #' @export
+#'
+#' @examples
+#' # One footprint row of 100, split over the two areas that supply item 20 to
+#' # the final demand of area 1 in the shares observed in `y_mat` (80 / 20).
+#' footprints <- tibble::tibble(
+#'   origin_area = 1L,
+#'   origin_item = 10L,
+#'   target_area = 1L,
+#'   target_area_name = "Target",
+#'   target_item = 20L,
+#'   target_fd = "food",
+#'   value = 100
+#' )
+#'
+#' add_footprint_product_stage(
+#'   footprints = footprints,
+#'   y_mat = Matrix::Matrix(c(80, 20), nrow = 2, sparse = TRUE),
+#'   labels = tibble::tibble(
+#'     area_code = c(1L, 2L),
+#'     item_cbs_code = c(20L, 20L)
+#'   ),
+#'   fd_labels = tibble::tibble(area_code = 1L, fd_col = "food")
+#' ) |>
+#'   dplyr::select(origin_item, product_area, product_share, value)
 add_footprint_product_stage <- function(
   footprints,
   y_mat,

--- a/R/polities.R
+++ b/R/polities.R
@@ -399,6 +399,17 @@
 #'   already-built table, whose published columns no longer carry
 #'   `mapping_status`.
 #' @export
+#'
+#' @examples
+#' # The same area code resolves to different polities in different years:
+#' # area 16 reports as East Pakistan before 1971 and as Bangladesh after it.
+#' tibble::tibble(area_code = c(16L, 16L), year = c(1965L, 2000L)) |>
+#'   add_polity_code() |>
+#'   dplyr::select(area_code, year, polity_code, polity_name, mapping_status)
+#'
+#' # Without a year column the current/default mapping is used.
+#' add_polity_code(tibble::tibble(area_code = 231L), year_column = NULL) |>
+#'   dplyr::select(area_code, polity_code, polity_name)
 add_polity_code <- function(
   table,
   code_column = "area_code",
@@ -882,6 +893,17 @@ polity_coverage_gaps <- function(
 #'
 #' @returns An sf data frame.
 #' @export
+#'
+#' @examples
+#' # sf is only suggested, and its methods are what make the geometry column
+#' # printable, so guard the example on it.
+#' if (requireNamespace("sf", quietly = TRUE)) {
+#'   codes <- add_polity_code(
+#'     tibble::tibble(area_code = c(203L, 68L), year = c(2000L, 2000L))
+#'   )$polity_code
+#'   geometries <- get_polity_geometries(codes)
+#'   print(geometries[, c("polity_code", "polity_name", "polygon_source")])
+#' }
 get_polity_geometries <- function(polity_codes = NULL) {
   out <- polities
   if (!is.null(polity_codes)) {

--- a/R/redistribute_feed.R
+++ b/R/redistribute_feed.R
@@ -36,6 +36,28 @@
 #'   attribute lists demand rows underfed below maintenance.
 #'
 #' @export
+#'
+#' @examples
+#' # Two variable-demand categories in one territory competing for a single
+#' # feed item. Availability (150) falls short of demand (200), so the
+#' # remaining-share principle underfeeds both by the same factor rather than
+#' # letting either exceed what is there.
+#' feed_demand <- tibble::tribble(
+#'   ~year, ~territory, ~sub_territory, ~livestock_category,
+#'   ~item_cbs_code, ~feed_group, ~feed_quality, ~demand_dm_t, ~fixed_demand,
+#'   2000L, "79", "79", "Cattle_milk",
+#'   NA_integer_, NA_character_, "high_quality", 120, FALSE,
+#'   2000L, "79", "79", "Pigs",
+#'   NA_integer_, NA_character_, "high_quality", 80, FALSE
+#' )
+#'
+#' feed_avail <- tibble::tribble(
+#'   ~year, ~territory, ~sub_territory, ~item_cbs_code, ~feed_group,
+#'   ~feed_quality, ~avail_dm_t, ~feed_scale,
+#'   2000L, "79", "79", 2514L, "cereals", "high_quality", 150, "national"
+#' )
+#'
+#' redistribute_feed(feed_demand, feed_avail)
 redistribute_feed <- function(feed_demand, feed_avail, options = list()) {
   options <- .redistribute_feed_options(options)
   .validate_feed_inputs(feed_demand, feed_avail)

--- a/R/toy_examples.R
+++ b/R/toy_examples.R
@@ -1145,3 +1145,81 @@
     2555L, "Soybeans"
   )
 }
+
+# Ten of the 50 provinces returned by create_typologies_grafs_spain() for its
+# default map_year of 1980, sampled from a real run.
+.ex_typologies_grafs_spain <- function() {
+  tibble::tribble(
+    ~Province_name, ~Typologie,
+    "Albacete", "Extensive cropping system",
+    "Alicante", "Extensive cropping system",
+    "Araba", "Extensive cropping system",
+    "Asturias", "Specialized livestock-farming system",
+    "Avila", "Extensive cropping system",
+    "Huelva", "Extensive cropping system",
+    "Jaen", "Extensive cropping system",
+    "Leon", "Extensive cropping system",
+    "Lleida", "Specialized livestock-farming system",
+    "Teruel", "Extensive cropping system"
+  )
+}
+
+# The three data elements create_typologies_of_josette() returns, sampled from
+# a real run at year 2020 over the first ten provinces alphabetically. The
+# fourth element of the real output is a ggplot, which is left out so the
+# example needs no plotting package.
+.example_typologies_josette <- function() {
+  list(
+    typologies_df = .ex_josette_typologies(),
+    n_input_df = .ex_josette_n_inputs(),
+    imported_feed_share_df = .ex_josette_feed_share()
+  )
+}
+
+.ex_josette_typologies <- function() {
+  tibble::tribble(
+    ~Year, ~Province_name, ~Typology,
+    2020, "A_Coruna", "Forage-based crop & livestock system",
+    2020, "Albacete", "Specialized stockless cropping system",
+    2020, "Alicante", "Urban system",
+    2020, "Almeria", "Forage-based crop & livestock system",
+    2020, "Araba", "Specialized stockless cropping system",
+    2020, "Asturias", "Grass-based crop & livestock system",
+    2020, "Avila", "Forage-based crop & livestock system",
+    2020, "Badajoz", "Forage-based crop & livestock system",
+    2020, "Barcelona", "Urban system",
+    2020, "Bizkaia", "Urban system"
+  )
+}
+
+.ex_josette_n_inputs <- function() {
+  tibble::tribble(
+    ~Year, ~Province_name, ~item, ~irrig_cat, ~Box, ~MgN_dep, ~MgN_fix, ~MgN_syn, ~MgN_manure, ~MgN_urban,
+    2020, "A_Coruna", "Fodder vegetables and roots", "Irrigated", "Cropland", 1.99, 1.06, 10.2, 0., 1.32,
+    2020, "Albacete", "Nuts and products", "Irrigated", "Cropland", 116., 85.1, 2190., 676., 11.4,
+    2020, "Albacete", "Maize and products", "Irrigated", "Cropland", 39.4, 16.6, 2070., 25.4, 3.87,
+    2020, "Albacete", "Peas", "Irrigated", "Cropland", 2.90, 33.5, 14.9, 0., 0.284,
+    2020, "Almeria", "Grapes and products (excl wine)", "Irrigated", "Cropland", 1.12, 1.00, 39.0, 0., 0.971,
+    2020, "Araba", "Beans", "Irrigated", "Cropland", 1.48, 7.46, 6.21, 0., 0.764,
+    2020, "Araba", "Soyabeans", "Rainfed", "Cropland", 0.0215, 0.146, 0.0798, 0., 0.0111,
+    2020, "Avila", "Rye and products", "Irrigated", "Cropland", 0.411, 0.242, 8.06, 0., 0.0729,
+    2020, "Badajoz", "Fodder legumes", "Rainfed", "Cropland", 65.9, 1660., 13.1, 212., 12.3,
+    2020, "Badajoz", "Firewood", "Rainfed", "semi_natural_agroecosystems", 6490., 12500., 0., 16400., 0.
+  )
+}
+
+.ex_josette_feed_share <- function() {
+  tibble::tribble(
+    ~Year, ~Province_name, ~LU_total, ~Feed_import_MgN, ~Domestic_feed_MgN, ~Total_feed_MgN, ~Imported_feed_share,
+    2020, "A_Coruna", 414814., 365672., 29936.3, 395608., 0.924,
+    2020, "Albacete", 178482., 157337., 8753.91, 166091., 0.947,
+    2020, "Alicante", 57203.3, 50426.5, 2561.46, 52987.9, 0.952,
+    2020, "Almeria", 224946., 198297., 11141.4, 209439., 0.947,
+    2020, "Araba", 87341.1, 76993.9, 2576.11, 79570.0, 0.968,
+    2020, "Asturias", 407178., 358940., 15068.6, 374009., 0.960,
+    2020, "Avila", 339709., 299464., 14377.8, 313842., 0.954,
+    2020, "Badajoz", 1005423., 886311., 37603.4, 923915., 0.959,
+    2020, "Barcelona", 776463., 684476., 39563.0, 724039., 0.945,
+    2020, "Bizkaia", 106968., 94295.4, 3505.52, 97800.9, 0.964
+  )
+}

--- a/R/whep_typologies_spain.R
+++ b/R/whep_typologies_spain.R
@@ -11,6 +11,41 @@
 #' @return A data frame with Year, Province_name, decision variables,
 #' and Category.
 #' @export
+#'
+#' @examples
+#' # Minimal stand-ins for the two real inputs, carrying only the columns the
+#' # decision variables read. Lugo feeds its livestock mostly on local grass;
+#' # Barcelona feeds them mostly on imported N.
+#' prod_destiny <- tibble::tribble(
+#'   ~year, ~province_name, ~box, ~item, ~origin, ~destiny, ~mg_n,
+#'   2020, "Lugo", "Cropland", "Wheat and products",
+#'   "Cropland", "population_food", 100,
+#'   2020, "Lugo", "semi_natural_agroecosystems", "Grassland",
+#'   "semi_natural_agroecosystems", "livestock_rum", 800,
+#'   2020, "Lugo", "Cropland", "Maize and products",
+#'   "Cropland", "livestock_rum", 200,
+#'   2020, "Lugo", "Cropland", "Soyabean cake",
+#'   "Outside", "livestock_mono", 50,
+#'   2020, "Barcelona", "Cropland", "Wheat and products",
+#'   "Cropland", "population_food", 100,
+#'   2020, "Barcelona", "Cropland", "Soyabean cake",
+#'   "Outside", "livestock_mono", 900,
+#'   2020, "Barcelona", "Cropland", "Maize and products",
+#'   "Cropland", "livestock_mono", 100
+#' )
+#'
+#' prod_n <- tibble::tribble(
+#'   ~year, ~province_name, ~box, ~production_n,
+#'   2020, "Lugo", "Cropland", 300,
+#'   2020, "Barcelona", "Cropland", 200
+#' )
+#'
+#' create_typologies_whep(
+#'   prod_destiny = prod_destiny,
+#'   prod_n = prod_n,
+#'   years = 2020
+#' ) |>
+#'   dplyr::select(year, province_name, human_share, import_share, Category)
 create_typologies_whep <- function(
   prod_destiny = create_n_prov_destiny(),
   prod_n = create_n_production() |> dplyr::rename(production_n = prod),

--- a/man/add_footprint_product_stage.Rd
+++ b/man/add_footprint_product_stage.Rd
@@ -49,3 +49,27 @@ origin-sector by product-sector Leontief cube. Instead, each existing
 footprint row is allocated over the product-area shares observed in final
 demand for the same \code{target_area}, \code{target_fd}, and \code{target_item}.
 }
+\examples{
+# One footprint row of 100, split over the two areas that supply item 20 to
+# the final demand of area 1 in the shares observed in `y_mat` (80 / 20).
+footprints <- tibble::tibble(
+  origin_area = 1L,
+  origin_item = 10L,
+  target_area = 1L,
+  target_area_name = "Target",
+  target_item = 20L,
+  target_fd = "food",
+  value = 100
+)
+
+add_footprint_product_stage(
+  footprints = footprints,
+  y_mat = Matrix::Matrix(c(80, 20), nrow = 2, sparse = TRUE),
+  labels = tibble::tibble(
+    area_code = c(1L, 2L),
+    item_cbs_code = c(20L, 20L)
+  ),
+  fd_labels = tibble::tibble(area_code = 1L, fd_col = "food")
+) |>
+  dplyr::select(origin_item, product_area, product_share, value)
+}

--- a/man/add_polity_code.Rd
+++ b/man/add_polity_code.Rd
@@ -44,6 +44,17 @@ to a polity that did not exist in that year, so treat it as a coverage gap:
 either the area needs the missing period added to the crosswalk, or the
 reporting area outlived (or predates) every polity mapped to it.
 }
+\examples{
+# The same area code resolves to different polities in different years:
+# area 16 reports as East Pakistan before 1971 and as Bangladesh after it.
+tibble::tibble(area_code = c(16L, 16L), year = c(1965L, 2000L)) |>
+  add_polity_code() |>
+  dplyr::select(area_code, year, polity_code, polity_name, mapping_status)
+
+# Without a year column the current/default mapping is used.
+add_polity_code(tibble::tibble(area_code = 231L), year_column = NULL) |>
+  dplyr::select(area_code, polity_code, polity_name)
+}
 \seealso{
 \code{\link[=polity_coverage_gaps]{polity_coverage_gaps()}}, which reports the stand-in rows of an
 already-built table, whose published columns no longer carry

--- a/man/compute_footprint_paths.Rd
+++ b/man/compute_footprint_paths.Rd
@@ -78,3 +78,28 @@ origin sector \eqn{i} and final-demand target, the origin requirement
 intermediate use \eqn{A_{ij} x_j}. Values are multiplied by the origin
 extension intensity \eqn{e_i / X_i}.
 }
+\examples{
+# A two-sector economy: sector 1 (item 10) carries the whole extension and
+# supplies 50 of intermediate input to sector 2 (item 20). Its footprint
+# therefore splits into a direct final-demand path and a first-use path
+# through item 20.
+z_mat <- matrix(c(0, 50, 0, 0), nrow = 2, byrow = TRUE)
+x_vec <- c(100, 200)
+y_mat <- matrix(c(10, 100), nrow = 2)
+labels <- tibble::tibble(
+  area_code = c(1L, 1L),
+  item_cbs_code = c(10L, 20L)
+)
+fd_labels <- tibble::tibble(area_code = 2L, fd_col = "food")
+
+compute_footprint_paths(
+  z_mat = z_mat,
+  x_vec = x_vec,
+  y_mat = y_mat,
+  extensions = c(200, 0),
+  labels = labels,
+  fd_labels = fd_labels,
+  conserve_extensions = FALSE
+) |>
+  dplyr::select(origin_item, use_item, target_area, path_type, value)
+}

--- a/man/compute_fp_product_paths.Rd
+++ b/man/compute_fp_product_paths.Rd
@@ -76,3 +76,25 @@ Unlike \code{\link[=compute_footprint_paths]{compute_footprint_paths()}}, this d
 intermediate input. It shows the downstream product row in \code{Y} whose final
 demand carries the origin footprint.
 }
+\examples{
+# Same two-sector economy as [compute_footprint_paths()], decomposed by the
+# product that reaches final demand instead of by the first intermediate
+# use. The path totals of the two functions agree with each other and with
+# [compute_footprint()] under a shared `max_column_sum`.
+z_mat <- matrix(c(0, 50, 0, 0), nrow = 2, byrow = TRUE)
+labels <- tibble::tibble(
+  area_code = c(1L, 1L),
+  item_cbs_code = c(10L, 20L)
+)
+
+compute_fp_product_paths(
+  z_mat = z_mat,
+  x_vec = c(100, 200),
+  y_mat = matrix(c(10, 100), nrow = 2),
+  extensions = c(200, 0),
+  labels = labels,
+  fd_labels = tibble::tibble(area_code = 2L, fd_col = "food"),
+  conserve_extensions = FALSE
+) |>
+  dplyr::select(origin_item, product_area, product_item, value)
+}

--- a/man/create_alfredos_typologies.Rd
+++ b/man/create_alfredos_typologies.Rd
@@ -25,3 +25,40 @@ fertilizer_N, feed_import_N, woody, herbaceous, woody_share, and Category.
 Calculates typologies for provinces based on grassland,
 fertilizer, imported feed, and woody/herbaceous shares.
 }
+\examples{
+# Minimal stand-ins for `create_n_prov_destiny()` and
+# `create_n_soil_inputs()`, carrying only the columns the classification
+# reads. One province of each of three categories: Lugo is dominated by
+# grassland N, Sevilla by synthetic N on herbaceous production, and Huelva
+# by synthetic N where the local production is woody (acorns).
+prod_destiny <- tibble::tribble(
+  ~year, ~province_name, ~box, ~item, ~origin, ~destiny, ~mg_n,
+  2000, "Lugo", "semi_natural_agroecosystems", "Grassland",
+  "semi_natural_agroecosystems", "livestock_rum", 900,
+  2000, "Sevilla", "semi_natural_agroecosystems", "Grassland",
+  "semi_natural_agroecosystems", "livestock_rum", 100,
+  2000, "Huelva", "semi_natural_agroecosystems", "Grassland",
+  "semi_natural_agroecosystems", "livestock_rum", 30,
+  2000, "Huelva", "semi_natural_agroecosystems", "Acorns",
+  "semi_natural_agroecosystems", "export", 200,
+  2000, "Lugo", "Cropland", "Maize and products",
+  "Outside", "livestock_mono", 20,
+  2000, "Sevilla", "Cropland", "Maize and products",
+  "Outside", "livestock_mono", 50,
+  2000, "Huelva", "Cropland", "Maize and products",
+  "Outside", "livestock_mono", 10
+)
+
+soil_inputs <- tibble::tribble(
+  ~year, ~province_name, ~synthetic,
+  2000, "Lugo", 10,
+  2000, "Sevilla", 400,
+  2000, "Huelva", 150
+)
+
+create_alfredos_typologies(
+  soil_inputs = soil_inputs,
+  prod_destiny = prod_destiny,
+  years = 2000
+)
+}

--- a/man/create_typologies_grafs_spain.Rd
+++ b/man/create_typologies_grafs_spain.Rd
@@ -7,7 +7,8 @@
 create_typologies_grafs_spain(
   make_map = TRUE,
   shapefile_path = NULL,
-  map_year = 1980
+  map_year = 1980,
+  example = FALSE
 )
 }
 \arguments{
@@ -20,33 +21,34 @@ cached locally; set \code{options(whep.provinces_shapefile = )} to point at
 an existing copy instead.}
 
 \item{map_year}{The year for which the typology map is created.}
+
+\item{example}{If \code{TRUE}, return a small example output without reading the
+remote inputs or the Natural Earth layer. Default is \code{FALSE}.}
 }
 \value{
-A tibble with the classification of Spanish provinces into typologies.
-It contains the following columns:
+A tibble with the classification of Spanish provinces into typologies for
+\code{map_year}. It contains the following columns:
 \itemize{
-\item \code{year}: The year in which the classification is performed.
-\item \code{province_name}: The name of the Spanish province.
-\item \code{livestock_density}: Livestock units (LU) per hectare of agricultural area
-(UAA). Reflects the intensity of animal farming.
-\item \code{productivity_kgN_ha}: Crop N productivity, in kilograms of N harvested
-per hectare of cropland.
-\item \code{semi_nat_share}: Share of total feed coming from semi-natural
-agroecosystems. Expressed between 0 and 1.
-\item \code{feed_imported_share}: Share of feed that is imported. Expressed between
-0 and 1.
-\item \code{typology}: Assigned typology category for each province.
-This is based on thresholds in livestock density, crop
-productivity, and feed patterns. The typologies include:
-- \verb{Specialized cropping system}
-- \verb{Extensive cropping system}
-- \verb{Extensive mixed crop-livestock system}
-- \verb{Intensive mixed crop-livestock system}
-- \verb{Specialized livestock-farming system}
+\item \code{Province_name}: The name of the Spanish province.
+\item \code{Typologie}: Assigned typology category for each province. This is based
+on thresholds in livestock density (livestock units per
+hectare of agricultural area), crop N productivity (kg N
+harvested per hectare of cropland), and the semi-natural and
+imported shares of feed. The typologies are:
+\itemize{
+\item \verb{Specialized cropping system}
+\item \verb{Extensive cropping system}
+\item \verb{Extensive mixed crop-livestock system}
+\item \verb{Intensive mixed crop-livestock system}
+\item \verb{Specialized livestock-farming system}
+}
 }
 }
 \description{
 Typologies of provinces in Spain based on nitrogen (N) production
 data of crops and livestock, using various input datasets and generating
 classification maps and data frames.
+}
+\examples{
+create_typologies_grafs_spain(example = TRUE)
 }

--- a/man/create_typologies_of_josette.Rd
+++ b/man/create_typologies_of_josette.Rd
@@ -7,7 +7,8 @@
 create_typologies_of_josette(
   make_map = TRUE,
   shapefile_path = NULL,
-  map_year = 1980
+  map_year = 1980,
+  example = FALSE
 )
 }
 \arguments{
@@ -20,12 +21,23 @@ cached locally; set \code{options(whep.provinces_shapefile = )} to point at
 an existing copy instead.}
 
 \item{map_year}{The year for which the typology map is created.}
+
+\item{example}{If \code{TRUE}, return a small example output without reading the
+remote inputs or the Natural Earth layer. Default is \code{FALSE}. The example
+output carries the three data elements only, not the \code{df_inputs_plots}
+plot, so that it needs no plotting package.}
 }
 \value{
-A tibble with the typology classification per year and province.
+A named list with \code{typologies_df} (the typology classification per
+year and province), \code{n_input_df} (the N soil inputs the classification
+read), \code{imported_feed_share_df} (the imported-feed share per year and
+province) and \code{df_inputs_plots} (a \code{ggplot} of N inputs by typology).
 }
 \description{
 Typologies of provinces in Spain based on nitrogen (N) production
 data of crops and livestock, considering multiple data inputs and
 producing classification maps and data frames.
+}
+\examples{
+create_typologies_of_josette(example = TRUE)$typologies_df
 }

--- a/man/create_typologies_whep.Rd
+++ b/man/create_typologies_whep.Rd
@@ -26,3 +26,38 @@ and Category.
 Calculates all decision variables for the WHEP typology
 using only production and consumption data (no import/export).
 }
+\examples{
+# Minimal stand-ins for the two real inputs, carrying only the columns the
+# decision variables read. Lugo feeds its livestock mostly on local grass;
+# Barcelona feeds them mostly on imported N.
+prod_destiny <- tibble::tribble(
+  ~year, ~province_name, ~box, ~item, ~origin, ~destiny, ~mg_n,
+  2020, "Lugo", "Cropland", "Wheat and products",
+  "Cropland", "population_food", 100,
+  2020, "Lugo", "semi_natural_agroecosystems", "Grassland",
+  "semi_natural_agroecosystems", "livestock_rum", 800,
+  2020, "Lugo", "Cropland", "Maize and products",
+  "Cropland", "livestock_rum", 200,
+  2020, "Lugo", "Cropland", "Soyabean cake",
+  "Outside", "livestock_mono", 50,
+  2020, "Barcelona", "Cropland", "Wheat and products",
+  "Cropland", "population_food", 100,
+  2020, "Barcelona", "Cropland", "Soyabean cake",
+  "Outside", "livestock_mono", 900,
+  2020, "Barcelona", "Cropland", "Maize and products",
+  "Cropland", "livestock_mono", 100
+)
+
+prod_n <- tibble::tribble(
+  ~year, ~province_name, ~box, ~production_n,
+  2020, "Lugo", "Cropland", 300,
+  2020, "Barcelona", "Cropland", 200
+)
+
+create_typologies_whep(
+  prod_destiny = prod_destiny,
+  prod_n = prod_n,
+  years = 2020
+) |>
+  dplyr::select(year, province_name, human_share, import_share, Category)
+}

--- a/man/get_polity_geometries.Rd
+++ b/man/get_polity_geometries.Rd
@@ -17,3 +17,14 @@ Returns the periodized polity database, including geometry. Pass
 \code{polity_codes} to retrieve a subset that can be joined to outputs from
 \code{\link[=add_polity_code]{add_polity_code()}}.
 }
+\examples{
+# sf is only suggested, and its methods are what make the geometry column
+# printable, so guard the example on it.
+if (requireNamespace("sf", quietly = TRUE)) {
+  codes <- add_polity_code(
+    tibble::tibble(area_code = c(203L, 68L), year = c(2000L, 2000L))
+  )$polity_code
+  geometries <- get_polity_geometries(codes)
+  print(geometries[, c("polity_code", "polity_name", "polygon_source")])
+}
+}

--- a/man/redistribute_feed.Rd
+++ b/man/redistribute_feed.Rd
@@ -45,3 +45,25 @@ hierarchical allocation that follows the remaining-share principle to
 avoid exceeding availability. The redistribution path adapts to the
 \code{fixed_demand} column in the demand table.
 }
+\examples{
+# Two variable-demand categories in one territory competing for a single
+# feed item. Availability (150) falls short of demand (200), so the
+# remaining-share principle underfeeds both by the same factor rather than
+# letting either exceed what is there.
+feed_demand <- tibble::tribble(
+  ~year, ~territory, ~sub_territory, ~livestock_category,
+  ~item_cbs_code, ~feed_group, ~feed_quality, ~demand_dm_t, ~fixed_demand,
+  2000L, "79", "79", "Cattle_milk",
+  NA_integer_, NA_character_, "high_quality", 120, FALSE,
+  2000L, "79", "79", "Pigs",
+  NA_integer_, NA_character_, "high_quality", 80, FALSE
+)
+
+feed_avail <- tibble::tribble(
+  ~year, ~territory, ~sub_territory, ~item_cbs_code, ~feed_group,
+  ~feed_quality, ~avail_dm_t, ~feed_scale,
+  2000L, "79", "79", 2514L, "cereals", "high_quality", 150, "national"
+)
+
+redistribute_feed(feed_demand, feed_avail)
+}

--- a/tests/testthat/test_exported_examples.R
+++ b/tests/testthat/test_exported_examples.R
@@ -1,0 +1,121 @@
+# Every exported function must carry an \examples block (whep#189).
+#
+# R CMD check only runs the examples that exist, so an export documented
+# without \examples is executed by no gate at all -- which is how the
+# always-erroring build_supply_use() of #176 stayed green through five
+# platforms. This file is that missing gate: it audits the Rd of every export
+# rather than any one function, so a new export cannot arrive unexercised.
+#
+# The Rd comes from whichever of the two trees this runs in. testthat runs
+# every test file with the working directory set to tests/testthat, so
+# ../../man is the source package's man/ under devtools::test() and covr, and
+# does not exist under R CMD check, which runs the tests inside
+# <pkg>.Rcheck/tests against an installed copy -- there the installed Rd
+# database is what there is. Both parse into the same Rd structure, so one
+# audit covers both. (A plain relative path rather than testthat::test_path(),
+# which aborts instead of resolving when it cannot find a tests/testthat above
+# the working directory.)
+
+.examples_audit_rd_list <- function() {
+  man_dir <- file.path("..", "..", "man")
+  if (dir.exists(man_dir)) {
+    files <- list.files(man_dir, pattern = "[.]Rd$", full.names = TRUE)
+    return(lapply(files, tools::parse_Rd))
+  }
+  unname(as.list(tools::Rd_db("whep")))
+}
+
+.examples_audit_rd_tags <- function(rd) {
+  vapply(
+    rd,
+    function(section) as.character(attr(section, "Rd_tag"))[1],
+    character(1)
+  )
+}
+
+.examples_audit_rd_aliases <- function(rd) {
+  aliases <- rd[.examples_audit_rd_tags(rd) == "\\alias"]
+  unname(vapply(
+    aliases,
+    function(alias) trimws(paste(unlist(alias), collapse = "")),
+    character(1)
+  ))
+}
+
+.examples_audit_rd_entry <- function(rd) {
+  aliases <- .examples_audit_rd_aliases(rd)
+  has_examples <- "\\examples" %in% .examples_audit_rd_tags(rd)
+  stats::setNames(rep(has_examples, length(aliases)), aliases)
+}
+
+# Named logical, one entry per documented alias: does its topic have examples?
+.examples_audit_index <- function() {
+  unlist(lapply(.examples_audit_rd_list(), .examples_audit_rd_entry))
+}
+
+.examples_audit_exports <- function() {
+  exports <- sort(getNamespaceExports("whep"))
+  is_function <- vapply(
+    exports,
+    function(name) is.function(getExportedValue("whep", name)),
+    logical(1)
+  )
+  exports[is_function]
+}
+
+.examples_audit_parse_rd <- function(lines, dir) {
+  path <- tempfile(tmpdir = dir, fileext = ".Rd")
+  writeLines(lines, path)
+  tools::parse_Rd(path)
+}
+
+testthat::test_that("the examples audit reads a populated Rd index", {
+  # A silent failure to find any Rd would make the audit below pass
+  # vacuously, so assert it saw the package before trusting what it says.
+  index <- .examples_audit_index()
+
+  testthat::expect_gt(length(index), 200L)
+  testthat::expect_true(any(index))
+  testthat::expect_gt(length(.examples_audit_exports()), 150L)
+})
+
+testthat::test_that("the examples detector separates present from absent", {
+  dir <- withr::local_tempdir()
+  base <- c("\\name{toy}", "\\alias{toy}", "\\title{Toy}")
+
+  with_examples <- .examples_audit_parse_rd(
+    c(base, "\\examples{1 + 1}"),
+    dir
+  )
+  without_examples <- .examples_audit_parse_rd(base, dir)
+
+  testthat::expect_true(
+    "\\examples" %in% .examples_audit_rd_tags(with_examples)
+  )
+  testthat::expect_false(
+    "\\examples" %in% .examples_audit_rd_tags(without_examples)
+  )
+  testthat::expect_equal(.examples_audit_rd_aliases(with_examples), "toy")
+  testthat::expect_equal(
+    .examples_audit_rd_entry(without_examples),
+    c(toy = FALSE)
+  )
+})
+
+testthat::test_that("every exported function is documented", {
+  undocumented <- setdiff(
+    .examples_audit_exports(),
+    names(.examples_audit_index())
+  )
+
+  testthat::expect_equal(undocumented, character(0))
+})
+
+testthat::test_that("every exported function has an @examples block", {
+  index <- .examples_audit_index()
+  exports <- intersect(.examples_audit_exports(), names(index))
+
+  without_examples <- exports[!index[exports]]
+
+  testthat::expect_equal(without_examples, character(0))
+})

--- a/tests/testthat/test_toy_examples.R
+++ b/tests/testthat/test_toy_examples.R
@@ -311,3 +311,82 @@ testthat::test_that("calculate_system_nue example returns valid tibble", {
     "nue_system"
   )
 })
+
+testthat::test_that("grafs Spain typologies example returns valid tibble", {
+  result <- whep::create_typologies_grafs_spain(example = TRUE)
+
+  testthat::expect_s3_class(result, "tbl_df")
+  testthat::expect_equal(nrow(result), 10)
+  pointblank::expect_col_exists(
+    result,
+    columns = c("Province_name", "Typologie")
+  )
+  pointblank::expect_col_vals_in_set(
+    result,
+    columns = "Typologie",
+    set = c(
+      "Specialized cropping system",
+      "Extensive cropping system",
+      "Extensive mixed crop-livestock system",
+      "Intensive mixed crop-livestock system",
+      "Specialized livestock-farming system"
+    )
+  )
+})
+
+testthat::test_that("Josette typologies example returns the data elements", {
+  result <- whep::create_typologies_of_josette(example = TRUE)
+
+  testthat::expect_type(result, "list")
+  testthat::expect_named(
+    result,
+    c("typologies_df", "n_input_df", "imported_feed_share_df")
+  )
+  purrr::walk(result, ~ testthat::expect_s3_class(.x, "tbl_df"))
+  purrr::walk(result, ~ testthat::expect_equal(nrow(.x), 10))
+
+  pointblank::expect_col_exists(
+    result$typologies_df,
+    columns = c("Year", "Province_name", "Typology")
+  )
+  pointblank::expect_col_exists(
+    result$n_input_df,
+    columns = c(
+      "Year",
+      "Province_name",
+      "item",
+      "irrig_cat",
+      "Box",
+      "MgN_dep",
+      "MgN_fix",
+      "MgN_syn",
+      "MgN_manure",
+      "MgN_urban"
+    )
+  )
+  pointblank::expect_col_exists(
+    result$imported_feed_share_df,
+    columns = c(
+      "Year",
+      "Province_name",
+      "LU_total",
+      "Feed_import_MgN",
+      "Domestic_feed_MgN",
+      "Total_feed_MgN",
+      "Imported_feed_share"
+    )
+  )
+  # The share is a share, and the feed total is the sum of its two parts.
+  pointblank::expect_col_vals_between(
+    result$imported_feed_share_df,
+    columns = "Imported_feed_share",
+    left = 0,
+    right = 1
+  )
+  testthat::expect_equal(
+    result$imported_feed_share_df$Total_feed_MgN,
+    result$imported_feed_share_df$Feed_import_MgN +
+      result$imported_feed_share_df$Domestic_feed_MgN,
+    tolerance = 1e-3
+  )
+})


### PR DESCRIPTION
## What was wrong

Ten exported functions carried no `@examples` block, so `R CMD check` never
executed them. That is the same blind spot that let the always-erroring
`build_supply_use()` of #176 survive five platforms, and **nothing in CI could
see it** — a missing example is silently OK to every gate the package runs.

Verified on `origin/main` by parsing every `man/*.Rd` for an `\examples`
section: 23 of 295 topics had none, of which 10 are `export()`ed functions and
13 are documented datasets plus `whep-package.Rd`. The 10 are exactly the six
this issue lists plus the four the issue comment adds:

```
add_footprint_product_stage   add_polity_code
compute_footprint_paths       compute_fp_product_paths
get_polity_geometries         redistribute_feed
create_alfredos_typologies    create_typologies_whep
create_typologies_of_josette  create_typologies_grafs_spain
```

## What changed

**Eight inline examples.** Those eight take their data as arguments and run in
well under a second, so each gets a self-contained example that also shows the
behaviour: `redistribute_feed()` underfeeding two categories by a common factor
when availability falls short; the three footprint-path decompositions on a
two-sector economy; `add_polity_code()` resolving area 16 to East Pakistan in
1965 and Bangladesh in 2000; `get_polity_geometries()` joined onto that, guarded
on `requireNamespace("sf")` because sf is only suggested; and the two
province-typology classifiers on purpose-built tribbles that land three and two
distinct categories respectively.

**Two `example = FALSE` arguments.** `create_typologies_of_josette()` and
`create_typologies_grafs_spain()` read pins and the Natural Earth layer and take
minutes on a real run, so they follow the package's documented fixture pattern.
The fixtures in `R/toy_examples.R` are **sampled from real runs** of both
functions on this machine, not invented.

**The CI blind spot itself**, in `tests/testthat/test_exported_examples.R`: it
audits the Rd of every namespace export and fails naming any that has no
`\examples`. It reads `man/` when run from the source tree (`devtools::test()`,
`covr`) and the installed Rd database when run from `<pkg>.Rcheck/tests`
(`R CMD check`), so it fires in both gates. It also asserts the index is
populated and cross-checks the detector against a synthetic Rd pair, so a broken
audit cannot pass vacuously.

**Two corrected `@return` blocks.** Writing the examples surfaced that both
typology functions' documented return was wrong, which is why they needed
correcting for the example to be coherent:

- `create_typologies_of_josette()` documented "a tibble with the typology
  classification per year and province"; it actually returns a named list of
  `typologies_df` (8,200 x 3), `n_input_df` (383,774 x 10),
  `imported_feed_share_df` (8,100 x 7) and a `ggplot`.
- `create_typologies_grafs_spain()` documented a seven-column all-years series
  (`year`, `province_name`, `livestock_density`, `productivity_kgN_ha`,
  `semi_nat_share`, `feed_imported_share`, `typology`); it actually returns
  `Province_name` and `Typologie` for `map_year` only (50 x 2).

Classification: **mechanical**. No coefficient, allocation rule or default
changes; the only new code path is an `example = TRUE` early return.

## What I verified

- **`R CMD check` on a clean export** (`git archive HEAD`, `--no-tests
  --ignore-vignettes --no-manual`, `_R_CHECK_FORCE_SUGGESTS_=false`):
  `* checking examples ... OK` — all ten new examples run. **Status: 1 NOTE**,
  and the identical run on `origin/main` is also **1 NOTE** with the same body
  (`.canonicalise_gdp_pop_area: no visible binding for ... key_row /
  canonical_area`), so nothing was introduced.
- **Full test suite**: `[ FAIL 0 | WARN 11 | SKIP 8 | PASS 5969 ]` in 211 s. The
  8 skips are the pre-existing `WHEP_*` / local-raster guards.
- **The new gate actually gates.** Stripping the `\examples` block from
  `man/redistribute_feed.Rd` makes it fail and name the offender:
  `` `without_examples` (`actual`) not equal to character(0) ... "redistribute_feed" ``.
  Restored afterwards.
- **Both Rd sources exercised.** The `man/` branch under `devtools::test()`
  (295 Rd, 192 exported functions, 0 without examples) and the installed-Rd
  branch by installing this export into a temp library and running the file with
  `../../man` absent (295 Rd in the database, same result). The first draft used
  `testthat::test_path()`, which *aborts* rather than resolving when it cannot
  find a `tests/testthat` above the working directory — that is why the file uses
  a plain relative path.
- `air format .` and `devtools::document()` both leave the tree clean;
  `lintr::lint()` with the project's disabled linters reports no lints on any
  changed file; every `man/*.Rd` is present in `_pkgdown.yml`.
- Rebased onto current `origin/main` (`ec85c8bb`) and re-ran the audit,
  `test_toy_examples.R` and `test_n_balance_spatialize.R` — all green.

## Left undone

- The wide `tribble()` rows in the two new `R/toy_examples.R` fixtures exceed 80
  columns. That matches the nearest existing fixtures in that file
  (`.example_create_n_soil_inputs()` and ~45 others), `air.toml` sets
  `skip = ["tribble"]`, and `line_length_linter` is disabled — but it is a
  deliberate consistency choice rather than compliance.
- `create_typologies_of_josette(example = TRUE)` returns the three data elements
  without the `df_inputs_plots` `ggplot`, so the example needs no plotting
  package. This is stated in the `example` `@param`.
- The `example = TRUE` early return does not exercise either typology function's
  body, so it does not smoke-test them the way the eight inline examples do.
  Making those two injectable (passing their inputs as arguments, as
  `create_alfredos_typologies()` and `create_typologies_whep()` already allow)
  would fix that and is worth a follow-up.
- `create_typologies_of_josette()` still has a stray `str(data$n_input_df)`
  debug print in its real path, and `create_typologies_spain()` in
  `R/typologies_spain.R` is documented but not exported. Both left alone as out
  of scope.

Closes #189

🤖 Generated with [Claude Code](https://claude.com/claude-code)
