### PR TITLE
perf(soc): spatialize and aggregate one year at a time

### DIFF
--- a/R/soil_carbon_inputs.R
+++ b/R/soil_carbon_inputs.R
@@ -70,20 +70,47 @@ build_soil_carbon_inputs <- function(
   }
   d <- .sci_resolve_inputs(data, years)
   components <- .sci_assemble_components(d$npp, d$manure)
-  gridded <- .sci_to_grid(
-    components,
-    d$country_grid,
-    d$crop_patterns,
-    d$harvested_area
-  )
-  .sci_finalise(gridded, resolution, d$residue_humification) |>
+  .sci_grid_and_finalise(components, d, resolution) |>
     .add_reporting_polity_columns()
 }
 
 # Private helpers ----
 
+# Spatialize and aggregate ONE YEAR AT A TIME, then bind.
+#
+# The spatial weights are time-invariant (crop_patterns has no year), so joining
+# every requested year at once inflates the intermediate by the number of years
+# for no benefit: 2.25e6 cell-crop weights x 3 input types x 123 years is 8.3e8
+# rows, ~49 GB of payload, and dplyr's copies through the join took a 1901-2023
+# run to 89 GB before the kernel killed it (#624). The crop dimension only
+# collapses later in .ci_cropland_class(), so chunking the join alone would not
+# help -- .sci_finalise() has to be inside the loop too, which is why this wraps
+# both.
+#
+# Output is unchanged: `year` is one of the .sci_finalise() grouping keys, so
+# grouping within a year gives exactly what grouping across years gave, and the
+# weights each year sees are identical.
+.sci_grid_and_finalise <- function(components, d, resolution) {
+  weights <- .sci_grid_weights(d$country_grid, d$crop_patterns)
+  # Once, over all components: this reports totals, so warning per year would
+  # both spam the caller and change the numbers it reports.
+  .sci_warn_unspatialized(components, weights)
+
+  # Split ONCE rather than filtering inside the loop. Filtering per year rescans
+  # the whole component table every iteration -- 6.7e6 rows x 123 years is 8.3e8
+  # row-scans for work that one pass does -- so the memory fix would have cost
+  # time. split() keeps it at one pass, and the pieces are what the loop needs.
+  by_year <- split(components, components$year)
+  parts <- lapply(by_year[order(as.integer(names(by_year)))], function(chunk) {
+    chunk |>
+      .sci_join_weights(weights, d$harvested_area) |>
+      .sci_finalise(resolution, d$residue_humification)
+  })
+  dplyr::bind_rows(parts)
+}
+
 # harvested_area is the FAOSTAT national harvested area per (area_code,
-# item_prod_code, year); .sci_to_grid renormalizes each polity-crop-year's
+# item_prod_code, year); .sci_join_weights() renormalizes each polity-crop-year's
 # spatialized cell area so its cell-sum equals this national truth (see there).
 # It is paired with the default NPP reader: the turnkey path derives it from the
 # same get_primary_production() table the NPP chain starts from, while a
