### PR TITLE
fix(#623): stop year-scoped builds dropping every forage crop

### DIFF
--- a/R/build_production.R
+++ b/R/build_production.R
@@ -636,6 +636,11 @@ build_primary_production <- function(
 
 # -- Fodder --------------------------------------------------------------------
 
+# Fodder rows are not read per year. `.fill_fodder_gaps()` takes the union of
+# (area, item) groups over every year and then interpolates along the year axis,
+# so a window narrower than the fodder sources both starts from a smaller group
+# universe and has no anchors to interpolate from -- which silently drops every
+# forage item (#623). Run the whole chain over the full span and trim at the end.
 .build_fodder <- function(fao_crop_liv, years = NULL) {
   cli::cli_progress_step("Building fodder dataset")
   items_prod <- whep::items_prod_full
@@ -644,14 +649,14 @@ build_primary_production <- function(
   biomass <- whep::biomass_coefs
 
   # Old FAO fodder data
-  i_fodder <- .read_fodder_old(years = years)
+  i_fodder <- .read_fodder_old(years = NULL)
 
   # EU AgriDB fodder
-  fodder_euadb <- .read_fodder_euadb(years = years)
+  fodder_euadb <- .read_fodder_euadb(years = NULL)
 
   # DM yields for imputing fodder areas
   dm_yield <- .compute_dm_yield(
-    fao_crop_liv,
+    .fodder_crop_liv(fao_crop_liv, i_fodder),
     items_prod,
     biomass
   )
@@ -663,7 +668,22 @@ build_primary_production <- function(
     dm_yield,
     items_prod,
     biomass
-  )
+  ) |>
+    .filter_years(years)
+}
+
+# `dm_yield` supplies the `yield_dm` that turns fodder tonnage into area, so the
+# interpolation in `.fill_fodder_gaps()` needs it at every year the fodder
+# sources cover, not only the requested ones. Reuse the caller's table whenever
+# it already spans them -- a full-range build always does, so that path pays
+# nothing extra and its output is unchanged.
+.fodder_crop_liv <- function(fao_crop_liv, i_fodder) {
+  needed <- range(i_fodder$year, na.rm = TRUE)
+  have <- range(fao_crop_liv$year, na.rm = TRUE)
+  if (have[[1]] <= needed[[1]] && have[[2]] >= needed[[2]]) {
+    return(fao_crop_liv)
+  }
+  .read_fao_crop_liv(years = NULL)
 }
 
 .read_fodder_old <- function(years = NULL) {

--- a/R/utils.R
+++ b/R/utils.R
@@ -74,6 +74,9 @@ utils::globalVariables(
     "source_prod",
     # polities.R + build_production.R (dependency-to-sovereign attribution)
     "sovereign_iso3c",
+    # build_cbs.R (.canonicalise_gdp_pop_area)
+    "canonical_area",
+    "key_row",
     # crop_npp.R (potential NPP + residues/roots/components)
     "temp_c",
     "temp_grassland_ha",

--- a/tests/testthat/test_build_production.R
+++ b/tests/testthat/test_build_production.R
@@ -963,3 +963,44 @@ test_that(".read_land_areas separates LUH2's own sentinel from real territories"
   expect_true(any(grepl("-99", msgs, fixed = TRUE)))
   expect_true(any(grepl("no country assignment", msgs)))
 })
+
+test_that(".fodder_crop_liv reuses a table that already spans the fodder years", {
+  # The fodder chain interpolates along the year axis, so it needs yield_dm at
+  # every year the fodder sources cover (#623). A full-range build already holds
+  # those years, and must not pay for a second read.
+  i_fodder <- tibble::tribble(
+    ~year, ~value,
+    1961L, 1,
+    2013L, 2
+  )
+  spanning <- tibble::tribble(
+    ~year, ~unit, ~value,
+    1961L, "ha", 10,
+    2020L, "ha", 20
+  )
+
+  expect_identical(
+    whep:::.fodder_crop_liv(spanning, i_fodder),
+    spanning
+  )
+})
+
+test_that(".fodder_crop_liv ignores NA years when comparing spans", {
+  i_fodder <- tibble::tribble(
+    ~year, ~value,
+    1961L, 1,
+    NA_integer_, 2,
+    2013L, 3
+  )
+  spanning <- tibble::tribble(
+    ~year, ~unit, ~value,
+    1960L, "ha", 10,
+    NA_integer_, "ha", 15,
+    2014L, "ha", 20
+  )
+
+  expect_identical(
+    whep:::.fodder_crop_liv(spanning, i_fodder),
+    spanning
+  )
+})


### PR DESCRIPTION
Fixes #623. Found while verifying #367 on real data; **pre-existing on `main`**,
and live today because `build_io_model(years = ...)` already scopes the
production build.

## The bug

`.fill_fodder_gaps()` (`R/build_production.R`) does not read fodder per year — it
*synthesises* rows from the whole series:

1. a `tidyr::complete`-equivalent cross join of `unique(year)` against the
   **union of (area, item) groups over every year**, then
2. three `fill_linear()` passes **along the year axis**.

A window narrower than the fodder sources therefore starts from a smaller group
universe *and* has no anchors to interpolate from, and the final
`!is.na(t_2)` filter drops the survivors. Traced at 2010:

| stage | narrow (2010 only) | full range |
| --- | --- | --- |
| rows after cross-join | 669 | **851** |
| `ha_share` non-NA after `fill_linear` | 456 (unchanged) | **572** |
| `ha` non-NA, final | 456 | **572** |

Cost: **137 rows lost, every one a forage item** (637, 639, 642, 643, 644, 651),
taking **1.16% of production tonnes, 1.85% of `t_ha`, and 1.36% of wide-CBS
`feed`**. Widening to ±5 years does not help — the EU AgriDB anchors are sparse
in time, so a 2005–2015 window gives byte-identical errors to a single year.

## The fix

Run the whole fodder chain over the full span and trim at the end.

The two fodder reads are cheap. The one that is not is `dm_yield`, and it is
genuinely needed at every year the fodder sources cover, because the quantity
being interpolated is `ha = t_dm / yield_dm` — the anchors at *other* years
require `yield_dm` there. So `.fodder_crop_liv()` reuses the caller's
crop/livestock table whenever it already spans those years, which a full-range
build always does. That leaves the full-range path byte-for-byte untouched and
paying nothing extra; only a scoped build takes the extra read
(12.8 s / 3.3 GB transient, yielding an 11,373-row / 0.5 MB table).

## Verification, against pristine `main` on real data

| criterion | result |
| --- | --- |
| full-range data payload | **`identical()`** to pristine `main` |
| scoped 2010 fodder rows | 375 → **447**, exactly matching full-range |
| `ha` relative difference | 1.06e-03 → **exactly 0** |
| `t_ha` relative difference | 1.85e-02 → **exactly 0** |
| `tonnes` | 1.16e-02 → 4.5e-07 |
| max relative difference, all units | 1.85e-02 → **3.0e-04** |
| scoped build | 16.1 s / 0.6 GB → 28.3 s / 2.9 GB |
| full build | 189 s → 176 s (unchanged; reuse branch confirmed, no second read) |
| `devtools::test()` | **5960 pass, 0 failed, 0 errors**, 8 pre-existing skips |
| `rcmdcheck` | **0 errors, 0 warnings, 0 notes** |
| `lintr` | 0 lints |

### On the one non-identical thing

`all.equal()` on the full-range result reports 32 differences, **all of them
inside the diagnostic `.cb_extracts` attribute, none in the data** — the payload
is `identical()`, and the attribute has the same row count and is identical once
sorted. I confirmed this is pre-existing nondeterminism rather than an effect of
this change by running **two builds of the same unmodified code on `main`**: they
also differ as-is and match after sorting. Related to the existing
`fix/build-nondeterminism` work; out of scope here.

## What this does not fix

**#625.** After this change a scoped build still differs from full-range by 11
rows in livestock units (`slaughtered_heads`, `t_LU`, `t_head`, plus 3 `tonnes`),
max relative difference **3.0e-04**. Those four relative errors are
byte-identical before and after this fix, so they are a separate cross-year
dependency — filed as #625 rather than folded in here.

## Second commit, unrelated

`7a33d5d3` declares `canonical_area` and `key_row` in `utils::globalVariables()`.
Not part of this work: `.canonicalise_gdp_pop_area()` in `R/build_cbs.R` uses
them as NSE columns without declaring them, which makes `rcmdcheck` report a note
on `main` itself. Kept as its own commit; drop it if it lands elsewhere first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)