### PR TITLE
Model the Rest-of-World reporting members in their own right (#459)

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,41 @@
 # whep (development version)
 
+* **WHEP now models the Rest-of-World reporting members in their own right.**
+  FABIO folds 61 FAOSTAT reporting areas into its single `Rest of World` column,
+  and `polity_area_code` inherited that fold, so any territory outside FABIO's
+  192-country layout was published as `ROW`. FABIO's layout is a methodology this
+  package compares against, not a constraint on which territories it represents,
+  and the country set is WHEP's own decision (#459).
+
+  The fold was also not doing what its name suggests. Of the 61 members only
+  about a third report anything; the rest contribute no rows, so folding them is
+  arithmetically a no-op. Everything the bucket carried came from the members
+  that DO file returns, and the fold discarded whose data it was — Syria's
+  production was published as "Rest of World" despite Syria filing its own
+  FAOSTAT returns. Promotion is therefore self-limiting: an area with no rows is
+  unaffected either way, so no hand-maintained list of "which ones to promote"
+  is needed.
+
+  Measured on two full-range `get_wide_cbs()` builds (1850-2023): the published
+  area count goes **195 → 216**, and 21 territories become standalone —
+  Bermuda, Cayman Islands, Cook Islands, Equatorial Guinea, Faroe Islands,
+  French Guiana, Greenland, Guadeloupe, Martinique, New Caledonia, North
+  Macedonia, Niue, Réunion, Eswatini, Syria, Palestine and five more. Global
+  totals move by at most **0.99%** (`stock_addition`), every other column inside
+  0.4%. **Bucket 999 survives** as a genuine residual for the territories that
+  report nothing, shrinking from 15,507 rows to 516.
+
+  `options(whep.unfold_rest_of_world = "none")` restores the fold, which is what
+  reproducing a number published before this change requires; it warns on every
+  crosswalk read, because such a run no longer matches the published series.
+  The `"successor_state"` folds (Sudan/South Sudan into bucket 206) are
+  untouched — those are territorial identities, not a FABIO convention, and
+  remain the subject of #414.
+
+  An earlier measurement in #419 put this change at up to 13.7x on `feed`. That
+  comparison predates the `dcast()` duplicate-key fix (#425/#429) and does not
+  reproduce; #555 re-measured it at 1.0000.
+
 * `create_typologies_of_josette()` and `create_typologies_grafs_spain()` gained
   an `example = FALSE` argument, so both now have runnable examples like the
   rest of the package's remote-data functions. Their documented `@return` was

--- a/R/polity_folds.R
+++ b/R/polity_folds.R
@@ -257,25 +257,36 @@ polity_bucket_coverage <- function(years = NULL) {
 #' because `polity_area_code` is derived from `fabio_code`, so the contradiction
 #' is left standing and reported here instead (issue 556).
 #'
-#' @section Measuring the alternative:
-#' `options(whep.unfold_rest_of_world = TRUE)` promotes every Rest-of-World
-#' member to its own `polity_area_code` for the whole pipeline, which is the
-#' experiment the decision needs. It is **off by default and not a production
-#' mode**: published WHEP values assume the fold, so every read of the crosswalk
-#' warns while it is set. The `"successor_state"` folds are never lifted by it,
-#' since those are territorial identities rather than a FABIO convention.
+#' @section The Rest-of-World fold is no longer applied:
+#' WHEP models every reporting member of bucket 999 in its own right. FABIO's
+#' 192-country layout is a methodology this package compares against, not a
+#' constraint on which territories it represents, and the choice of country set
+#' is WHEP's to make (issue 459).
 #'
-#' `options(whep.unfold_rest_of_world = "cbs_reporters")` promotes only the four
-#' `"cbs_reporter_folded"` areas, which is the narrower experiment issue 556
-#' asks for: it lifts exactly the folds FABIO does not make and leaves the 57
-#' folds FABIO agrees with in place. `TRUE` and `"all"` are the same mode.
+#' That matters because the fold was never doing what its name suggests. Of the
+#' 61 members, only about a third report anything at all; the rest contribute no
+#' rows and folding them is arithmetically a no-op. Everything the bucket
+#' actually carried came from the members that DO file returns -- Syria,
+#' Eswatini, North Macedonia, New Caledonia, the Faroe Islands, Palestine,
+#' Greenland and the like -- and folding them discarded whose data it was. So
+#' promotion is self-limiting: an area with no rows is unaffected either way.
 #'
-#' Measured with it on a full-range `get_wide_cbs()` (1850-2023, all 61 members
-#' promoted), global totals move by at most 1.2% (`stock_addition`) and by less
-#' than 0.1% for `feed`, `production` and `processing`. An earlier measurement
-#' recorded in issue 419 reported up to 13.7x; that comparison predates the
-#' `dcast()` duplicate-key fix in `.select_best_source()` (issue 425) and does
-#' not reproduce.
+#' Bucket 999 survives as a genuine residual for the territories that report
+#' nothing. Measured on a full-range `get_wide_cbs()` (1850-2023), promotion
+#' takes the published area count from 195 to 216 and moves global totals by at
+#' most 0.99% (`stock_addition`), with every other column inside 0.4%.
+#'
+#' `options(whep.unfold_rest_of_world = "none")` restores the fold, which is
+#' what reproducing a number published before this change requires. Because that
+#' no longer matches the published series, every read of the crosswalk warns
+#' while it is set. `"cbs_reporters"` re-folds all but the four
+#' `"cbs_reporter_folded"` areas and warns for the same reason. The
+#' `"successor_state"` folds are never lifted by any mode, since those are
+#' territorial identities rather than a FABIO convention.
+#'
+#' An earlier measurement recorded in issue 419 reported this change at up to
+#' 13.7x on `feed`; that comparison predates the `dcast()` duplicate-key fix in
+#' `.select_best_source()` (issue 425) and does not reproduce.
 #'
 #' @param crosswalk Crosswalk to inspect. Defaults to [polity_area_crosswalk].
 #'
@@ -473,7 +484,7 @@ folded_reporting_areas <- function(crosswalk = NULL) {
 }
 
 .unfold_rest_of_world_mode <- function() {
-  value <- getOption("whep.unfold_rest_of_world", FALSE)
+  value <- getOption("whep.unfold_rest_of_world", "all")
   if (isTRUE(value)) {
     return("all")
   }
@@ -489,10 +500,6 @@ folded_reporting_areas <- function(crosswalk = NULL) {
      {.val FALSE} or one of {.val {modes}}.",
     "x" = "Got {.val {value}}."
   ))
-}
-
-.unfold_rest_of_world_option <- function() {
-  .unfold_rest_of_world_mode() != "none"
 }
 
 # The ONE predicate deciding which members a mode promotes. `regions_full` and
@@ -516,21 +523,30 @@ folded_reporting_areas <- function(crosswalk = NULL) {
 .unfold_rest_of_world <- function(crosswalk) {
   mode <- .unfold_rest_of_world_mode()
   promoted <- .rest_of_world_members(crosswalk, mode)
+  # The WARNING FOLLOWS THE DEFAULT, and the default is now `"all"`. It used to
+  # fire whenever anything was promoted, because the fold was what WHEP
+  # published; now promotion IS what WHEP publishes, so the thing worth warning
+  # about is the opposite -- a run that re-folds and therefore does not match
+  # anything published.
+  #
+  # Warned on EVERY read rather than once per session: the crosswalk is read
+  # dozens of times in a build, and a run whose numbers do not match the
+  # published series should be impossible to mistake for one that does.
+  # Session-level "once" state would also make the warning untestable.
+  if (mode != "all") {
+    cli::cli_warn(c(
+      "!" = "{.code whep.unfold_rest_of_world} is set to {.val {mode}}:
+             the FABIO Rest-of-World fold is being applied to
+             {sum(!promoted & .rest_of_world_members(crosswalk, 'all'))}
+             reporting area{?s} that WHEP models in their own right.",
+      "i" = "Published WHEP values do NOT fold them. This is a sensitivity
+             setting for issues 419 and 556, not the production mode."
+    ))
+  }
   if (!any(promoted)) {
     return(crosswalk)
   }
   crosswalk[promoted, polity_area_code := area_code]
-  # Warned on EVERY read rather than once per session: the crosswalk is read
-  # dozens of times in a build, and a run whose numbers do not match anything
-  # published should be impossible to mistake for one that does. Session-level
-  # "once" state would also make the warning untestable.
-  cli::cli_warn(c(
-    "!" = "{.code whep.unfold_rest_of_world} is set to {.val {mode}}:
-           {sum(promoted)} crosswalk row{?s} promoted out of the FABIO
-           Rest-of-World bucket.",
-    "i" = "Published WHEP values assume the fold. This is a sensitivity setting
-           for issues 419 and 556, not a supported production mode."
-  ))
   crosswalk
 }
 

--- a/man/folded_reporting_areas.Rd
+++ b/man/folded_reporting_areas.Rd
@@ -78,26 +78,37 @@ because \code{polity_area_code} is derived from \code{fabio_code}, so the contra
 is left standing and reported here instead (issue 556).
 }
 
-\section{Measuring the alternative}{
+\section{The Rest-of-World fold is no longer applied}{
 
-\code{options(whep.unfold_rest_of_world = TRUE)} promotes every Rest-of-World
-member to its own \code{polity_area_code} for the whole pipeline, which is the
-experiment the decision needs. It is \strong{off by default and not a production
-mode}: published WHEP values assume the fold, so every read of the crosswalk
-warns while it is set. The \code{"successor_state"} folds are never lifted by it,
-since those are territorial identities rather than a FABIO convention.
+WHEP models every reporting member of bucket 999 in its own right. FABIO's
+192-country layout is a methodology this package compares against, not a
+constraint on which territories it represents, and the choice of country set
+is WHEP's to make (issue 459).
 
-\code{options(whep.unfold_rest_of_world = "cbs_reporters")} promotes only the four
-\code{"cbs_reporter_folded"} areas, which is the narrower experiment issue 556
-asks for: it lifts exactly the folds FABIO does not make and leaves the 57
-folds FABIO agrees with in place. \code{TRUE} and \code{"all"} are the same mode.
+That matters because the fold was never doing what its name suggests. Of the
+61 members, only about a third report anything at all; the rest contribute no
+rows and folding them is arithmetically a no-op. Everything the bucket
+actually carried came from the members that DO file returns -- Syria,
+Eswatini, North Macedonia, New Caledonia, the Faroe Islands, Palestine,
+Greenland and the like -- and folding them discarded whose data it was. So
+promotion is self-limiting: an area with no rows is unaffected either way.
 
-Measured with it on a full-range \code{get_wide_cbs()} (1850-2023, all 61 members
-promoted), global totals move by at most 1.2\% (\code{stock_addition}) and by less
-than 0.1\% for \code{feed}, \code{production} and \code{processing}. An earlier measurement
-recorded in issue 419 reported up to 13.7x; that comparison predates the
-\code{dcast()} duplicate-key fix in \code{.select_best_source()} (issue 425) and does
-not reproduce.
+Bucket 999 survives as a genuine residual for the territories that report
+nothing. Measured on a full-range \code{get_wide_cbs()} (1850-2023), promotion
+takes the published area count from 195 to 216 and moves global totals by at
+most 0.99\% (\code{stock_addition}), with every other column inside 0.4\%.
+
+\code{options(whep.unfold_rest_of_world = "none")} restores the fold, which is
+what reproducing a number published before this change requires. Because that
+no longer matches the published series, every read of the crosswalk warns
+while it is set. \code{"cbs_reporters"} re-folds all but the four
+\code{"cbs_reporter_folded"} areas and warns for the same reason. The
+\code{"successor_state"} folds are never lifted by any mode, since those are
+territorial identities rather than a FABIO convention.
+
+An earlier measurement recorded in issue 419 reported this change at up to
+13.7x on \code{feed}; that comparison predates the \code{dcast()} duplicate-key fix in
+\code{.select_best_source()} (issue 425) and does not reproduce.
 }
 
 \examples{

--- a/tests/testthat/test_build_cbs.R
+++ b/tests/testthat/test_build_cbs.R
@@ -211,6 +211,11 @@ test_that(".read_land_areas_wide keys its output on polity_code", {
 })
 
 test_that(".read_land_areas_wide holds back folded aggregate buckets", {
+  # Scoped to the explicit fold. WHEP now models the reporting members of
+  # bucket 999 in their own right (#459), so there is no Rest-of-World fold
+  # by default; what this pins is the fold behaviour itself, which still has
+  # to work for anyone reproducing a published-before number.
+  withr::local_options(whep.unfold_rest_of_world = "none")
   # Equatorial Guinea and Syria both fold into the Rest of World bucket (999).
   # Summing their agricultural land into it would give the bucket an extent that
   # is neither member's nor the real rest of the world's, so proxies are not
@@ -624,6 +629,11 @@ test_that(".fill_with_proxies keys its proxies on the polity, not the name", {
 })
 
 test_that(".fill_with_proxies leaves a folded aggregate bucket unproxied", {
+  # Scoped to the explicit fold. WHEP now models the reporting members of
+  # bucket 999 in their own right (#459), so there is no Rest-of-World fold
+  # by default; what this pins is the fold behaviour itself, which still has
+  # to work for anyone reproducing a published-before number.
+  withr::local_options(whep.unfold_rest_of_world = "none")
   # Syria folds into the Rest of World bucket (999), so the pin's Syrian
   # population is not the bucket's population and a per-capita rate against it
   # would mean nothing. Deciding what an aggregate's proxy should be is a
@@ -923,6 +933,11 @@ test_that(".resolve_hist_trade_polities keys on the reported year, not today", {
 })
 
 test_that(".resolve_hist_trade_polities drops pre-range aggregate rows", {
+  # Scoped to the explicit fold. WHEP now models the reporting members of
+  # bucket 999 in their own right (#459), so there is no Rest-of-World fold
+  # by default; what this pins is the fold behaviour itself, which still has
+  # to work for anyone reproducing a published-before number.
+  withr::local_options(whep.unfold_rest_of_world = "none")
   # Guadeloupe and Martinique are folded into the ROW bucket, whose only polity
   # ROW-1850-2025 is of type "aggregate". .add_polity_columns_dt refuses to
   # extend aggregate reporting areas outside their range, so an 1830 figure has
@@ -956,6 +971,11 @@ test_that(".resolve_hist_trade_polities leaves unknown iso3 labels unresolved", 
 })
 
 test_that(".canonicalise_gdp_pop_area relabels through the ISO3 code", {
+  # Scoped to the explicit fold. WHEP now models the reporting members of
+  # bucket 999 in their own right (#459), so there is no Rest-of-World fold
+  # by default; what this pins is the fold behaviour itself, which still has
+  # to work for anyone reproducing a published-before number.
+  withr::local_options(whep.unfold_rest_of_world = "none")
   # `.fill_with_proxies()` joins population on `c("year", "area")` -- the name --
   # and the two sides speak different vocabularies. Everything that comes through
   # `.aggregate_to_polities()` carries the period-specific `polity_name`, while the

--- a/tests/testthat/test_build_trade.R
+++ b/tests/testthat/test_build_trade.R
@@ -292,6 +292,11 @@ testthat::test_that("polity self-trade is removed after aggregation", {
 })
 
 testthat::test_that("intra-aggregate distinct-origin trade survives collapse", {
+  # Scoped to the explicit fold. WHEP now models the reporting members of
+  # bucket 999 in their own right (#459), so there is no Rest-of-World fold
+  # by default; what this pins is the fold behaviour itself, which still has
+  # to work for anyone reproducing a published-before number.
+  withr::local_options(whep.unfold_rest_of_world = "none")
   # American Samoa (5) and Andorra (6) both collapse to the Rest of World
   # aggregate polity (999). A real flow 5 -> 6 becomes 999 -> 999, which the
   # naive polity-level self-trade filter would delete. It must survive: these

--- a/tests/testthat/test_feed_intake_build.R
+++ b/tests/testthat/test_feed_intake_build.R
@@ -127,6 +127,11 @@ testthat::test_that("region_fallback 'none' is the pre-467 status quo", {
 })
 
 testthat::test_that("the Rest-of-World weights come from real fold members", {
+  # Scoped to the explicit fold. WHEP now models the reporting members of
+  # bucket 999 in their own right (#459), so there is no Rest-of-World fold
+  # by default; what this pins is the fold behaviour itself, which still has
+  # to work for anyone reproducing a published-before number.
+  withr::local_options(whep.unfold_rest_of_world = "none")
   # Selected by the bucket they fold INTO, not by what the fold is called.
   # `fold_kind` is a classification and it moves: #556 reclassified Syria (212),
   # Eswatini (209), North Macedonia (154) and New Caledonia (153) from

--- a/tests/testthat/test_grassland_land_extension.R
+++ b/tests/testthat/test_grassland_land_extension.R
@@ -73,6 +73,11 @@ testthat::test_that("faostat_pasture drops aggregates via the polity crosswalk",
 })
 
 testthat::test_that("faostat_pasture collapses ROW territories to a polity key", {
+  # Scoped to the explicit fold. WHEP now models the reporting members of
+  # bucket 999 in their own right (#459), so there is no Rest-of-World fold
+  # by default; what this pins is the fold behaviour itself, which still has
+  # to work for anyone reproducing a published-before number.
+  withr::local_options(whep.unfold_rest_of_world = "none")
   # Small territories FABIO buckets into Rest of World (e.g. American Samoa 5,
   # Andorra 6) carry an iso3c, so the old filter kept them under their raw
   # FAOSTAT codes -- a different key basis than the LUH2 source. The crosswalk

--- a/tests/testthat/test_n_balance_spatialize.R
+++ b/tests/testthat/test_n_balance_spatialize.R
@@ -123,6 +123,11 @@ testthat::test_that("build_cell_polity keeps on-bucket grids silent", {
 })
 
 testthat::test_that("area_key = polity_area re-keys the grid on buckets", {
+  # Scoped to the explicit fold. WHEP now models the reporting members of
+  # bucket 999 in their own right (#459), so there is no Rest-of-World fold
+  # by default; what this pins is the fold behaviour itself, which still has
+  # to work for anyone reproducing a published-before number.
+  withr::local_options(whep.unfold_rest_of_world = "none")
   path <- .nbs_write_grid(.nbs_off_bucket_grid())
 
   result <- whep::build_cell_polity(

--- a/tests/testthat/test_polities.R
+++ b/tests/testthat/test_polities.R
@@ -467,6 +467,11 @@ testthat::test_that("the iso3c lookup is unique per code", {
 })
 
 testthat::test_that("the iso3c lookup is many-to-one, deliberately", {
+  # Scoped to the explicit fold. WHEP now models the reporting members of
+  # bucket 999 in their own right (#459), so there is no Rest-of-World fold
+  # by default; what this pins is the fold behaviour itself, which still has
+  # to work for anyone reproducing a published-before number.
+  withr::local_options(whep.unfold_rest_of_world = "none")
   # Unique per iso3c (above) says nothing about the other direction, and the
   # other direction is where the aggregation lives: `polity_area_code` is a
   # bucket, so 257 ISO3 codes share 195 codes. Anything reading a population or

--- a/tests/testthat/test_polity_folds.R
+++ b/tests/testthat/test_polity_folds.R
@@ -168,6 +168,11 @@ test_that(".aggregate_to_polities warns when it folds Sudan into bucket 206", {
 # loud instead of reporting a clean match. See #419.
 
 testthat::test_that("folded_reporting_areas() names every fold and its kind", {
+  # Scoped to the explicit fold, because it is no longer the default: WHEP
+  # now models the reporting members in their own right (#459). What this
+  # pins is the fold ITSELF -- its membership and its kinds -- which still
+  # has to work, because reproducing a published-before number depends on it.
+  withr::local_options(whep.unfold_rest_of_world = "none")
   folded <- whep::folded_reporting_areas()
 
   testthat::expect_s3_class(folded, "tbl_df")
@@ -207,6 +212,11 @@ testthat::test_that("folded_reporting_areas() names every fold and its kind", {
 })
 
 testthat::test_that("the four CBS reporters folded into 999 are named (#556)", {
+  # Scoped to the explicit fold, because it is no longer the default: WHEP
+  # now models the reporting members in their own right (#459). What this
+  # pins is the fold ITSELF -- its membership and its kinds -- which still
+  # has to work, because reproducing a published-before number depends on it.
+  withr::local_options(whep.unfold_rest_of_world = "none")
   # `"fabio_rest_of_world"` claimed something about FABIO that is false for four
   # of the 61 members. FABIO's published region list -- `io_codes.csv` of the
   # v1.1 release (Zenodo record 2577067), 192 areas x 125 commodities -- gives
@@ -241,6 +251,11 @@ testthat::test_that("folded_reporting_areas() needs the cbs flag", {
 })
 
 testthat::test_that("the areas that report real data of their own are folded", {
+  # Scoped to the explicit fold, because it is no longer the default: WHEP
+  # now models the reporting members in their own right (#459). What this
+  # pins is the fold ITSELF -- its membership and its kinds -- which still
+  # has to work, because reproducing a published-before number depends on it.
+  withr::local_options(whep.unfold_rest_of_world = "none")
   # Measured against the raw FAOSTAT pins at the base commit: these are the
   # reporting areas FABIO folds into Rest of World that carry observed rows,
   # with their `faostat-production` row counts. The fold is left standing on
@@ -278,6 +293,11 @@ testthat::test_that("the areas that report real data of their own are folded", {
 })
 
 testthat::test_that("regions_full and the crosswalk state the fold alike", {
+  # Scoped to the explicit fold, because it is no longer the default: WHEP
+  # now models the reporting members in their own right (#459). What this
+  # pins is the fold ITSELF -- its membership and its kinds -- which still
+  # has to work, because reproducing a published-before number depends on it.
+  withr::local_options(whep.unfold_rest_of_world = "none")
   # The promotion this pins against survived one round of withdrawal by being
   # written down twice and only one table being rebuilt. `regions_full` feeds
   # `.iso3c_area_code_lookup()` and the crosswalk feeds every polity join, so
@@ -312,6 +332,11 @@ testthat::test_that("regions_full and the crosswalk state the fold alike", {
 })
 
 testthat::test_that(".aggregate_to_polities() sums a fold and reports it", {
+  # Scoped to the explicit fold: Syria is a standalone area by default now
+  # (#459), so there is no fold here to sum unless one is asked for. The
+  # summing behaviour itself still has to be right, because bucket 206 folds
+  # regardless of this option and the same code path serves both.
+  withr::local_options(whep.unfold_rest_of_world = "none")
   # The whole defect in one fixture: Syria's row keeps its value but comes back
   # under area 999, added to Rest of World's own row. Nothing is dropped, so the
   # only way a build can know is the warning.
@@ -376,26 +401,54 @@ testthat::test_that("nothing is reported when nothing is folded", {
   )
 })
 
-testthat::test_that("the fold stands unless it is switched off explicitly", {
-  # The default must be byte-identical to the committed crosswalk, because that
-  # is what every published number assumes.
+testthat::test_that("the un-fold is the default and the fold is now opt-in", {
+  # THIS TEST ASSERTED THE OPPOSITE until the fold stopped being WHEP's country
+  # set. FABIO's 192-country layout is a methodology this package compares
+  # against, not a constraint on which territories it models: WHEP decides that
+  # for itself, and 21 of the folded areas file their own FAOSTAT returns.
+  #
+  # So the committed crosswalk is no longer the published shape -- it is the raw
+  # input, and `.polity_crosswalk()` promotes on read. Syria is the clearest
+  # case: it reports its own production and was being published as
+  # "Rest of World".
+  cw <- as.data.frame(whep:::.polity_crosswalk())
+  testthat::expect_equal(whep:::.iso3c_to_area_code("SYR"), 212L)
+  testthat::expect_equal(whep:::.unfold_rest_of_world_mode(), "all")
+
+  # Only bucket 999 itself still carries 999: every member has been promoted.
+  still_folded <- unique(cw$area_code[which(cw$polity_area_code == 999L)])
+  testthat::expect_equal(still_folded, 999L)
+
+  # The bucket survives, and that matters -- it is a genuine residual for the
+  # territories that report nothing, not an empty shell. Of the 61 members only
+  # about a third ever report, so promotion is self-limiting: an area with no
+  # rows contributes none either way.
+  testthat::expect_true(999L %in% cw$area_code)
+
+  # And the fold is still reachable, because reproducing a published-before
+  # number has to stay possible.
+  refolded <- as.data.frame(
+    withr::with_options(
+      list(whep.unfold_rest_of_world = "none"),
+      suppressWarnings(whep:::.polity_crosswalk())
+    )
+  )
   testthat::expect_equal(
-    whep:::.polity_crosswalk()$polity_area_code,
+    refolded$polity_area_code,
     as.data.frame(whep::polity_area_crosswalk)$polity_area_code
   )
-  testthat::expect_equal(whep:::.iso3c_to_area_code("SYR"), 999L)
-  testthat::expect_false(whep:::.unfold_rest_of_world_option())
 })
 
-testthat::test_that("the unfold switch promotes the whole pipeline and warns", {
+testthat::test_that("promotion reaches the whole pipeline, silently by default", {
   testthat::skip_if_not_installed("withr")
-  withr::local_options(whep.unfold_rest_of_world = TRUE)
+  # This asserted a WARNING when promotion happened, because the fold was what
+  # WHEP published. Promotion is now the published shape (#459), so warning on it
+  # would fire on every read of every build. The warning moved to the opposite
+  # case -- re-folding -- and is asserted below.
+  withr::local_options(whep.unfold_rest_of_world = "all")
 
-  testthat::expect_true(whep:::.unfold_rest_of_world_option())
-  testthat::expect_warning(
-    whep:::.polity_crosswalk(),
-    "promoted out of the FABIO"
-  )
+  testthat::expect_equal(whep:::.unfold_rest_of_world_mode(), "all")
+  testthat::expect_no_warning(whep:::.polity_crosswalk())
   cw <- as.data.frame(suppressWarnings(whep:::.polity_crosswalk()))
   members <- suppressWarnings(whep::folded_reporting_areas(
     as.data.frame(whep::polity_area_crosswalk)
@@ -428,10 +481,13 @@ testthat::test_that("the unfold switch can lift only the CBS reporters", {
   testthat::skip_if_not_installed("withr")
   withr::local_options(whep.unfold_rest_of_world = "cbs_reporters")
 
-  testthat::expect_true(whep:::.unfold_rest_of_world_option())
+  # It warns because it is NARROWER than the default: 57 areas that WHEP now
+  # models in their own right get re-folded, so the run does not match the
+  # published series and has to say so.
+  testthat::expect_equal(whep:::.unfold_rest_of_world_mode(), "cbs_reporters")
   testthat::expect_warning(
     whep:::.polity_crosswalk(),
-    "promoted out of the FABIO"
+    "Rest-of-World fold is being applied"
   )
   cw <- as.data.frame(suppressWarnings(whep:::.polity_crosswalk()))
   reporters <- c(153L, 154L, 209L, 212L)

--- a/tests/testthat/test_population.R
+++ b/tests/testthat/test_population.R
@@ -143,6 +143,11 @@ testthat::test_that("missing required columns abort", {
 # to which ISO3 codes land on 999 or 206 has to fail something (#482).
 
 testthat::test_that("the Rest-of-World fold is reported, not silent", {
+  # Scoped to the explicit fold. WHEP now models the reporting members of
+  # bucket 999 in their own right (#459), so there is no Rest-of-World fold
+  # by default; what this pins is the fold behaviour itself, which still has
+  # to work for anyone reproducing a published-before number.
+  withr::local_options(whep.unfold_rest_of_world = "none")
   testthat::expect_message(
     whep::read_population(data = list(gdp_population = .popf_folded())),
     "aggregate"
@@ -159,6 +164,11 @@ testthat::test_that("the Rest-of-World fold is reported, not silent", {
 })
 
 testthat::test_that("the folded rows carry the summed population", {
+  # Scoped to the explicit fold. WHEP now models the reporting members of
+  # bucket 999 in their own right (#459), so there is no Rest-of-World fold
+  # by default; what this pins is the fold behaviour itself, which still has
+  # to work for anyone reproducing a published-before number.
+  withr::local_options(whep.unfold_rest_of_world = "none")
   out <- suppressMessages(
     whep::read_population(data = list(gdp_population = .popf_folded()))
   )
@@ -184,6 +194,11 @@ testthat::test_that("the folded rows carry the summed population", {
 })
 
 testthat::test_that("the fold-bucket summary lists members per bucket", {
+  # Scoped to the explicit fold. WHEP now models the reporting members of
+  # bucket 999 in their own right (#459), so there is no Rest-of-World fold
+  # by default; what this pins is the fold behaviour itself, which still has
+  # to work for anyone reproducing a published-before number.
+  withr::local_options(whep.unfold_rest_of_world = "none")
   parsed <- whep:::.pop_parse(.popf_folded(), NULL)
   folded <- whep:::.pop_folded_buckets(whep:::.pop_folded_cells(parsed))
   testthat::expect_equal(folded$area_code, c(206L, 999L))

--- a/tests/testthat/test_read_raw_inputs.R
+++ b/tests/testthat/test_read_raw_inputs.R
@@ -59,26 +59,25 @@ test_that(".aggregate_to_polities works without fao_flag", {
 test_that("a bucket comes out of the aggregator under exactly one area label", {
   # THE INVARIANT THAT VALUE-NEUTRALITY CHECKS CANNOT SEE (whep#563).
   #
-  # `.aggregate_to_polities()` used to group by `polity_name` as well as
-  # `polity_area_code`, and renames the pair to `area`/`area_code`. So a change
-  # that gives two members of one FABIO bucket different polities split the
-  # bucket's rows WITHOUT moving any value: mass still conserves, the bucket keeps
-  # its members, `polity_area_code` is untouched, and every check anyone thought
-  # to run passes. What breaks is downstream -- `area` is a join key, four inner
-  # joins use `c("area", "area_code")`, and duplicate `(area_code, year, item)`
-  # keys are what fed the `dcast()` `length()` fallback in whep#425.
+  # `.aggregate_to_polities()` renames `polity_area_code`/`polity_name` onto
+  # `area_code`/`area`. A change that gives two members of one bucket different
+  # polities splits the bucket's rows WITHOUT moving a value: mass conserves,
+  # membership is unchanged, `polity_area_code` is untouched, and every check
+  # anyone thought to run passes. What breaks is downstream -- `area` is a join
+  # key, four inner joins use `c("area", "area_code")`, and duplicate
+  # `(area_code, year, item)` keys are what fed the `dcast()` fallback in #425.
   #
-  # PR whep#480 did exactly this and had to be reverted (whep#561): FAOSTAT area
-  # 212 Syria was un-folded onto `SYR-*` while keeping bucket 999, so
-  # `999 Rest of World 340` became `999 Syrian Arab Republic 300` plus
-  # `999 Rest of World 40`. 347 tonnes in, 347 tonnes out, and a split bucket.
-  #
-  # Areas 212 and 999 are the live pair: both carry `polity_area_code` 999 today.
+  # KEYED ON BUCKET 206, not 999. The first version of this guard used areas 212
+  # and 999, and both reviewers of #563 pointed out that it could not fail:
+  # bucket 999's members all resolved to `Rest of World`, so the one bucket that
+  # WAS splitting -- 206, folding Sudan and South Sudan -- went unnoticed while
+  # it corrupted the published production series. 999 is now un-folded outright
+  # (#459), so 206 is both the honest case and the only remaining one.
   raw <- tibble::tribble(
     ~year, ~area_code, ~item_cbs_code, ~element,     ~unit,    ~value,
-    2010L, 212L,       2511,           "production", "tonnes", 300,
-    2010L, 999L,       2511,           "production", "tonnes", 40,
-    2010L, 40L,        2511,           "production", "tonnes", 7
+    2015L, 276L,       2511,           "production", "tonnes", 100,
+    2015L, 277L,       2511,           "production", "tonnes", 25,
+    2015L, 40L,        2511,           "production", "tonnes", 7
   )
 
   out <- suppressWarnings(
@@ -88,15 +87,15 @@ test_that("a bucket comes out of the aggregator under exactly one area label", {
     )
   )
 
-  # One label per bucket. This is the assertion the reverted change failed.
+  # One label per bucket. This is the assertion the reverted #480 failed.
   labels_per_code <- tapply(out$area, out$area_code, function(x) {
     length(unique(x))
   })
   expect_true(all(labels_per_code == 1L))
 
   # And the fold therefore SUMS rather than merely conserving.
-  expect_equal(nrow(out[out$area_code == 999L, ]), 1L)
-  expect_equal(sum(out$value[out$area_code == 999L]), 340)
+  expect_equal(nrow(out[out$area_code == 206L, ]), 1L)
+  expect_equal(sum(out$value[out$area_code == 206L]), 125)
 
   # Mass conservation is asserted too, but note it holds either way -- which is
   # precisely why it is not sufficient on its own.


### PR DESCRIPTION
Closes #459. Also settles #556, and supersedes the sensitivity switch #555 shipped.

## The decision

FABIO folds 61 FAOSTAT reporting areas into a single `Rest of World` column, and `polity_area_code` inherited that fold, so any territory outside FABIO's 192-country layout was published as `ROW`.

**FABIO's layout is a methodology this package compares against, not a constraint on which territories it represents.** The country set is WHEP's own decision.

## The fold was not doing what its name suggests

Of the 61 members, **only about a third report anything at all**. The rest contribute no rows, so folding them is arithmetically a no-op — there is no "aggregating small countries" happening.

Everything the bucket actually carried came from the members that **do** file returns. The fold discarded whose data it was. Syria files its own FAOSTAT production returns and was published as "Rest of World".

That also settles the design question cleanly: **promotion is self-limiting.** An area with no rows is unaffected either way, so `"all"` produces exactly the same output as hand-picking the reporters, and no maintained list is needed.

## Measured

Two full-range `get_wide_cbs()` builds, 1850-2023:

| | fold | un-folded |
|---|---|---|
| published areas | 195 | **216** |
| rows | 2,055,398 | 2,094,408 |
| largest column move | — | **−0.99%** (`stock_addition`) |
| every other column | — | within ±0.4% |

**21 territories become standalone:** Bermuda, Cayman Islands, Cook Islands, Equatorial Guinea, Faroe Islands, French Guiana, Greenland, Guadeloupe, Martinique, New Caledonia, North Macedonia, Niue, Réunion, Eswatini, Syria, Palestine, and five more.

**Bucket 999 survives**, shrinking from 15,507 rows to 516 — a genuine residual for the territories that report nothing, not an empty shell.

## What this does to #556

Dissolved. Those four areas — Syria, Eswatini, North Macedonia, New Caledonia — were marked *both* "reports its own CBS data" *and* "fold into Rest of World". They now take their own codes, so the contradiction has no way to arise.

## The warning follows the default, not the mechanism

It used to fire whenever anything was promoted, because the fold was what WHEP published. Promotion is now what WHEP publishes, so warning on it would fire on every read of every build. It fires on **re-folding** instead — the run that no longer matches the published series.

`options(whep.unfold_rest_of_world = "none")` restores the fold, which is what reproducing a number published before this change requires. The `"successor_state"` folds (Sudan/South Sudan into 206) are untouched by every mode — those are territorial identities, not a FABIO convention, and remain #414's subject.

## Tests: 23 across 11 files, scoped rather than deleted

Most of them describe the fold, and the fold still has to work. They are scoped to `withr::local_options(whep.unfold_rest_of_world = "none")` so the behaviour stays pinned for anyone reproducing older numbers, instead of the knowledge being thrown away.

**The #566 invariant guard is re-keyed from bucket 999 onto 206.** Both reviewers of #563 pointed out it could not fail as written: 999's members all resolved to a single name, so the bucket that *was* splitting went unnoticed while it corrupted the published production series. With 999 un-folded, 206 is both the honest case and the only remaining one. Verified load-bearing rather than assumed — re-introducing the #563 split makes it fail 3 assertions; restoring the fix makes it pass.

Also removed `.unfold_rest_of_world_option()`: dead, and its sense had silently inverted — it meant "un-folding is on, i.e. non-default" and would now be `TRUE` almost always.

## Gates

Full suite **6255 pass, 0 fail, 8 skip**. `lintr`, `air` and the pkgdown index all clean.

## Note on #419

That issue put this change at up to **13.7x** on `feed`. It does not reproduce — the comparison predates the `dcast()` duplicate-key fix (#425/#429), and #555 re-measured it at 1.0000. This PR moves `feed` by 0.08%.

Part of the polity migration epic #458.

🤖 Generated with [Claude Code](https://claude.com/claude-code)