### PR TITLE
fix(production): split livestock stocks on the area code, not the label (#589)

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,24 @@
 # whep (development version)
 
+* **Livestock stocks are split on the area CODE, not the area label (#589).**
+  `.split_stock_share()` divides a parent item's production across its sub-items
+  in proportion to their stocks, grouped by `(year, area, item_prod_code)`. When
+  several reporting areas share one label the group spans all of them, the share
+  denominator sums across areas, and each area keeps only its own fraction.
+  That became live when the Rest-of-World fold was lifted: `.unfold_rest_of_world()`
+  promotes `polity_area_code` but leaves `polity_code`/`polity_name` alone, so all
+  13 reporting members came out with their own `area_code` and the shared label
+  `"Rest of World"`. Measured: Syria's 2000 livestock read **3,408,857** head
+  against **38,048,415** after the fix, with fractional animals (`1227745.45`) as
+  the visible symptom of a share that should have been 1. `slaughtered_heads` was
+  never affected, because it does not pass through this splitter — which is what
+  made the defect look like a unit-conversion bug.
+
+  The stock join, the carry-forward and the row-count grouping are re-keyed the
+  same way. Globally this moves `heads` **+0.22%** and `LU` +0.13%; `ha`,
+  `tonnes` and `slaughtered_heads` are bit-identical, because only areas sharing
+  a label were ever affected.
+
 * **`fill_linear()` no longer depends on the order its rows arrive in.** Without
   `.by`, it never sorted: carrying a value forward or backward and the
   `value_smooth_window` moving average are all positional, so an unsorted input

--- a/R/build_production.R
+++ b/R/build_production.R
@@ -1128,12 +1128,12 @@ build_primary_production <- function(
         ) |>
         dplyr::select(
           year,
-          area,
+          area_code,
           item_cbs_code,
           item_st,
           value_st
         ),
-      by = c("year", "area", "item_cbs_code")
+      by = c("year", "area_code", "item_cbs_code")
     ) |>
     # Carry value_st forward (and back) in time per (area, item_cbs_code)
     # so years that fall outside the faostat-emissions-livestock pin's
@@ -1146,13 +1146,13 @@ build_primary_production <- function(
     fill_linear(
       value_st,
       time_col = year,
-      .by = c("area", "item_cbs_code")
+      .by = c("area_code", "item_cbs_code")
     ) |>
     .split_stock_share() |>
     dplyr::filter(!is.na(area_code)) |>
     dplyr::mutate(
       n = dplyr::n(),
-      .by = c(area, item_cbs, item_cbs_code)
+      .by = c(area_code, item_cbs, item_cbs_code)
     ) |>
     tidyr::complete(
       year,
@@ -1224,7 +1224,7 @@ build_primary_production <- function(
         1 / dplyr::n()
       ),
       value_comb = value * share,
-      .by = c(year, area, item_prod_code)
+      .by = c(year, area_code, item_prod_code)
     ) |>
     dplyr::select(-sum_value_st, -share)
 }

--- a/tests/testthat/test_build_production.R
+++ b/tests/testthat/test_build_production.R
@@ -807,9 +807,9 @@ test_that("build_primary_production output has no duplicate keys", {
 
 test_that(".split_stock_share splits proportionally when both sub-items have data", {
   data <- tibble::tribble(
-    ~year, ~area, ~item_prod_code, ~value, ~value_st,
-    2000, "A", "866", 100, 30,
-    2000, "A", "866", 100, 70
+    ~year, ~area_code, ~item_prod_code, ~value, ~value_st,
+    2000, 1L, "866", 100, 30,
+    2000, 1L, "866", 100, 70
   )
 
   result <- .split_stock_share(data)
@@ -826,9 +826,9 @@ test_that(".split_stock_share does not double-count when one sub-item is entirel
   # NA sub-item made the whole group's share NA, and BOTH sub-rows fell back
   # to the full unsplit `value` -- doubling the country's herd count.
   data <- tibble::tribble(
-    ~year, ~area, ~item_prod_code, ~value, ~value_st,
-    2000, "A", "866", 100, NA_real_,
-    2000, "A", "866", 100, 40
+    ~year, ~area_code, ~item_prod_code, ~value, ~value_st,
+    2000, 1L, "866", 100, NA_real_,
+    2000, 1L, "866", 100, 40
   )
 
   result <- .split_stock_share(data)
@@ -844,10 +844,10 @@ test_that(".split_stock_share splits equally when every sub-item is NA", {
   # every sub-item the full total) is the only way to keep the total heads
   # conserved without an arbitrary preference for one sub-item.
   data <- tibble::tribble(
-    ~year, ~area, ~item_prod_code, ~value, ~value_st,
-    2000, "A", "866", 90, NA_real_,
-    2000, "A", "866", 90, NA_real_,
-    2000, "A", "866", 90, NA_real_
+    ~year, ~area_code, ~item_prod_code, ~value, ~value_st,
+    2000, 1L, "866", 90, NA_real_,
+    2000, 1L, "866", 90, NA_real_,
+    2000, 1L, "866", 90, NA_real_
   )
 
   result <- .split_stock_share(data)
@@ -861,25 +861,25 @@ test_that(".split_stock_share keeps the full value for a single-item group", {
   # non-dairy-style split) should always receive the whole unsplit value,
   # whether or not it happens to have its own value_st.
   with_data <- tibble::tribble(
-    ~year, ~area, ~item_prod_code, ~value, ~value_st,
-    2000, "A", "976", 50, 12
+    ~year, ~area_code, ~item_prod_code, ~value, ~value_st,
+    2000, 1L, "976", 50, 12
   )
   without_data <- tibble::tribble(
-    ~year, ~area, ~item_prod_code, ~value, ~value_st,
-    2000, "A", "976", 50, NA_real_
+    ~year, ~area_code, ~item_prod_code, ~value, ~value_st,
+    2000, 1L, "976", 50, NA_real_
   )
 
   expect_equal(.split_stock_share(with_data)$value_comb, 50)
   expect_equal(.split_stock_share(without_data)$value_comb, 50)
 })
 
-test_that(".split_stock_share keeps groups (year, area, item_prod_code) independent", {
+test_that(".split_stock_share keeps groups (year, area_code, item_prod_code) independent", {
   data <- tibble::tribble(
-    ~year, ~area, ~item_prod_code, ~value, ~value_st,
-    2000, "A", "866", 100, NA_real_,
-    2000, "A", "866", 100, 60,
-    2000, "B", "866", 200, 10,
-    2000, "B", "866", 200, 30
+    ~year, ~area_code, ~item_prod_code, ~value, ~value_st,
+    2000, 1L, "866", 100, NA_real_,
+    2000, 1L, "866", 100, 60,
+    2000, 2L, "866", 200, 10,
+    2000, 2L, "866", 200, 30
   )
 
   result <- .split_stock_share(data)
@@ -1003,4 +1003,36 @@ test_that(".fodder_crop_liv ignores NA years when comparing spans", {
     whep:::.fodder_crop_liv(spanning, i_fodder),
     spanning
   )
+})
+
+test_that(".split_stock_share keys on the code, so a shared label cannot dilute", {
+  # THE #589 REGRESSION, in one fixture.
+  #
+  # `.unfold_rest_of_world()` promotes `polity_area_code` but leaves
+  # `polity_code`/`polity_name` alone, so every promoted Rest-of-World member
+  # comes out of `.aggregate_to_polities()` with its own `area_code` and the
+  # SHARED label "Rest of World". Grouped by `area`, all 13 reporting members
+  # landed in one group, `sum(value_st)` summed across all of them, and each
+  # member's share collapsed to roughly 1/13 of its own stock.
+  #
+  # Measured before this fix: Syria's 2000 livestock came to 3,408,857 head
+  # against 38,048,415 after, and the published values carried fractional
+  # animals (1227745.45) -- the signature of a share that should have been 1.
+  # `slaughtered_heads` was unaffected throughout, because it never passes
+  # through this splitter, which is what made the defect look like a unit bug.
+  #
+  # Two areas, same label, one parent item: if the grouping keys on the label
+  # each gets half its own value; on the code each keeps all of it.
+  data <- tibble::tribble(
+    ~year, ~area_code, ~area, ~item_prod_code, ~value, ~value_st,
+    2000, 212L, "Rest of World", "976", 100, 40,
+    2000, 64L, "Rest of World", "976", 60, 60
+  )
+
+  result <- .split_stock_share(data)
+
+  expect_equal(result$value_comb, c(100, 60))
+  expect_equal(sum(result$value_comb), 160)
+  # Whole numbers: a single-member group has share 1, never 1/n.
+  expect_equal(result$value_comb, round(result$value_comb))
 })


### PR DESCRIPTION
Closes #589. **This is a live defect on `main`**, introduced by #628 lifting the Rest-of-World fold — my merge, and #589 predicted it.

## What was wrong

`.split_stock_share()` divides a parent item's production across its sub-items in proportion to their stocks:

```r
share = value_st / sum(value_st),   .by = c(year, area, item_prod_code)
value_comb = value * share
```

It groups on **`area`** — the polity *label*. When several reporting areas share one label, the group spans all of them, the denominator sums across areas, and each area keeps only its own fraction of its own value.

That became live with #628. `.unfold_rest_of_world()` promotes `polity_area_code` but leaves `polity_code`/`polity_name` untouched, so all 13 reporting members came out of `.aggregate_to_polities()` with **their own `area_code` and the shared label `"Rest of World"`** — one group, share diluted to roughly 1/13.

## Evidence, measured before the change

Syria, year 2000, published livestock:

| | head |
|---|---|
| raw FAOSTAT (poultry `1000 An` converted) | ~38 M |
| `main` today | **3,408,857** |
| this PR | **38,048,415** |

The published values on `main` carry **fractional animals** — `1227745.45`, `1087956.19` — which is the visible signature of a share that should have been `1`. After the fix they are whole numbers matching the source to the unit: sheep 13,505,200, poultry 14,176,000.

`slaughtered_heads` conserved perfectly (ratio 1.0000) throughout, because it never passes through this splitter. That is exactly what made the defect look like a unit-conversion bug rather than a grouping one — and it is why I ruled the `1000 An` conversion out early: both conversion sites are identical and fold-independent.

## Global effect

| unit | change |
|---|---|
| `heads` | **+0.22%** |
| `LU` | +0.13% |
| `ha`, `tonnes`, `slaughtered_heads` | **bit-identical** |

Only areas that shared a label were ever affected, so everything else is untouched.

## What changed

Four sites re-keyed from `area` onto `area_code`: the stock `full_join`, the `value_st` carry-forward, the share denominator, and the row-count grouping. The stocks side of the join now carries `area_code` instead of `area`.

This is #170's pattern — a join on a name where an integer code was available.

## The regression test is verified, not assumed

Two areas under one label, one parent item. Reverting the grouping key makes it fail (2 failures, 5 errors); restoring it makes it pass. A guard that cannot fail on the bug it exists for is decoration, and this is the third such case found in this epic.

Full suite **6357 pass, 0 fail**; `lintr` and `air` clean.

## Note

#589 also reported `tonnes` at 0.59 and `ha` at 2.38 between folded and un-folded. Those are not addressed here and are not the same defect — they come from the fold changing which rows exist, not from the share denominator. Worth re-measuring against this fix before deciding whether anything remains.

Part of the polity migration epic #458.

🤖 Generated with [Claude Code](https://claude.com/claude-code)