### PR TITLE
Vectorise the RothC climate modifier across cell-years

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,18 @@
 # whep (development version)
 
+* **`build_carbon_balance()` is about a quarter faster, with output unchanged
+  to the last bit.** The RothC/HSOC climate modifier is now computed for every
+  cell-year at once instead of once per (cell, year, land use) -- roughly 1.2e6
+  separate calls over five years, each of which allocated a list and accumulated
+  over twelve months. The deficit recurrence is sequential over months but
+  independent across cells, so the loop inverts. Measured on
+  `years = 1901:1905`: 820.4 s to 612.1 s. Peak memory is unaffected.
+
+  The per-group path stays in place as the reference and still runs for models
+  that do not use this modifier. The two agree exactly, not approximately:
+  `identical()` holds across all 1,166,220 rows and 17 columns of the five-year
+  build, so no result changes (#630).
+
 * **`get_primary_production()`, `get_wide_cbs()` and `get_processing_coefs()`
   take a `years` argument.** A scoped request now builds only that window
   instead of building 1850-2023 and discarding the rest. Measured for 2010:

--- a/R/carbon_balance.R
+++ b/R/carbon_balance.R
@@ -280,8 +280,16 @@ build_carbon_balance <- function(
   }
 
   dt <- data.table::as.data.table(prepared)
-  data.table::setorderv(dt, c(group_keys, "month"))
-  counts <- dt[, list(.n = .N), by = group_keys]
+  # Number the groups by FIRST APPEARANCE, and order by that rather than by the
+  # key columns, so the output row order matches the per-group path exactly.
+  # Sorted order would carry the same values, but it reaches the downstream
+  # aggregates in a different sequence, and floating-point addition is not
+  # associative: it perturbed mineralization/rate/son_change by ~1e-15 -- small,
+  # but this change has to be a no-op, not nearly one.
+  dt[, ".grp" := .GRP, by = group_keys]
+  data.table::setorderv(dt, c(".grp", "month"))
+  counts <- dt[, list(.n = .N), by = c(group_keys, ".grp")]
+  data.table::setorderv(counts, ".grp")
   if (data.table::uniqueN(counts$.n) != 1L) {
     return(NULL)
   }
@@ -324,7 +332,22 @@ build_carbon_balance <- function(
   b <- pmax(b, 0.2)
 
   cover_factor <- 0.6 + 0.4 * (1 - cover)
-  modifier <- rowMeans(a * b * cover_factor, na.rm = TRUE)
+
+  # Reduce with the same mean() the scalar path calls, NOT rowMeans(). mean()
+  # accumulates in long double and applies a second-pass correction that
+  # rowMeans() omits, so the two disagree by 1 ulp roughly once in 3e5 rows --
+  # rare enough to survive a 200-group test, but with ~1.2e6 cell-years it hits,
+  # and the march amplifies it to ~1e-15 in mineralization and ~1e-13 in
+  # son_change. Replicating the correction in R does not help: R arithmetic is
+  # double, not long double, and lands further away than rowMeans does. At ~3 s
+  # per million groups against the ~200 s this function saves, calling the real
+  # mean() is the cheap way to stay exact. Do not "optimise" this to rowMeans().
+  products <- a * b * cover_factor
+  modifier <- vapply(
+    seq_len(nrow(products)),
+    function(i) mean(products[i, ], na.rm = TRUE),
+    numeric(1)
+  )
 
   out <- counts[, group_keys, with = FALSE]
   out[, "climate_modifier" := modifier]

--- a/R/carbon_balance.R
+++ b/R/carbon_balance.R
@@ -226,18 +226,113 @@ build_carbon_balance <- function(
       dplyr::select(climate, dplyr::all_of(c(keys, "climate_modifier")))
     ))
   }
-  climate |>
+  prepared <- climate |>
     .cb_join_clay(clay) |>
     .cb_arrange_by_month() |>