@@ -227,14 +254,10 @@ build_soil_carbon_inputs <- function(
 # national density and conserving the polity carbon mass (see
 # .sci_rescale_cell_area). This leaves area_weight, and therefore the cell mass
 # distribution, unchanged.
-.sci_to_grid <- function(
-  components,
-  country_grid,
-  crop_patterns,
-  harvested_area = NULL
-) {
-  cells <- .sci_cell_crop_area(country_grid, crop_patterns)
-  weights <- cells |>
+# The per-cell share of each polity-crop's area. Time-invariant, so it is built
+# once and reused for every year (see .sci_grid_and_finalise()).
+.sci_grid_weights <- function(country_grid, crop_patterns) {
+  .sci_cell_crop_area(country_grid, crop_patterns) |>
     # Zero, missing and non-finite harvested areas provide no spatial support.
     # Keeping a zero-only group here would divide 0 by 0 and silently turn its
     # carbon mass into NaN; dropping it lets .sci_warn_unspatialized() report
@@ -248,7 +271,10 @@ build_soil_carbon_inputs <- function(
         sum(.data$crop_area_ha),
       .by = c("area_code", "item_prod_code")
     )
-  .sci_warn_unspatialized(components, weights)
+}
+
+# Fan one year's polity-crop components out onto that polity-crop's cells.
+.sci_join_weights <- function(components, weights, harvested_area = NULL) {
   components |>
     dplyr::inner_join(
       weights,
@@ -502,7 +528,7 @@ build_soil_carbon_inputs <- function(
 }
 
 # FAOSTAT national harvested area (ha) per (area_code, item_prod_code, year),
-# the truth .sci_to_grid renormalizes the spatialized cell area to. Read from
+# the truth .sci_join_weights() renormalizes the spatialized cell area to. Read from
 # the same get_primary_production() table the NPP chain starts from, filtered to
 # crop harvested-area rows (grassland and livestock dropped, matching
 # .sci_crop_prod_wide). One table serves every input_type (residue/root/weed and
@@ -635,7 +661,7 @@ build_soil_carbon_inputs <- function(
 # it resolves straight back through .sci_manure_crop_prod_code();
 # manure_n_receptivity is the harvested area, so collected manure is spread
 # across a polity's crops in proportion to each crop's area (the same basis
-# .sci_to_grid re-grids by); the fixed_ceiling cap needs only crop_area_ha.
+# .sci_join_weights() re-grids by); the fixed_ceiling cap needs only crop_area_ha.
 # Grassland and livestock rows are excluded, matching .sci_crop_prod_wide().
 .sci_manure_crop_layer <- function(production) {
   grass <- c(3000L, 3002L, 3003L)


### PR DESCRIPTION
Addresses #624. **Makes long spans possible, not faster** — stating that up front
because the `perf` prefix invites the wrong expectation.

## The problem

`build_carbon_balance(years = 1901:2023)` — the production configuration — reached
**89.3 GB** and was OOM-killed. 1961–2023 was killed too.

A dimension mismatch in the spatialization: `components` carry a `year`, the
weights from `crop_patterns` do not (that raster is time-invariant). So the
many-to-many join replicated the same **2.25 M cell-crop weights across every
requested year simultaneously**:

| span | fan-out rows | payload |
|---|---|---|
| 1 year | 6.7 M | ~0.4 GB |
| 123 years | **829 M** | **~49 GB** |

## The change

Chunked per year, with four details that matter:

- **The chunk wraps the join *and* `.sci_finalise()`.** Chunking the join alone
  would not help — `.sci_finalise()` collapses only `input_type` and keeps the crop
  dimension, so its output is still cell × crop × year and the caller receives an
  O(years) table regardless. The crop dimension only collapses later, in
  `.ci_cropland_class()`.
- Weights built **once**, not per year.
- `.sci_warn_unspatialized()` stays **outside** the loop: it reports totals, so
  warning per year would spam the caller *and* change the reported numbers.
- Components are `split()` once, not filtered per year. Filtering inside the loop
  rescans the whole table every iteration — 829 M row-scans where one pass does
  6.7 M — so the memory fix would have cost time.

## Verified identical, not assumed

Same 3-year span through old and new in separate processes:

| | rows | columns | max abs diff (11 numeric cols) |
|---|---|---|---|
| old vs new | 4,861,893 both | identical | **0** |

66 unit tests pass, `lint_package()` clean.

## What this does not do

**Not a speed-up.** 3 years: 7.7 min chunked vs 7.4 min unchunked.

**Does not touch the fixed floor.** At 3 years the fan-out payload is ~1.2 GB while
peak RSS is 29.4 GB — the rest is `build_primary_production()` +
`build_commodity_balances()`. So the profile is roughly:

```
peak ~ 29 GB floor (input chain)  +  ~0.4 GB per year of fan-out
```

This removes the second term only. **Whether that is enough for 1901–2023 is
untested**, because no long run has completed yet. If the floor turns out to grow
with span, this is necessary but not sufficient and the floor needs its own issue.

Separately, profiling suggests the *runtime* cost of a long span is the
`build_carbon_balance` march (~1.5 min/year), which this does not address either.
That is being measured now.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TvvcyfcfaSxW9pywZsdvAY
