### PR TITLE
fix(livestock): warn when work_hours_day cannot do anything (#210)

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -13,6 +13,14 @@
   `identical()` holds across all 1,166,220 rows and 17 columns of the five-year
   build, so no result changes (#630).
 
+* **`estimate_energy_demand()` now warns when `work_hours_day` is supplied
+  without a work coefficient.** `whep` ships `cw = 0` for every species, so
+  draft work is opt-in per call via `work_coef` — passing only the hours
+  produced `ne_work = 0` with no indication that the input had been ignored
+  (#210). The numbers are unchanged; only the silence is. Hours filled in from
+  `livestock_production_defaults` never warn, since several species carry a
+  non-zero default and warning about those would fire on ordinary runs.
+
 * **`get_primary_production()`, `get_wide_cbs()` and `get_processing_coefs()`
   take a `years` argument.** A scoped request now builds only that window
   instead of building 1850-2023 and discarding the rest. Measured for 2010:

--- a/R/livestock_energy.R
+++ b/R/livestock_energy.R
@@ -166,12 +166,46 @@ estimate_energy_demand <- function(data, method = "ipcc2019") {
 #' alongside `work_hours_day`.
 #' @noRd
 .calc_energy_work <- function(data) {
-  data |>
+  data <- data |>
     dplyr::mutate(
       cw_effective = dplyr::coalesce(work_coef, cw, 0),
       ne_work = cw_effective * ne_maintenance * work_hours_day
-    ) |>
-    dplyr::select(-cw_effective)
+    )
+  .warn_inert_work_hours(data)
+  data |>
+    dplyr::select(-dplyr::any_of(c("cw_effective", "work_hours_set_by_caller")))
+}
+
+# whep ships `cw` = 0 for every species, so draft work is opt-in per call via
+# `work_coef`. That is deliberate -- IPCC Eq 10.11 defines the term for cattle
+# and buffalo only, and switching it on globally would move enteric CH4
+# everywhere -- but returning `ne_work` = 0 without a word to someone who
+# explicitly passed working hours is the surprise reported in #210. Say so.
+#
+# Only hours the caller set are worth warning about: `.join_production_defaults()`
+# fills the rest from `livestock_production_defaults`, where several species
+# carry a non-zero default, and warning about those would fire on ordinary runs.
+.warn_inert_work_hours <- function(data) {
+  if (!rlang::has_name(data, "work_hours_set_by_caller")) {
+    return(invisible(NULL))
+  }
+  inert <- data$work_hours_set_by_caller &
+    !is.na(data$work_hours_day) &
+    data$work_hours_day > 0 &
+    data$cw_effective == 0
+  n_inert <- sum(inert, na.rm = TRUE)
+  if (n_inert == 0L) {
+    return(invisible(NULL))
+  }
+  cli::cli_warn(c(
+    "{n_inert} row{?s} set {.arg work_hours_day} but have no work
+     coefficient, so {.field ne_work} is 0 for {cli::qty(n_inert)}{?it/them}.",
+    i = "{.pkg whep} ships {.field cw} = 0 for every species: draft work is
+         opt-in, not a global default.",
+    i = "Pass {.arg work_coef} to activate it -- IPCC Eq 10.11 gives 0.10 for
+         cattle and buffalo, and defines the term for those only."
+  ))
+  invisible(NULL)
 }
 
 #' NEp: IPCC Eq 10.13.
@@ -368,6 +402,10 @@ estimate_energy_demand <- function(data, method = "ipcc2019") {
       suffix = c("", "_default")
     ) |>
     dplyr::select(-defaults_key) |>
+    # Remember whether the caller set the working hours themselves, before the
+    # coalesce below makes that indistinguishable from the species default.
+    # `.calc_energy_work()` warns only about hours the caller asked for (#210).
+    dplyr::mutate(work_hours_set_by_caller = !is.na(work_hours_day)) |>
     dplyr::mutate(
       milk_yield_kg_day = dplyr::coalesce(
         milk_yield_kg_day,

--- a/tests/testthat/test_livestock_energy.R
+++ b/tests/testthat/test_livestock_energy.R
@@ -307,3 +307,59 @@ testthat::test_that("cfi is NA-safe and does not affect rows without it", {
     estimate_energy_demand()
   testthat::expect_equal(with_na$ne_maintenance, no_col$ne_maintenance)
 })
+
+# .warn_inert_work_hours (issue #210) ---------------------------------------
+
+testthat::test_that("supplying work_hours_day without work_coef warns", {
+  # whep's own cw is 0, so the hours produce nothing. Returning 0 silently is
+  # the #210 complaint; the number is unchanged, the silence is not.
+  testthat::expect_warning(
+    result <- working_oxen_tier2_fixture(work_coef = NA_real_) |>
+      estimate_energy_demand(),
+    "work_hours_day"
+  )
+  testthat::expect_equal(result$ne_work, 0)
+})
+
+testthat::test_that("the inert-hours warning names work_coef as the remedy", {
+  testthat::expect_warning(
+    working_oxen_tier2_fixture(work_coef = NA_real_) |>
+      estimate_energy_demand(),
+    "work_coef"
+  )
+})
+
+testthat::test_that("supplying work_coef alongside the hours does not warn", {
+  testthat::expect_no_warning(
+    result <- working_oxen_tier2_fixture(work_coef = 0.10) |>
+      estimate_energy_demand()
+  )
+  testthat::expect_gt(result$ne_work, 0)
+})
+
+testthat::test_that("a defaulted work_hours_day never warns", {
+  # `livestock_production_defaults` carries non-zero work_hours_day for several
+  # species. Those are not a caller mistake, and warning about them would fire
+  # on ordinary pipeline runs -- the whole reason the caller-set flag exists.
+  testthat::expect_no_warning(
+    tibble::tibble(
+      species = "Buffalo",
+      cohort = "Adult Male",
+      weight = 450,
+      diet_quality = "Medium",
+      heads = 10
+    ) |>
+      estimate_energy_demand()
+  )
+})
+
+testthat::test_that("the helper column does not leak into the output", {
+  result <- suppressWarnings(
+    working_oxen_tier2_fixture(work_coef = NA_real_) |>
+      estimate_energy_demand()
+  )
+  testthat::expect_false(
+    rlang::has_name(result, "work_hours_set_by_caller")
+  )
+  testthat::expect_false(rlang::has_name(result, "cw_effective"))
+})


### PR DESCRIPTION
Closes #210.

**Classification: mechanical.** No coefficient changes, no number changes — the
only difference is that a silently-ignored input now says so.

## Why not the obvious fix

#210 reads as "the draft-work term is dead: `cw` is 0 for every species, so
`ne_work = cw * ne_maintenance * work_hours_day` is always 0 and
`work_hours_day` is ignored." The obvious fix — and what the now-closed #315
proposed — is to set `cw = 0.10`.

That would be wrong here. `cw = 0` is **deliberate on `main`**:

- `R/livestock_energy.R` — `cw_effective = dplyr::coalesce(work_coef, cw, 0)`
- roxygen — *"`work_coef` overrides the joined IPCC work coefficient (`cw`, 0 by
  default)"*
- a test named **"work_coef override activates NE_work for cattle (whep's own
  cw is 0)"**

Draft work is **opt-in per call**, not a global default. IPCC Eq 10.11 defines
the term for cattle and buffalo only, and switching it on globally would move
enteric CH4 for every head of cattle and buffalo in the world. Setting
`cw = 0.10` also fails 3 existing tests.

So the design is right and the *silence* is the bug. This warns instead.

## The change

`.calc_energy_work()` now calls `.warn_inert_work_hours()`, which warns when a
row has `work_hours_day > 0` but an effective work coefficient of 0, naming
`work_coef` as the remedy and citing Eq 10.11's 0.10 for cattle and buffalo.

## The part that needed care

**Only caller-supplied hours warn.** `.join_production_defaults()` fills
`work_hours_day` from `livestock_production_defaults`, where several species
carry a non-zero default — Buffalo 2, others 4 and 6. Warning on those would
fire on ordinary pipeline runs and make the warning worthless.

The flag is captured immediately before the `coalesce()` that merges caller
values with defaults — the last point where the two are distinguishable — and
dropped again before the function returns, so it never reaches output.

## Tests

Five new tests covering both branches and the trap:

| test | asserts |
| --- | --- |
| caller sets hours, no coef | **warns**, and `ne_work` is still 0 |
| the warning text | names `work_coef` as the remedy |
| hours + `work_coef` | **no warning**, `ne_work > 0` |
| hours from the species default | **no warning** |
| output columns | neither `work_hours_set_by_caller` nor `cw_effective` leaks |

The defaulted-hours test is **verified non-vacuous**: that Buffalo row really
does receive `work_hours_day = 2` and `ne_work = 0`, and stays silent. A test
that passed because the default happened to be 0 would prove nothing.

## Verification

`devtools::test()` **6393 pass, 0 failed, 0 errors** (8 pre-existing skips) ·
`rcmdcheck` **0 errors, 0 warnings, 0 notes** · `lintr` 0 lints ·
`livestock_energy` 40 pass.

## Note

If you would rather make draft work a global default after all, that is a
separate decision with a real numeric consequence, and it should carry a
measured before/after for enteric CH4. This PR deliberately does not make it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)