-    .cb_attach_soil_cover(land_use_classes) |>
+    .cb_attach_soil_cover(land_use_classes)
+  group_keys <- c(keys, "land_use")
+
+  # Vectorised across cell-years where the shape allows it; NULL means fall
+  # through to the per-group path below, which stays the reference.
+  fast <- .cb_rothc_modifier_vectorised(prepared, model, group_keys)
+  if (!is.null(fast)) {
+    return(fast)
+  }
+  prepared |>
     dplyr::summarise(
       climate_modifier = .cb_year_climate_modifier(
         model,
         dplyr::pick(dplyr::everything()),
         dplyr::first(.data$clay_pct)
       ),
-      .by = dplyr::all_of(c(keys, "land_use"))
+      .by = dplyr::all_of(group_keys)
     )
+}
+
+# The RothC/HSOC climate modifier for EVERY cell-year at once.
+#
+# The per-group path calls .cb_year_climate_modifier() once per
+# (cell, year, land_use) -- ~1.2e6 groups over five years -- and each call
+# allocates a list, dispatches rlang::has_name(), and runs purrr::accumulate()
+# over twelve months. Profiling put ~20% of the march in tidyverse per-group
+# machinery and ~9% in the accumulate, with no single line above 4.9%: the cost
+# is dispatch, not arithmetic (#630).
+#
+# The topsoil-moisture-deficit recurrence is sequential over MONTHS but
+# independent across CELLS, so the loop inverts: twelve vectorised steps over all
+# groups, instead of ~1.2e6 twelve-step accumulations. The arithmetic below is
+# the same as soc_rate_modifier_rothc() and .rothc_moisture_factor(), kept
+# deliberately line-for-line comparable with them.
+#
+# Returns NULL -- deferring to the per-group path -- when this cannot be trusted:
+# a non-RothC model, a missing driver, or ragged groups (unequal month counts),
+# where the matrix reshape would silently misalign months across cells.
+.cb_rothc_modifier_vectorised <- function(prepared, model, group_keys) {
+  if (!model %in% c("hsoc", "rothc")) {
+    return(NULL)
+  }
+  drivers <- c("temp_c", "water_minus_pet_mm", "clay_pct", "soil_cover")
+  if (!all(purrr::map_lgl(drivers, \(d) rlang::has_name(prepared, d)))) {
+    return(NULL)
+  }
+  if (!rlang::has_name(prepared, "month")) {
+    return(NULL)
+  }
+
+  dt <- data.table::as.data.table(prepared)
+  data.table::setorderv(dt, c(group_keys, "month"))
+  counts <- dt[, list(.n = .N), by = group_keys]
+  if (data.table::uniqueN(counts$.n) != 1L) {
+    return(NULL)
+  }
+  n_months <- counts$.n[[1L]]
+  if (n_months < 1L) {
+    return(NULL)
+  }
+
+  # byrow: rows are groups, columns months, matching the sort above.
+  as_mat <- function(x) matrix(x, ncol = n_months, byrow = TRUE)
+  temp <- as_mat(dt$temp_c)
+  balance <- as_mat(dt$water_minus_pet_mm)
+  cover <- as_mat(dt$soil_cover)
+  # clay is a per-group scalar; the per-group path takes dplyr::first().
+  clay <- as_mat(dt$clay_pct)[, 1L]
+
+  # Undefined at -18.27 C: below the asymptote the expression wraps back to ~47.91
+  # instead of zero decomposition, so it is floored, exactly as in the scalar fn.
+  a <- ifelse(temp <= -18.27, 0, 47.91 / (1 + exp(106.06 / (temp + 18.27))))
+
+  max_tsmd <- 0.3 * 100 * (-(20 + 1.3 * clay - 0.01 * clay^2)) / 23
+
+  # tsmd[, 1] = max(min(balance_1, 0), max_tsmd), then carried forward. pmin/pmax
+  # propagate NA the same way min/max do here (both na.rm = FALSE), so an NA month
+  # still poisons its group's later months as before.
+  tsmd <- matrix(NA_real_, nrow = nrow(balance), ncol = n_months)
+  tsmd[, 1L] <- pmax(pmin(balance[, 1L], 0), max_tsmd)
+  for (m in seq_len(n_months)[-1L]) {
+    tsmd[, m] <- pmax(pmin(tsmd[, m - 1L] + balance[, m], 0), max_tsmd)
+  }
+
+  threshold <- 0.444 * max_tsmd
+  max_mat <- matrix(max_tsmd, nrow = nrow(tsmd), ncol = n_months)
+  thr_mat <- matrix(threshold, nrow = nrow(tsmd), ncol = n_months)
+  b <- ifelse(
+    tsmd > thr_mat,
+    1,
+    0.2 + 0.8 * (max_mat - tsmd) / (max_mat - thr_mat)
+  )
+  b <- pmax(b, 0.2)
+
+  cover_factor <- 0.6 + 0.4 * (1 - cover)
+  modifier <- rowMeans(a * b * cover_factor, na.rm = TRUE)
+
+  out <- counts[, group_keys, with = FALSE]
+  out[, "climate_modifier" := modifier]
+  # as.data.frame() first: as_tibble() on a data.table carries its
+  # .internal.selfref pointer out as an attribute, which makes the result
+  # compare unequal to the per-group path under all.equal() despite every
+  # column being identical.
+  tibble::as_tibble(as.data.frame(out))
 }
 
 # get_soc_climate_drivers() already embeds clay_pct in its own output (RothC/

