### PR TITLE
Pin the cropland env var in the no-land-support test

### DIFF
--- a/tests/testthat/test_n_balance_inputs.R
+++ b/tests/testthat/test_n_balance_inputs.R
@@ -430,6 +430,13 @@ testthat::test_that("agricultural support is derived when not supplied", {
 })
 
 testthat::test_that("non-item inputs abort when no support can be derived", {
+  # Dropping data$type_cropland does not remove the input, it makes the reader
+  # fall back to WHEP_TYPE_CROPLAND_PATH. Without pinning the variable the test
+  # reads whatever gridded cropland the machine happens to have configured and
+  # asserts "no land surface exists" while one is being loaded -- so it checks
+  # the branch it is named after only where the data is absent, which is never
+  # the machines that have it.
+  withr::local_envvar(WHEP_TYPE_CROPLAND_PATH = NA)
   data <- .nbi_full_data()
   data$ag_land_support <- NULL
   data$type_cropland <- NULL


### PR DESCRIPTION
Closes #635.

## The defect

`test_n_balance_inputs.R:432` drops `data$type_cropland` to assert that
`build_n_inputs()` aborts when no land support can be derived. Dropping that
entry does not remove the input — it makes the reader fall back to
`WHEP_TYPE_CROPLAND_PATH`.

So wherever that variable is set, the test loads the real gridded cropland and
asserts *"no land surface exists"* while one is being read. The abort then
arrives from a different place with a message the regex does not match:

```
Cannot spatialize 2 polity-crop totals: no positive cropland cells are available.
```

The test therefore checked the branch it is named after **only on machines
where the data is absent** — never the machines that have it.

## Why nothing caught it

| how it runs | reads `~/.Renviron`? | env var | result before this PR |
|---|---|---|---|
| GitHub Actions | n/a | unset | passes |
| `Rscript --vanilla` (our local recipe) | no | unset | passes |
| `devtools::test()` from a normal R session | yes | set | **fails** |

CI is structurally blind here: it never has the env vars, so it only ever sees
the happy path. The third row is the `devtools::test()` step of the "Before
committing" sequence in `CLAUDE.md`, which is how this turned up.

## Fix

Pin the variable rather than inherit it:

```r
withr::local_envvar(WHEP_TYPE_CROPLAND_PATH = NA)
```

Verified both ways on a machine that has the variable set — passes under plain
`Rscript` and under `Rscript --vanilla`.

## Scope

One test. I checked the rest of the suite for the same shape (a test nulling a
`data` entry to reach an "input absent" branch that has an env-var fallback);
the only other candidate, `test_build_sjos_nitrogen.R:199`, falls back to the
IO model rather than to an env var, and is unaffected.

The broader point in #635 stands and is left open there: any such test asserts
"input absent **and** env var unset", and CI cannot tell us which one it is
exercising.
