### PR TITLE
fix(soc): stop the unspatialized-carbon warning aborting multi-year runs

### DIFF
--- a/R/soil_carbon_inputs.R
+++ b/R/soil_carbon_inputs.R
@@ -317,12 +317,27 @@ build_soil_carbon_inputs <- function(
     return(invisible(NULL))
   }
   crops <- sort(unique(lost$item_prod_code))
+  # Every plural marker gets its quantity pinned with cli::qty(), and the numbers
+  # are precomputed into scalars instead of being interpolated inline.
+  #
+  # Left to infer, cli has to decide which value each marker refers to, and with
+  # two numbers in the first bullet and a vector in the second it can conclude
+  # the answer is ambiguous and throw "Multiple quantities for pluralization" --
+  # from inside the warning, so the abort lands on the caller. That killed
+  # build_carbon_balance(1901:2023) outright after ~10 minutes of work, and only
+  # on multi-year spans: 1901-1905 warns fine, 1901-1910 dies. No single-year
+  # test would have caught it. polity_folds.R already pins a marker this way.
+  n_lost <- nrow(lost)
+  n_crops <- length(crops)
+  lost_mass <- round(sum(lost$c_mass_mg), 3)
   cli::cli_warn(c(
-    "!" = "{nrow(lost)} polity-crop carbon component{?s}
-           ({round(sum(lost$c_mass_mg), 3)} Mg C) had no crop-pattern cells and
-           {?was/were} dropped from the gridded soil carbon input.",
-    i = "Unspatialized item_prod_code{?s}: {.val {crops}}. Add {?its/their}
-         cells to {.field crop_patterns} to retain the carbon."
+    "!" = "{cli::qty(n_lost)}{n_lost} polity-crop carbon component{?s}
+           ({lost_mass} Mg C) had no crop-pattern cells and
+           {cli::qty(n_lost)}{?was/were} dropped from the gridded soil carbon
+           input.",
+    i = "{cli::qty(n_crops)}Unspatialized item_prod_code{?s}: {.val {crops}}.
+         Add {cli::qty(n_crops)}{?its/their} cells to {.field crop_patterns} to
+         retain the carbon."
   ))
   invisible(lost)
 }

--- a/tests/testthat/test_soil_carbon_inputs.R
+++ b/tests/testthat/test_soil_carbon_inputs.R
@@ -634,3 +634,44 @@ test_that(".sci_read_manure wires the turnkey chain to cropland applied_c", {
   # item_prod_code -- never on the grassland row.
   testthat::expect_setequal(unique(cropland$crop), c("15", "27"))
 })
+
+# The unspatialized-carbon warning used to abort instead of warning once more
+# than one crop went unmatched, because item_prod_code is INTEGER and cli then
+# could not tell which value the plural markers referred to. It killed
+# build_carbon_balance() on any multi-year span -- 1901-1905 warned fine,
+# 1901-1910 died -- so a single-year run never showed it.
+testthat::test_that("unspatialized carbon warns, and does not abort, for many crops", {
+  components <- tibble::tribble(
+    ~area_code, ~item_prod_code, ~c_mass_mg,
+    68L, 15L, 100.5,
+    68L, 56L, 200.25,
+    68L, 71L, 300.125
+  )
+  # No weights at all, so every component is unmatched.
+  weights <- tibble::tibble(
+    area_code = integer(),
+    item_prod_code = integer()
+  )
+
+  testthat::expect_warning(
+    lost <- .sci_warn_unspatialized(components, weights),
+    "had no crop-pattern cells"
+  )
+  testthat::expect_equal(nrow(lost), 3L)
+})
+
+testthat::test_that("unspatialized carbon warning reads singular for one crop", {
+  components <- tibble::tribble(
+    ~area_code, ~item_prod_code, ~c_mass_mg,
+    68L, 15L, 100.5
+  )
+  weights <- tibble::tibble(
+    area_code = integer(),
+    item_prod_code = integer()
+  )
+
+  testthat::expect_warning(
+    .sci_warn_unspatialized(components, weights),
+    "1 polity-crop carbon component"
+  )
+})


### PR DESCRIPTION
`build_carbon_balance(years = 1901:2023)` died after ~10 minutes of work with

```
Error in post_process_plurals(pstr, values): Multiple quantities for pluralization
```

from inside `.sci_warn_unspatialized()`. **The abort came out of a warning** — a
message that merely failed to format destroyed a three-hour computation.

## Cause

The message left `cli` to infer which value each plural marker refers to, and it
cannot. The first bullet interpolates **two** numbers (`nrow(lost)` and the rounded
mass), the second a vector — and `item_prod_code` is **integer**, so `cli` treats
the crop vector as another quantity candidate too.

Depending on the values it then throws one of two errors, which is why this was
awkward to pin down:

| values | error |
|---|---|
| the real 123-year run | `Multiple quantities for pluralization` |
| integer crops, length ≥ 2 | `length(object) == 1 is not TRUE` |

Two faces of the same ambiguity.

## Fix

Every marker gets its quantity pinned with `cli::qty()`, and the numbers are
precomputed into scalars instead of interpolated inline, so nothing depends on
`cli` guessing. `polity_folds.R` already pins a marker this way, so the pattern was
established in the codebase.

Pluralisation still reads correctly:

```
7488 polity-crop carbon components (4.3e+08 Mg C) ... were dropped.
1 polity-crop carbon component (4.3e+08 Mg C) ... was dropped.
```

## Why no test caught it

**Only multi-year spans reach it**: `1901-1905` warns fine, `1901-1910` aborts. A
single-year run cannot trigger it, and single-year is what everything tested.

The regression test uses integer `item_prod_code` with more than one unmatched crop
— the minimal trigger — and **fails without the fix**:

```
Error in `make_quantity(values$qty)`: length(object) == 1 is not TRUE
```

Verified by stashing the `R/` change and re-running: 1 failure, then passing with
it restored. 66 tests in the file, `lint_package()` clean.

## Note on the wider defect

The narrow bug is one message. The shape of it is worth noticing: a `cli` message
with more than one interpolated quantity is a latent abort in any code path that
only shows up with the right data, and it lands on the caller rather than on the
warning. There are other messages in `R/` with two interpolations and a plural
marker; I have not audited them, and a sweep might be worth its own issue.

Found while measuring what the LPJmL 6.x pin swap does to soil carbon (#559),
which this was blocking.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TvvcyfcfaSxW9pywZsdvAY
