### PR TITLE
fix(energy): price the dissolved federations from the membership they held

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,29 @@
 # whep (development version)
 
+* **`build_energy_co2_extension(unclassified = "historical_region")` prices the
+  dissolved federations instead of losing them (#553).** Measured on the real
+  `get_primary_production()` output (6,305,656 rows, 1850-2023), 569.4 Mt of
+  meat carcass production — 3.33% of all of it, and 15.2% of the world's 1961
+  tonnage — gets no energy intensity and leaves the extension, because
+  `gleam_geographic_hierarchy` is a present-day country table with no row for
+  the USSR, Belgium-Luxembourg, Czechoslovakia, the Yugoslav SFR or Serbia and
+  Montenegro. Those five are now 99.998% of the loss: since the Rest-of-World
+  fold was lifted (#628) bucket 999 no longer contributes to it at all. The new
+  treatment groups them by running GLEAM's own scheme rules on the OECD and EU
+  membership they themselves held while they existed — Belgium and Luxembourg
+  were OECD founding members and EEC founders, so Belgium-Luxembourg is OECD/EU
+  27; no successor of the other four was in either body before the entity
+  dissolved, so they are non-OECD, non-EU. Rows carry
+  `method_energy = "GLEAM_3.0_energy_meat_historical_region"`, and the option
+  is a superset of `"polity_region"`.
+
+  **No published value changes**: the default `unclassified = "drop"` is
+  bit-identical on the full real input (181,831 rows, `sum(impact_u) =
+  6.530863856531e12` before and after, `identical()` TRUE). Opting in adds
+  1,190 rows and 7 areas, moves no shared row by any amount, and raises total
+  energy CO2e by **+2.40%** over 1850-2023 — **+12.0% in 1961**, +11.3% in
+  1990, +0.26% in 2000 and 0% from 2010 on.
+
 * **`get_primary_production()`, `get_wide_cbs()` and `get_processing_coefs()`
   take a `years` argument.** A scoped request now builds only that window
   instead of building 1850-2023 and discarding the rest. Measured for 2010:

--- a/R/energy_co2_extension.R
+++ b/R/energy_co2_extension.R
@@ -34,12 +34,14 @@
 #' 901-906) and the dissolved entities GLEAM's present-day country table cannot
 #' carry (USSR, Czechoslovakia, Yugoslavia, Belgium-Luxembourg, Serbia and
 #' Montenegro). The size of that loss is now **reported** on every build rather
-#' than left to be inferred, and two opt-in treatments recover it instead of
+#' than left to be inferred, and three opt-in treatments recover it instead of
 #' losing it: `unclassified = "polity_region"` groups the **live** reporting
-#' areas GLEAM omits (today Nauru and Tuvalu) from the polity crosswalk, and
+#' areas GLEAM omits (today Nauru and Tuvalu) from the polity crosswalk,
+#' `unclassified = "historical_region"` additionally groups the **dissolved**
+#' entities from the membership they themselves held while they existed, and
 #' `unclassified = "global_mean"` prices **every** unclassifiable area at the
 #' world-mean GLEAM intensity. The default keeps the historical behaviour; see
-#' whep#415 and whep#492.
+#' whep#415, whep#492 and whep#553.
 #'
 #' @param method Estimation method. Only `"gleam"` (default), the GLEAM 3.0
 #'   per-live-weight factors, is currently available.
@@ -54,6 +56,11 @@
 #'   polity in `polity_area_crosswalk`, running GLEAM's own scheme rules on that
 #'   continent, and marks those rows `"GLEAM_3.0_energy_meat_polity_region"`;
 #'   the aggregate buckets and dissolved entities still drop.
+#'   `"historical_region"` does everything `"polity_region"` does and also
+#'   groups the **dissolved** entities (USSR, Czechoslovakia, the Yugoslav SFR,
+#'   Belgium-Luxembourg, Serbia and Montenegro, the Netherlands Antilles) from
+#'   the OECD and EU membership they held while they existed, marking those rows
+#'   `"GLEAM_3.0_energy_meat_historical_region"`.
 #'   `"global_mean"` instead prices every unclassifiable area at the unweighted
 #'   world mean of the published GLEAM factors, marking those rows
 #'   `"GLEAM_3.0_energy_meat_global_mean"`.
@@ -63,7 +70,9 @@
 #' @return A tibble with columns `year`, `area_code`, `item_cbs_code`,
 #'   `impact_u` (energy-use emissions in kilograms CO2e) and `method_energy`
 #'   (`"GLEAM_3.0_energy_meat"`, `"GLEAM_3.0_energy_meat_polity_region"` for
-#'   rows grouped from the polity crosswalk, or
+#'   rows grouped from the polity crosswalk,
+#'   `"GLEAM_3.0_energy_meat_historical_region"` for dissolved entities grouped
+#'   from their own era's memberships, or
 #'   `"GLEAM_3.0_energy_meat_global_mean"` for rows priced at the world mean),
 #'   plus the polity columns below.
 #'
@@ -76,7 +85,7 @@
 build_energy_co2_extension <- function(
   method = c("gleam"),
   data = list(),
-  unclassified = c("drop", "polity_region", "global_mean"),
+  unclassified = c("drop", "polity_region", "historical_region", "global_mean"),
   example = FALSE
 ) {
   method <- match.arg(method)
@@ -251,7 +260,7 @@ build_energy_co2_extension <- function(
   }
   n_gaps <- nrow(gaps)
   areas <- sort(gaps$area_name)
-  if (identical(unclassified, "polity_region")) {
+  if (unclassified %in% .energy_derived_treatments()) {
     cli::cli_inform(c(
       "i" = "{n_gaps} live reporting area{?s} {?has/have} no row in
          {.field gleam_geographic_hierarchy} and {?is/are} grouped from the
@@ -273,9 +282,33 @@ build_energy_co2_extension <- function(
   invisible(NULL)
 }
 
+# The two treatments that DERIVE a grouping for an area GLEAM omits, rather than
+# dropping it or averaging the world. `"historical_region"` is a superset of
+# `"polity_region"`: it adds the dissolved entities to the live areas.
+.energy_derived_treatments <- function() {
+  c("polity_region", "historical_region")
+}
+
+.inform_dissolved_grouped <- function() {
+  rows <- .energy_dissolved_rows()
+  if (nrow(rows) == 0L) {
+    return(invisible(NULL))
+  }
+  n <- nrow(rows)
+  cli::cli_inform(c(
+    "i" = "{n} dissolved reporting entit{?y/ies} {?is/are} grouped from the
+       OECD and EU membership {?it/they} held while {?it/they} existed:
+       {.val {sort(rows$iso3)}}.",
+    "i" = "Those rows are labelled
+       {.val GLEAM_3.0_energy_meat_historical_region}; see whep#553."
+  ))
+  invisible(NULL)
+}
+
 # The country universe the whole extension is derived from: GLEAM's own table,
 # plus -- only when the caller asks for it -- one row per live reporting area
-# GLEAM omits, built from the polity crosswalk.
+# GLEAM omits, built from the polity crosswalk, and under
+# `"historical_region"` one row per dissolved entity as well.
 #
 # `ef_scope` rides with each country so `method_energy` can say afterwards which
 # rows were grouped from the crosswalk rather than read off GLEAM's table.
@@ -284,10 +317,15 @@ build_energy_co2_extension <- function(
   hierarchy <- gleam_geographic_hierarchy |>
     tibble::as_tibble() |>
     dplyr::mutate(ef_scope = "country")
-  if (!identical(unclassified, "polity_region")) {
+  if (!unclassified %in% .energy_derived_treatments()) {
     return(hierarchy)
   }
-  dplyr::bind_rows(hierarchy, .energy_polity_hierarchy_rows())
+  derived <- .energy_polity_hierarchy_rows()
+  if (identical(unclassified, "historical_region")) {
+    .inform_dissolved_grouped()
+    derived <- dplyr::bind_rows(derived, .energy_dissolved_rows())
+  }
+  dplyr::bind_rows(hierarchy, derived)
 }
 
 # Rows shaped like `gleam_geographic_hierarchy` for the live reporting areas it
@@ -317,6 +355,7 @@ build_energy_co2_extension <- function(
 .energy_polity_hierarchy_rows <- function() {
   overrides <- .gleam_region_overrides()
   .areas_gleam_cannot_group() |>
+    dplyr::mutate(continent = .energy_gleam_continent(.data$continent)) |>
     dplyr::filter(.data$continent %in% .energy_scheme_continents()) |>
     dplyr::transmute(
       iso3 = .data$area_iso3c,
@@ -341,6 +380,120 @@ build_energy_co2_extension <- function(
 # quietly mis-grouped.
 .energy_scheme_continents <- function() {
   c("Africa", "Americas", "Europe", "Oceania")
+}
+
+# `polity_area_crosswalk` splits the Americas into "North America" and
+# "South America"; `gleam_geographic_hierarchy`, whose vocabulary the scheme
+# rules above are written against, has one "Americas". Without this, a crosswalk
+# row for an American area would match no branch of `region5` and fall through
+# its `.default` to "Non-OECD Asia". MEASURED: no area reaching either derived
+# treatment today is in the Americas with production (the live pair is Nauru and
+# Tuvalu, both Oceania; the Netherlands Antilles is dissolved and produces no
+# meat), so this maps a latent mis-grouping, not a live one.
+.energy_gleam_continent <- function(continent) {
+  dplyr::case_match(
+    continent,
+    c("North America", "South America") ~ "Americas",
+    .default = continent
+  )
+}
+
+# ---- dissolved entities ----------------------------------------------------
+
+# The self-reporting areas GLEAM omits that no longer exist: every polity period
+# the crosswalk gives them ended before the crosswalk's open end. That is what
+# separates them from the live omissions (Nauru, Tuvalu) and from the aggregate
+# buckets 901-906 and 999, whose periods all run to the open end. Derived rather
+# than listed so a crosswalk revision cannot leave a hardcoded list behind.
+.energy_dissolved_areas <- function() {
+  crosswalk <- tibble::as_tibble(polity_area_crosswalk)
+  open_end <- max(crosswalk$polity_end_year, na.rm = TRUE)
+  crosswalk |>
+    dplyr::filter(
+      !is.na(.data$area_code),
+      !is.na(.data$area_iso3c),
+      !is.na(.data$polity_end_year),
+      .data$area_code == .data$polity_area_code,
+      !.data$area_iso3c %in% gleam_geographic_hierarchy$iso3
+    ) |>
+    dplyr::summarise(
+      last_year = max(.data$polity_end_year),
+      .by = c(
+        "area_code",
+        "area_name",
+        "area_iso3c",
+        "polity_area_code",
+        "continent"
+      )
+    ) |>
+    dplyr::filter(.data$last_year < open_end)
+}
+
+# The OECD and EU membership each dissolved entity held WHILE IT EXISTED. This
+# is the whep#553 decision, and it is deliberately contemporaneous rather than
+# inherited from the successor states as they stand today.
+#
+# Every value is a membership date, not an estimate:
+#
+# * Belgium and Luxembourg both signed the OECD Convention on 14 December 1960
+#   and are founding members (in force 30 September 1961), and both are founding
+#   members of the EEC (Treaty of Rome 1957, in force 1 January 1958). So
+#   Belgium-Luxembourg was OECD and EU for the whole 1961-1999 span it reports.
+# * No successor of Czechoslovakia, the USSR, the Yugoslav SFR or Serbia and
+#   Montenegro was in either body during the entity's own lifetime: Czechia
+#   joined the OECD on 21 December 1995 and Slovakia on 14 December 2000, both
+#   after the 1992 dissolution, and both joined the EU on 1 May 2004; Slovenia
+#   joined the OECD in 2010; no Soviet successor is an OECD member. So those
+#   four are non-OECD and non-EU throughout, with no weighting between
+#   successors needed -- the successors agree, they were all outside.
+# * The Netherlands Antilles never held either membership in its own right: the
+#   OECD member is the Kingdom of the Netherlands, and its Caribbean territories
+#   are EU Overseas Countries and Territories, associated with the Union but
+#   outside its territory.
+#
+# Taking the successors' PRESENT-DAY flags instead would make Czechoslovakia
+# OECD and EU 27 in 1990, which is anachronistic; that alternative is quantified
+# in whep#553 and is the open question there. An entity with no row here stays
+# unpriced and keeps being reported, rather than defaulting to zeros.
+.energy_dissolved_membership <- function() {
+  tibble::tribble(
+    ~polity_area_code, ~oecd, ~eu27,
+    15L,               1L,    1L, # Belgium-Luxembourg
+    51L,               0L,    0L, # Czechoslovakia
+    151L,              0L,    0L, # Netherlands Antilles
+    186L,              0L,    0L, # Serbia and Montenegro
+    228L,              0L,    0L, # USSR
+    248L,              0L,    0L # Yugoslav SFR
+  )
+}
+
+# Rows shaped like `gleam_geographic_hierarchy` for the dissolved entities, so
+# `.energy_country_grouping()` runs GLEAM's OWN scheme rules on them. As with
+# the live areas, no grouping label is typed in here: only the three inputs
+# those rules read are supplied -- the continent from the crosswalk, the
+# memberships above, and the GLEAM region from the merged whep#465 override
+# table (which only feeds the dressing fraction). An entity the membership
+# table does not cover is dropped by the inner join and stays reported.
+.energy_dissolved_rows <- function() {
+  overrides <- .gleam_region_overrides()
+  .energy_dissolved_areas() |>
+    dplyr::inner_join(
+      .energy_dissolved_membership(),
+      by = "polity_area_code"
+    ) |>
+    dplyr::mutate(continent = .energy_gleam_continent(.data$continent)) |>
+    dplyr::filter(.data$continent %in% .energy_scheme_continents()) |>
+    dplyr::transmute(
+      iso3 = .data$area_iso3c,
+      continent = .data$continent,
+      faostat_region = NA_character_,
+      gleam_region = overrides$gleam_region[
+        match(.data$polity_area_code, overrides$polity_area_code)
+      ],
+      eu27 = .data$eu27,
+      oecd = .data$oecd,
+      ef_scope = "historical_region"
+    )
 }
 
 # Map each country to its grouping under each of the three GLEAM schemes.
@@ -789,6 +942,7 @@ build_energy_co2_extension <- function(
     ef_scope,
     "global" ~ paste0(label, "_global_mean"),
     "polity_region" ~ paste0(label, "_polity_region"),
+    "historical_region" ~ paste0(label, "_historical_region"),
     .default = label
   )
 }

--- a/man/build_energy_co2_extension.Rd
+++ b/man/build_energy_co2_extension.Rd
@@ -7,7 +7,7 @@
 build_energy_co2_extension(
   method = c("gleam"),
   data = list(),
-  unclassified = c("drop", "polity_region", "global_mean"),
+  unclassified = c("drop", "polity_region", "historical_region", "global_mean"),
   example = FALSE
 )
 }
@@ -27,6 +27,11 @@ the \strong{live, self-reporting} ones among them a grouping derived from their
 polity in \code{polity_area_crosswalk}, running GLEAM's own scheme rules on that
 continent, and marks those rows \code{"GLEAM_3.0_energy_meat_polity_region"};
 the aggregate buckets and dissolved entities still drop.
+\code{"historical_region"} does everything \code{"polity_region"} does and also
+groups the \strong{dissolved} entities (USSR, Czechoslovakia, the Yugoslav SFR,
+Belgium-Luxembourg, Serbia and Montenegro, the Netherlands Antilles) from
+the OECD and EU membership they held while they existed, marking those rows
+\code{"GLEAM_3.0_energy_meat_historical_region"}.
 \code{"global_mean"} instead prices every unclassifiable area at the unweighted
 world mean of the published GLEAM factors, marking those rows
 \code{"GLEAM_3.0_energy_meat_global_mean"}.}
@@ -38,7 +43,9 @@ data. Defaults to \code{FALSE}.}
 A tibble with columns \code{year}, \code{area_code}, \code{item_cbs_code},
 \code{impact_u} (energy-use emissions in kilograms CO2e) and \code{method_energy}
 (\code{"GLEAM_3.0_energy_meat"}, \code{"GLEAM_3.0_energy_meat_polity_region"} for
-rows grouped from the polity crosswalk, or
+rows grouped from the polity crosswalk,
+\code{"GLEAM_3.0_energy_meat_historical_region"} for dissolved entities grouped
+from their own era's memberships, or
 \code{"GLEAM_3.0_energy_meat_global_mean"} for rows priced at the world mean),
 plus the polity columns below.
 }
@@ -76,12 +83,14 @@ buckets (\code{polity_area_code} 999 "Rest of World" and the continental residua
 901-906) and the dissolved entities GLEAM's present-day country table cannot
 carry (USSR, Czechoslovakia, Yugoslavia, Belgium-Luxembourg, Serbia and
 Montenegro). The size of that loss is now \strong{reported} on every build rather
-than left to be inferred, and two opt-in treatments recover it instead of
+than left to be inferred, and three opt-in treatments recover it instead of
 losing it: \code{unclassified = "polity_region"} groups the \strong{live} reporting
-areas GLEAM omits (today Nauru and Tuvalu) from the polity crosswalk, and
+areas GLEAM omits (today Nauru and Tuvalu) from the polity crosswalk,
+\code{unclassified = "historical_region"} additionally groups the \strong{dissolved}
+entities from the membership they themselves held while they existed, and
 \code{unclassified = "global_mean"} prices \strong{every} unclassifiable area at the
 world-mean GLEAM intensity. The default keeps the historical behaviour; see
-whep#415 and whep#492.
+whep#415, whep#492 and whep#553.
 }
 \section{Polity columns}{
 

--- a/tests/testthat/test_energy_co2_extension.R
+++ b/tests/testthat/test_energy_co2_extension.R
@@ -511,3 +511,226 @@ testthat::test_that("unclassified only takes the documented values", {
     class = "rlang_error"
   )
 })
+
+# ---- whep#553: the dissolved entities --------------------------------------
+
+# The USSR (area 228) is 437 Mt of the 569 Mt of carcass production that no
+# GLEAM grouping can price, measured on the real `get_primary_production()`
+# output. Belgium-Luxembourg (area 15) is the one dissolved entity that was
+# itself OECD and EU while it reported, so the two are fixtured together.
+.energy_dissolved_fixture <- function() {
+  .energy_prod_fixture() |>
+    dplyr::bind_rows(
+      tibble::tribble(
+        ~year, ~area_code, ~item_cbs_code, ~unit, ~value,
+        1980L, 228L, 2731L, "tonnes", 6.5e6,
+        1980L, 228L, 961L, "slaughtered_heads", 3e7,
+        1980L, 228L, 946L, "slaughtered_heads", 1e6,
+        1980L, 15L, 2733L, "tonnes", 7e5,
+        1980L, 15L, 1049L, "slaughtered_heads", 8e6,
+        1980L, 15L, 1051L, "slaughtered_heads", 1e5
+      )
+    )
+}
+
+testthat::test_that("the dissolved set is derived, not typed in", {
+  # What separates a dissolved entity from the live omissions and from the
+  # aggregate buckets is a property of the crosswalk, not a list: every polity
+  # period a dissolved area carries ended before the crosswalk's open end.
+  dissolved <- .energy_dissolved_areas()
+
+  testthat::expect_setequal(
+    dissolved$area_code,
+    c(15L, 51L, 151L, 186L, 228L, 248L)
+  )
+  # The live omissions stay with whep#415's treatment ...
+  testthat::expect_false(any(c(148L, 227L) %in% dissolved$area_code))
+  # ... and the aggregate buckets stay with whep#492's, because their periods
+  # run to the open end rather than stopping at a dissolution.
+  testthat::expect_false(
+    any(c(901L, 902L, 903L, 904L, 905L, 906L, 999L) %in% dissolved$area_code)
+  )
+  open_end <- max(whep::polity_area_crosswalk$polity_end_year, na.rm = TRUE)
+  testthat::expect_true(all(dissolved$last_year < open_end))
+  # One row per area, so the hierarchy cannot gain a duplicate iso3 and
+  # duplicate every production row it joins to.
+  testthat::expect_equal(anyDuplicated(dissolved$area_code), 0L)
+  testthat::expect_equal(
+    anyDuplicated(.energy_dissolved_rows()$iso3),
+    0L
+  )
+  hierarchy <- suppressMessages(suppressWarnings(
+    .energy_hierarchy("historical_region")
+  ))
+  testthat::expect_equal(anyDuplicated(hierarchy$iso3), 0L)
+})
+
+testthat::test_that("a dissolved entity is grouped as it was, not as now", {
+  # The whep#553 decision, made visible: memberships are taken as of the
+  # entity's own existence. Belgium and Luxembourg both signed the OECD
+  # Convention in 1960 and both are EEC founders, so Belgium-Luxembourg reports
+  # its whole 1961-1999 span as an OECD/EU member and must land exactly where
+  # Belgium and Luxembourg do. Czechoslovakia's successors joined the OECD in
+  # 1995 and 2000 and the EU in 2004 -- all after the 1992 dissolution -- so it
+  # must NOT inherit their present-day groupings.
+  grouping <- suppressMessages(suppressWarnings(
+    .energy_country_grouping(.energy_hierarchy("historical_region"))
+  ))
+  at <- function(code) {
+    as.list(dplyr::filter(grouping, .data$iso3 == code))
+  }
+
+  testthat::expect_equal(at("BLX")$development3, at("BEL")$development3)
+  testthat::expect_equal(at("BLX")$region5, at("BEL")$region5)
+  testthat::expect_equal(at("BLX")$detailed15, at("BEL")$detailed15)
+  testthat::expect_equal(at("BLX")$detailed15, at("LUX")$detailed15)
+  testthat::expect_equal(at("BLX")$detailed15, "EU 27")
+
+  testthat::expect_equal(at("CSK")$development3, "Others")
+  testthat::expect_equal(at("CSK")$detailed15, "Non-OECD Europe")
+  testthat::expect_false(identical(at("CSK")$detailed15, at("CZE")$detailed15))
+  testthat::expect_false(identical(at("CSK")$detailed15, at("SVK")$detailed15))
+  # The Yugoslav successors were outside both bodies while the federation
+  # existed and Serbia still is, so there the two readings agree.
+  testthat::expect_equal(at("YUG")$detailed15, at("SRB")$detailed15)
+  testthat::expect_equal(at("SCG")$detailed15, at("SRB")$detailed15)
+  # The Netherlands Antilles is the reason the crosswalk's continent has to be
+  # translated: it says "North America" where GLEAM's rules say "Americas".
+  testthat::expect_equal(.energy_gleam_continent("North America"), "Americas")
+  testthat::expect_equal(.energy_gleam_continent("South America"), "Americas")
+  testthat::expect_equal(.energy_gleam_continent("Europe"), "Europe")
+  testthat::expect_equal(at("ANT")$region5, at("CUB")$region5)
+})
+
+testthat::test_that("historical_region recovers the dissolved entities", {
+  # whep#553's fix, opt-in so nothing moves without consent: the areas must come
+  # back with their own factors, be labelled as such, and leave every
+  # GLEAM-classified area bit-identical -- structure included.
+  base <- suppressWarnings(
+    whep::build_energy_co2_extension(
+      data = list(primary_prod = .energy_dissolved_fixture())
+    )
+  )
+  result <- suppressWarnings(suppressMessages(
+    whep::build_energy_co2_extension(
+      data = list(primary_prod = .energy_dissolved_fixture()),
+      unclassified = "historical_region"
+    )
+  ))
+
+  testthat::expect_false(any(c(15L, 228L) %in% base$area_code))
+  recovered <- dplyr::filter(result, .data$area_code %in% c(15L, 228L))
+  testthat::expect_setequal(
+    recovered$item_cbs_code,
+    c(961L, 946L, 1049L, 1051L)
+  )
+  testthat::expect_true(all(recovered$impact_u > 0))
+  testthat::expect_true(all(
+    recovered$method_energy == "GLEAM_3.0_energy_meat_historical_region"
+  ))
+
+  usa <- dplyr::filter(result, .data$area_code == 231L)
+  testthat::expect_equal(usa, dplyr::filter(base, .data$area_code == 231L))
+  testthat::expect_equal(nrow(result), nrow(base) + nrow(recovered))
+  testthat::expect_setequal(
+    setdiff(result$area_code, base$area_code),
+    c(15L, 228L)
+  )
+  testthat::expect_length(setdiff(base$area_code, result$area_code), 0L)
+  # One area_code, one label: recovering an area must not split its key.
+  testthat::expect_equal(
+    max(
+      dplyr::summarise(
+        result,
+        n = dplyr::n_distinct(.data$polity_area_code),
+        .by = "area_code"
+      )$n
+    ),
+    1L
+  )
+})
+
+testthat::test_that("the default still drops the dissolved entities", {
+  # Status quo pin: `unclassified = "drop"` publishes the same numbers it did
+  # before whep#553, so adding dissolved-entity production can neither add rows
+  # nor move another area's value.
+  base <- suppressWarnings(
+    whep::build_energy_co2_extension(
+      data = list(primary_prod = .energy_prod_fixture())
+    )
+  )
+  with_dissolved <- suppressWarnings(
+    whep::build_energy_co2_extension(
+      data = list(primary_prod = .energy_dissolved_fixture())
+    )
+  )
+
+  testthat::expect_equal(with_dissolved, base)
+  reported <- testthat::capture_warnings(
+    whep::build_energy_co2_extension(
+      data = list(primary_prod = .energy_dissolved_fixture())
+    )
+  )
+  testthat::expect_match(reported, "USSR", all = FALSE)
+})
+
+testthat::test_that("historical_region keeps the live areas on whep#415", {
+  # It is a superset of `polity_region`, not a replacement: Tuvalu must still be
+  # grouped from the crosswalk and still carry that label, so the two decisions
+  # stay distinguishable row by row.
+  prod <- dplyr::bind_rows(
+    .energy_omitted_area_fixture(),
+    dplyr::filter(.energy_dissolved_fixture(), .data$area_code == 228L)
+  )
+  result <- suppressWarnings(suppressMessages(
+    whep::build_energy_co2_extension(
+      data = list(primary_prod = prod),
+      unclassified = "historical_region"
+    )
+  ))
+
+  testthat::expect_true(all(
+    result$method_energy[result$area_code == 227L] ==
+      "GLEAM_3.0_energy_meat_polity_region"
+  ))
+  testthat::expect_true(all(
+    result$method_energy[result$area_code == 228L] ==
+      "GLEAM_3.0_energy_meat_historical_region"
+  ))
+  testthat::expect_true(all(
+    result$method_energy[result$area_code == 231L] == "GLEAM_3.0_energy_meat"
+  ))
+})
+
+testthat::test_that("an uncovered dissolved entity stays unpriced", {
+  # The membership table is the whep#553 decision itself, so an entity it does
+  # not cover must fall out of the join and keep being reported, rather than
+  # defaulting to non-OECD/non-EU zeros nobody decided on.
+  testthat::local_mocked_bindings(
+    .energy_dissolved_membership = function() {
+      tibble::tibble(
+        polity_area_code = 51L,
+        oecd = 0L,
+        eu27 = 0L
+      )
+    }
+  )
+  rows <- .energy_dissolved_rows()
+  testthat::expect_setequal(rows$iso3, "CSK")
+
+  msgs <- testthat::capture_warnings(
+    whep::build_energy_co2_extension(
+      data = list(primary_prod = .energy_dissolved_fixture()),
+      unclassified = "historical_region"
+    )
+  )
+  result <- suppressMessages(suppressWarnings(
+    whep::build_energy_co2_extension(
+      data = list(primary_prod = .energy_dissolved_fixture()),
+      unclassified = "historical_region"
+    )
+  ))
+  testthat::expect_false(any(c(15L, 228L) %in% result$area_code))
+  testthat::expect_match(msgs, "has no row for", all = FALSE)
+  testthat::expect_match(msgs, "USSR", all = FALSE)
+})


### PR DESCRIPTION
## What was wrong

`gleam_geographic_hierarchy` is the country universe of the whole energy
extension: all three grouping schemes in `.energy_country_grouping()` are
`transmute()`d off it. It is a **present-day** table of 204 sovereign states, so
the dissolved federations have no row in it, get no energy intensity, and their
meat production leaves the extension without a number.

PR #508 (#465) solved exactly this for the **livestock GHG** extension with
`.gleam_region_of()` and a `polity_area_code`-keyed override table, and said
explicitly that `R/energy_co2_extension.R` "keeps its own ISO3-keyed `iso2reg`"
and that wiring it was not its call. PR #552 (#492) then made the loss
**visible** and gave it a world-mean escape hatch, and said the strictly better
fix for 96% of the tonnage was to resolve these five properly. Nobody owned
that, which is what #553 is.

The issue asks a real question the region alone cannot answer: the three schemes
are keyed on `oecd` / `eu27` / `continent` / `faostat_region`, not on
`gleam_region`, so someone has to say what OECD and EU mean for the USSR in 1975
or for Czechoslovakia in 1990.

## Evidence it reproduced BEFORE the change

At the base commit (`de7e2ff9`), driving `build_energy_co2_extension()` over the
real `get_primary_production()` output (**6,305,656 rows, 1850-2023, 217 areas**):

```
carcass rows entering .energy_co2e_by_group: 111715   tonnes: 17,084,808,616
after inner_join(area_code -> iso3):         111715   tonnes: 17,084,808,616   (loses nothing)
rows left with NA ef_total (these disappear):   840   tonnes:    569,447,998   = 3.3331%
```

| area | iso3 | carcass Mt | years |
|---|---|---|---|
| 228 USSR | SUN | 436.8 | 1961-1991 |
| 15 Belgium-Luxembourg | BLX | 43.9 | 1961-1999 |
| 51 Czechoslovakia | CSK | 38.1 | 1961-1992 |
| 248 Yugoslav SFR | YUG | 37.8 | 1961-1991 |
| 186 Serbia and Montenegro | SCG | 12.8 | 1992-2005 |
| 227 Tuvalu | TUV | 0.007 | 1961-2023 |
| 148 Nauru | NRU | 0.004 | 1961-2023 |
| **dissolved subtotal** | | **569.4** | |

Share of world meat carcass tonnage lost: **15.2% in 1961**, 14.1% in 1980,
13.8% in 1990, 0.41% in 2000, ~0 from 2010 on.

**The issue's headline holds exactly (569 Mt), but one line of its table no
longer does, and re-measuring mattered:** it reported 595.0 Mt including 25.5 Mt
of bucket 999. Since the Rest-of-World fold was lifted (#628), **bucket 999
contributes nothing to this loss at all** — its 21 reporting members now price
under their own ISO3 codes. The dissolved entities are therefore no longer 96%
of the loss, they are **99.998%** of it, and #492's `"global_mean"` is now a
world mean applied to five European federations and two Pacific islands.

## What I changed

`R/energy_co2_extension.R` only, plus its tests, docs and `NEWS.md`.

A fourth value of the existing argument, `unclassified = "historical_region"`,
which is a **superset** of `"polity_region"`: it does everything that does for
the live areas GLEAM omits, and additionally builds one
`gleam_geographic_hierarchy`-shaped row per **dissolved** entity so
`.energy_country_grouping()` runs GLEAM's own `case_when()` on it. As with #415's
treatment, **no grouping label is typed in** — only the inputs those rules read:

* `continent` from the polity crosswalk;
* `gleam_region` from **#508's merged `.gleam_region_overrides()`**, not a second
  copy of that decision (it only feeds the dressing fraction) — this is the
  compose-don't-duplicate the issue asks for;
* `oecd` / `eu27` from a new six-row table of the membership each entity held
  **while it existed**.

Which entities qualify is derived, not listed: a self-reporting area with no
GLEAM row **all of whose polity periods ended before the crosswalk's open end**.
That is what separates the dissolved five (plus the Netherlands Antilles) from
the live omissions and from buckets 901-906/999, whose periods run to the open
end — so this cannot silently pre-empt #415's or #492's decisions. An entity the
membership table does not cover falls out of the join and keeps being reported
rather than defaulting to zeros nobody chose.

Rows carry `method_energy = "GLEAM_3.0_energy_meat_historical_region"`, per row,
so a coarser treatment is never a silent fallback and the three treatments stay
distinguishable inside one build.

One incidental correctness fix the new path needed: `.energy_gleam_continent()`
translates the crosswalk's `"North America"`/`"South America"` into GLEAM's
`"Americas"`. Without it an American area matches no `region5` branch and falls
through `.default` to **"Non-OECD Asia"**. Measured: no area reaching either
derived treatment today is in the Americas with production, so this maps a
latent mis-grouping, not a live one, and it moves no number.

### The memberships, each with its date (verified, not assumed)

| entity | oecd | eu27 | why |
|---|---|---|---|
| 15 Belgium-Luxembourg | 1 | 1 | BEL and LUX both signed the OECD Convention on 14 Dec 1960 (founding members, in force 30 Sep 1961) and are both EEC founders (Treaty of Rome, in force 1 Jan 1958) — so OECD and EU across its whole 1961-1999 span |
| 51 Czechoslovakia | 0 | 0 | Czechia joined the OECD 21 Dec 1995, Slovakia 14 Dec 2000, both the EU 1 May 2004 — all after the 1992 dissolution |
| 228 USSR | 0 | 0 | no Soviet successor is an OECD member; the Baltics joined the EU in 2004 |
| 248 Yugoslav SFR | 0 | 0 | Slovenia joined the OECD in 2010, Croatia the EU in 2013 |
| 186 Serbia and Montenegro | 0 | 0 | neither successor is in either body |
| 151 Netherlands Antilles | 0 | 0 | the OECD member is the Kingdom of the Netherlands; its Caribbean territories are EU Overseas Countries and Territories, associated with the Union but outside its territory |

No successor weighting is involved: for the four non-members the successors
agree, they were all outside.

## How I verified

**The default is bit-identical on the real input.** Full
`build_energy_co2_extension(data = list(primary_prod = get_primary_production()))`
before and after: 181,831 rows both times, `identical(before, after)` **TRUE**,
`sum(impact_u) = 6.530863856531e12` both times.

**What opting in does** (measured, so the decision is not taken blind):

* +1,190 rows (183,021), +7 areas (204), **no area and no row removed**;
* the 181,831 shared rows are unchanged to the last bit (`max|Δ| = 0`) and not
  one of them changes `method_energy`;
* total energy CO2e **+2.399%** over 1850-2023 — **+12.0% in 1961**, +11.5% in
  1980, +11.3% in 1990, +0.26% in 2000, **0% from 2010**;
* recovered per area (kg CO2e): USSR 1.197e11, Belgium-Luxembourg 1.454e10,
  Yugoslav SFR 1.017e10, Czechoslovakia 9.17e9, Serbia and Montenegro 3.12e9,
  Tuvalu 4.2e5, Nauru 2.9e5;
* the build now emits no unpriced-meat warning at all, because nothing in the
  real input is left unpriced.

**Structural checks** (a PR was reverted this week for conserving mass while
splitting a bucket): 0 duplicated `(year, area_code, item_cbs_code)` keys before
and after; **one `area_code` -> one `polity_area_code`** (0 violations) and one
`reporting_polity_name` per `(area_code, year)` (0 violations, before and
after); `setdiff(before$area_code, after$area_code)` empty. The recovered areas
carry their own labels ("USSR (1945-1991)", "Czechoslovakia (1947-1993)"), not a
shared one.

**Tests**: 6 new blocks in `tests/testthat/test_energy_co2_extension.R`.
**Load-bearing, proved by reverting only `R/energy_co2_extension.R` to
`origin/main` and re-running the file: FAIL 14, PASS 78** (9 assertion failures
plus 5 errors — the helpers and the argument value do not exist). With the
change: **FAIL 0, PASS 114**. One of the six is a status-quo pin that holds
before and after by design (adding dissolved production under the default must
neither add a row nor move another area's value), and one drives the failure
branch: with the membership table mocked down to one entity, the others stay
unpriced and are still named in the warning.

**Gates**: `air format .` (binary) clean; `devtools::document()` run and `man/`
committed; `lintr::lint_package()` with the CI config — **No lints found** (it
caught `.energy_dissolved_hierarchy_rows` at 32 characters; renamed);
`devtools::test()` full suite green; both changed files pure ASCII. No new NSE
symbol (`.data$` throughout), so `R/utils.R` is untouched; no new documented
topic, so `_pkgdown.yml` is untouched (verified: nothing in `man/` missing
from it).

## Moves published values

**No.** The default `unclassified = "drop"` is bit-identical on the full real
input, measured above, which is why this is not a draft. What changes is that a
caller can now opt into pricing 569 Mt of production that today leaves the
extension silently. `NEWS.md` carries the numbers.

## The open decision

This is a **science decision** and the default deliberately does not take it.
Both alternatives are measured:

1. **Contemporaneous membership (what this PR implements when opted into).**
   Czechoslovakia lands on "Others"/"Non-OECD Europe"; Belgium-Luxembourg on
   "OECD"/"EU 27", identical to BEL and LUX.
2. **Successors' present-day flags** (the issue's option 1). The two readings
   disagree on exactly one entity, Czechoslovakia, because CZE and SVK are both
   OECD and EU today: it would be **+38.0%** on Czechoslovakia (9.17e9 ->
   1.266e10 kg CO2e) and +0.052% on the world total. I did not implement it,
   because making Czechoslovakia an OECD and EU-27 member in 1990 is
   anachronistic — but it is one row of `.energy_dissolved_membership()` away if
   you prefer it.
3. **The USSR's `detailed15` bucket.** It resolves to "Non-OECD Europe" from its
   continent, while GLEAM's `detailed15` also has a "Russian Federation" bucket
   that #508's region override points the USSR's *dressing* at. Putting the USSR
   on the Russian factor instead would be **-9.6%** on the USSR (1.197e11 ->
   1.082e11 kg CO2e, -0.18% of the world total): bovine is identical, the
   difference is direct energy on pig (0.139 vs 0.111), poultry (0.338 vs 0.298)
   and mutton/goat (0.261 vs 0.231 kg CO2e/kg LW). Left as it is because
   "Non-OECD Europe" comes out of GLEAM's own rules while "Russian Federation"
   would be a hand-placement, but say the word and it is a one-line change.

Option 3 of the issue (keep them out) remains the shipped default.

## What I deliberately did not do

- **Did not change any default**, and did not touch `"drop"`, `"polity_region"`
  or `"global_mean"` behaviour.
- **Did not touch `gleam_geographic_hierarchy`.** It is parsed from the GLEAM
  workbook; adding rows would make the package's copy diverge from the published
  source with nothing recording it — the same reasoning #415, #475 and #552
  fixed on.
- **Did not touch `.gleam_region_overrides()` or `R/livestock_enteric.R`.** This
  consumes #508's decision; it does not restate it.
- **Did not assign RAFR/RASI/REUR/RLAM/RNAM/ROCE or bucket 999 anything.** They
  are aggregates, they carry no meat production, and #492 already ruled on 999.
- **Did not guess a single membership.** Every date above is from the OECD's and
  the EU's own published accession records; where I could not attribute a
  membership to the entity itself (the Netherlands Antilles) I said why it has
  none rather than inferring one.
- **Did not run `build_footprint()`.** The extension is exported but not wired
  into the IO core, so there is no published footprint for it to move.
- **Did not widen this PR to the two adjacent gaps I measured.** Filed instead.

Closes #553
Part of the polity migration epic #458.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