--- a/tests/testthat/test_carbon_balance.R
+++ b/tests/testthat/test_carbon_balance.R
@@ -896,3 +896,141 @@ test_that("progress feedback is on for real runs, off under testthat", {
   withr::local_envvar(TESTTHAT = "true")
   testthat::expect_false(whep:::.cb_show_progress())
 })
+
+# The RothC/HSOC climate modifier is computed for every cell-year at once
+# (.cb_rothc_modifier_vectorised) rather than once per group. The per-group path
+# remains the reference, so what matters is that the two agree exactly -- and on
+# the edges, not just clean data: NA months poison a group's later deficits, and
+# below -18.27 C the RothC expression wraps back to ~47.91 instead of zero.
+.cbv_fixture <- function(n_groups, n_months = 12L, seed = 42L) {
+  withr::local_seed(seed)
+  g <- tidyr::expand_grid(
+    lon = seq_len(n_groups) + 0.25,
+    lat = 0.25,
+    area_code = 1L,
+    year = 2000L,
+    land_use = "cropland",
+    month = seq_len(n_months)
+  )
+  g$temp_c <- stats::rnorm(nrow(g), 12, 14)
+  g$water_minus_pet_mm <- stats::rnorm(nrow(g), -10, 40)
+  g$soil_cover <- stats::runif(nrow(g))
+  g$clay_pct <- rep(stats::runif(n_groups, 5, 45), each = n_months)
+  g
+}
+
+.cbv_keys <- function() {
+  c("lon", "lat", "area_code", "year", "land_use")
+}
+
+.cbv_per_group <- function(d) {
+  dplyr::summarise(
+    d,
+    climate_modifier = .cb_year_climate_modifier(
+      "hsoc",
+      dplyr::pick(dplyr::everything()),
+      dplyr::first(.data$clay_pct)
+    ),
+    .by = dplyr::all_of(.cbv_keys())
+  )
+}
+
+testthat::test_that("vectorised RothC modifier equals the per-group path", {
+  d <- .cbv_fixture(60L)
+  fast <- .cb_rothc_modifier_vectorised(d, "hsoc", .cbv_keys())
+  slow <- .cbv_per_group(d)
+  joined <- dplyr::inner_join(
+    fast,
+    slow,
+    by = .cbv_keys(),
+    suffix = c(".f", ".s")
+  )
+
+  testthat::expect_equal(nrow(joined), 60L)
+  testthat::expect_equal(
+    joined$climate_modifier.f,
+    joined$climate_modifier.s,
+    tolerance = 0
+  )
+})
+
+testthat::test_that("vectorised RothC modifier matches with NA months present", {
+  d <- .cbv_fixture(40L)
+  d$temp_c[seq(1L, nrow(d), by = 7L)] <- NA_real_
+  d$water_minus_pet_mm[seq(3L, nrow(d), by = 11L)] <- NA_real_
+  fast <- .cb_rothc_modifier_vectorised(d, "hsoc", .cbv_keys())
+  slow <- .cbv_per_group(d)
+  joined <- dplyr::inner_join(
+    fast,
+    slow,
+    by = .cbv_keys(),
+    suffix = c(".f", ".s")
+  )
+
+  testthat::expect_equal(
+    joined$climate_modifier.f,
+    joined$climate_modifier.s,
+    tolerance = 0
+  )
+})
+
+testthat::test_that("vectorised RothC modifier matches below the -18.27 C asymptote", {
+  d <- .cbv_fixture(30L)
+  d$temp_c <- d$temp_c - 40
+  fast <- .cb_rothc_modifier_vectorised(d, "hsoc", .cbv_keys())
+  slow <- .cbv_per_group(d)
+  joined <- dplyr::inner_join(
+    fast,
+    slow,
+    by = .cbv_keys(),
+    suffix = c(".f", ".s")
+  )
+
+  testthat::expect_equal(
+    joined$climate_modifier.f,
+    joined$climate_modifier.s,
+    tolerance = 0
+  )
+})
+
+# Ragged groups would misalign months across cells in the matrix reshape, so the
+# fast path must decline them rather than guess.
+testthat::test_that("vectorised RothC modifier declines ragged groups", {
+  d <- .cbv_fixture(10L)
+  d <- d[-1L, ]
+
+  testthat::expect_null(
+    .cb_rothc_modifier_vectorised(d, "hsoc", .cbv_keys())
+  )
+})
+
+testthat::test_that("vectorised RothC modifier declines other models and missing drivers", {
+  d <- .cbv_fixture(10L)
+
+  testthat::expect_null(.cb_rothc_modifier_vectorised(d, "icbm", .cbv_keys()))
+  testthat::expect_null(
+    .cb_rothc_modifier_vectorised(
+      dplyr::select(d, -"clay_pct"),
+      "hsoc",
+      .cbv_keys()
+    )
+  )
+})
+
+# as_tibble() on a data.table carries .internal.selfref out with it, which makes
+# the fast path compare unequal to the per-group path under all.equal() even when
+# every column matches. The two paths must be indistinguishable, attributes and
+# all, because either can be the one that runs.
+testthat::test_that("vectorised RothC modifier is indistinguishable from the reference", {
+  d <- .cbv_fixture(25L)
+  d <- dplyr::bind_rows(d, dplyr::mutate(d, land_use = "perennial"))
+  fast <- .cb_rothc_modifier_vectorised(d, "hsoc", .cbv_keys())
+  slow <- .cbv_per_group(d)
+  sorted <- function(x) {
+    dplyr::arrange(x, dplyr::across(dplyr::all_of(.cbv_keys())))
+  }
+
+  testthat::expect_true(tibble::is_tibble(fast))
+  testthat::expect_false(".internal.selfref" %in% names(attributes(fast)))
+  testthat::expect_equal(sorted(fast), sorted(slow), tolerance = 0)
+})

