### PR TITLE
fix(nitrogen): let the ambiguous-crosswalk abort report its own codes

### DIFF
--- a/R/n_balance_spatialize.R
+++ b/R/n_balance_spatialize.R
@@ -209,10 +209,18 @@ spatialize_country_n_to_crops <- function(
     )
   ambiguous <- lookup$area_code[duplicated(lookup$area_code)]
   if (length(ambiguous) > 0) {
+    codes <- sort(unique(ambiguous))
+    n_ambiguous <- length(codes)
     cli::cli_abort(c(
-      "{.field polity_area_crosswalk} maps {length(ambiguous)} area
+      "{.field polity_area_crosswalk} maps {n_ambiguous} area
        code{?s} to more than one {.field polity_area_code}.",
-      x = "Ambiguous area code{?s}: {sort(unique(ambiguous))}."
+      # qty() pinned, and the codes pulled into a variable: with the marker
+      # ahead of them and nothing numeric before it, cli tries to read the
+      # quantity off the INTEGER code vector and dies on
+      # "length(object) == 1 is not TRUE" -- so the abort that is supposed to
+      # name the offending codes instead reports a cli internal, exactly when
+      # someone needs to know which codes. Same class as #618, see #621.
+      x = "{cli::qty(n_ambiguous)}Ambiguous area code{?s}: {codes}."
     ))
   }
   lookup

--- a/tests/testthat/test_n_balance_spatialize.R
+++ b/tests/testthat/test_n_balance_spatialize.R
@@ -519,3 +519,25 @@ testthat::test_that("a country-year with no positive rate falls back cleanly", {
     "area_share"
   )
 })
+
+# The abort that reports an ambiguous crosswalk used to lose its own message:
+# the plural marker sits ahead of the INTEGER code vector with nothing numeric
+# before it, so cli read the quantity off the vector and died on
+# "length(object) == 1 is not TRUE" -- hiding which codes were at fault, exactly
+# when someone needs them. Same class as #618; see #621.
+testthat::test_that("an ambiguous crosswalk names the offending area codes", {
+  testthat::local_mocked_bindings(
+    .polity_crosswalk = function() {
+      tibble::tribble(
+        ~area_code, ~polity_area_code,
+        41L, 41L,
+        41L, 214L,
+        96L, 96L,
+        96L, 344L
+      )
+    }
+  )
+
+  testthat::expect_error(.cell_polity_bucket_lookup(), "Ambiguous area code")
+  testthat::expect_error(.cell_polity_bucket_lookup(), "41")
+})


### PR DESCRIPTION
Fixes the one confirmed live case in #621.

`.cell_polity_bucket_lookup()` guards against a crosswalk mapping one `area_code`
to several `polity_area_code`s, and the entire value of that abort is **naming
which codes**. It couldn't: the plural marker sits ahead of the *integer* code
vector with nothing numeric before it, so `cli` read the quantity off the vector
and died on

```
Error in make_quantity(values$qty): length(object) == 1 is not TRUE
```

So when the crosswalk actually is ambiguous — the one moment the message matters —
the reader got a `cli` internal instead of the codes.

**Unlike #618 this never destroyed a working run**, since the path was already
aborting. It destroyed the *diagnostic*, which is why it's worth fixing but not
urgent.

One ambiguous code formats fine; only two or more trigger it, which is why it
survived.

## Fix

Same as #618 and the existing `polity_folds.R` precedent — pin the quantity with
`cli::qty()` and pull the codes into a variable:

| | message |
|---|---|
| before | `Error: length(object) == 1 is not TRUE` |
| after | `Ambiguous area codes: 41, 96, and 128.` |
| after, one code | `Ambiguous area code: 41.` |

## One small behaviour change worth flagging

The count in the first bullet now counts **distinct** codes rather than duplicated
rows, so it matches the list the second bullet prints. Previously a code duplicated
three times inflated the count above the number of codes actually named — mildly
misleading in its own right.

## Test

Mocks `.polity_crosswalk()` with two ambiguous codes and asserts the message names
them. Verified it **fails without the fix**, with the `make_quantity` error above.
`lint_package()` clean.

Leaves #621 open: the remaining audit entries there are character-vector cases that
are safe today but unpinned, and a `lintr` custom linter for the class would be a
larger piece of work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TvvcyfcfaSxW9pywZsdvAY