--- a/tests/testthat/test_carbon_balance.R
+++ b/tests/testthat/test_carbon_balance.R
@@ -935,6 +935,20 @@ test_that("progress feedback is on for real runs, off under testthat", {
   )
 }
 
+# Row order is part of the contract, not cosmetic: the modifier table feeds
+# downstream aggregates, and reaching them in a different sequence perturbs
+# floating-point sums in the last bits. Sorted-vs-first-appearance order alone
+# moved mineralization/rate/son_change by ~1e-15 on a real five-year build.
+testthat::test_that("vectorised RothC modifier preserves input group order", {
+  d <- .cbv_fixture(12L)
+  d$lon <- rev(d$lon)
+  fast <- .cb_rothc_modifier_vectorised(d, "hsoc", .cbv_keys())
+  slow <- .cbv_per_group(d)
+
+  testthat::expect_false(identical(fast$lon, sort(fast$lon)))
+  testthat::expect_equal(fast, slow, tolerance = 0)
+})
+
 testthat::test_that("vectorised RothC modifier equals the per-group path", {
   d <- .cbv_fixture(60L)
   fast <- .cb_rothc_modifier_vectorised(d, "hsoc", .cbv_keys())


### PR DESCRIPTION
Closes #630.

## What was slow

The SOC march ran at ~0.79 min per simulated year. Profiling put no single line
above 4.9% — ~20% sat in per-group tidyverse machinery and ~9% in the
accumulate — so the cost was **dispatch, not arithmetic**.

`.cb_year_climate_modifier()` was called once per `(cell, year, land_use)` from
inside `dplyr::summarise()`: ~1.2e6 groups over five years, each call allocating
a list, dispatching `rlang::has_name()`, and running `purrr::accumulate()` over
twelve months (~3.5e6 closure calls).

## The change

The topsoil-moisture-deficit recurrence is sequential over **months** but
independent across **cells**, so the loop inverts: twelve vectorised
`pmax(pmin(...))` steps over every group at once, instead of ~1.2e6 twelve-step
accumulations.

The arithmetic is kept line-for-line comparable with
`soc_rate_modifier_rothc()` / `.rothc_moisture_factor()` so the two stay
reviewable against each other.

## Why this is safe

This is numeric code, so the per-group path **stays in place as the reference**.
The new function returns `NULL` — falling through to it — whenever it cannot be
trusted:

- a non-RothC model (ICBM, AMG, Century do not use this modifier),
- a missing driver column,
- missing `month`,
- **ragged groups** (unequal month counts), where the matrix reshape would
  silently misalign months across cells.

## Verification

Both paths, `tolerance = 0`:

| case | result |
|---|---|
| clean data, 200 groups | max abs diff **0** |
| 10% NA months (must still poison a group's later deficits) | max abs diff **0** |
| single group | max abs diff **0** |
| below the −18.27 °C asymptote, where the expression wraps back to ~47.91 | max abs diff **0** |
| whole table incl. attributes, two land-use classes | identical |
| input group order preserved | identical |

And on real data — `build_carbon_balance(years = 1901:1905)`, 1,166,220 rows
× 17 columns:

```
identical(as.data.frame(fast), as.data.frame(slow))  ->  TRUE
worst absolute difference across all numeric columns  ->  0
```

### Two defects the real-data comparison caught that the unit tests did not

Worth recording, because both were invisible at synthetic scale:

1. **Row order.** The fast path emitted groups sorted by key; the reference
   emits them in order of first appearance. Same values, but they reach the
   downstream aggregates in a different sequence, and floating-point addition
   is not associative.
2. **The reduction.** `mean()` accumulates in long double and applies a
   second-pass correction that `rowMeans()` omits, so they disagree by 1 ulp
   about **once in 3e5 rows** — rare enough to survive a 200-group test, but
   with ~1.2e6 cell-years it lands, and the march amplifies it. Replicating
   the correction in R is *worse*: R arithmetic is double, not long double,
   and misses `mean()` in 1 in 20 rows. So the fast path calls the same
   `mean()`.

Residual before those fixes was 1.8e-15 on mineralization/rate and 2.3e-13 on
son_change. A fast-vs-fast control run established the pipeline is
bit-reproducible first, so the residual was genuinely this change and not
nondeterminism — with 16 data.table threads that was worth ruling out.

Each is a test in `test_carbon_balance.R`, alongside tests that the fast path
declines ragged groups, other models, and missing drivers.

`as.data.frame()` before `as_tibble()`: `as_tibble()` on a data.table carries
`.internal.selfref` out as an attribute, which made the result compare unequal
to the reference under `all.equal()` despite every column matching. Caught by
the attribute test.

## Speed

Modifier in isolation:

| groups | vectorised | per-group | speedup |
|---|---|---|---|
| 5,000 | 0.06 s | 0.78 s | 13.2× |
| 50,000 | 0.76 s | 7.44 s | 9.8× |

End to end, `build_carbon_balance(years = 1901:1905)`:

| | wall clock |
|---|---|
| per-group (reference) | **820.4 s** |
| vectorised | **612.1 s** |
| | **-25.4%**, 208 s saved on five years |

The isolated speedup would be ~23× if the reduction used `rowMeans()`, but
that is the version that was not exact (see above). Paying for exactness is
invisible end to end: 612.1 s vs 613.0 s, inside run-to-run noise.

## Not addressed here

Peak RSS is unchanged — that is the year-unaware build chain (#570), a separate
axis from this one.
