### PR TITLE
fix(production): read the stock shares over their own span (#665)

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -222,6 +222,16 @@
   `"flag"` is numerically identical to it. `"drop"` removes 20.4% of the run's
   cell-years and makes South Sudan disappear from it entirely, which is why it
   is opt-in.
+
+* **Year-scoped builds no longer drop split-species slaughter counts.**
+  `.compute_stock_shares()` read the livestock stock series scoped to the
+  caller's window, but those shares are carried along the year axis precisely
+  because the `faostat-emissions-livestock` pin lags QCL slaughter by 1-2 years.
+  A narrow window left the carry-forward nothing to fill from, and the join in
+  `.split_slaughter_by_shares()` then dropped the slaughter row entirely. At
+  2010 that was 2 Singapore rows (Pigs, Hogs); `slaughtered_heads` now agrees
+  exactly with the full-range build instead of by 4.7e-06. The stock series is
+  read over its full span; full-range output is unchanged (#665).
 * **`build_carbon_balance()` is about a quarter faster, with output unchanged
   to the last bit.** The RothC/HSOC climate modifier is now computed for every
   cell-year at once instead of once per (cell, year, land use) -- roughly 1.2e6

--- a/R/build_production.R
+++ b/R/build_production.R
@@ -199,10 +199,7 @@ build_primary_production <- function(
   )
 
   # 5b. Livestock slaughter counts
-  fao_slaughter <- .build_livestock_slaughter(
-    fao_combined,
-    years = years
-  )
+  fao_slaughter <- .build_livestock_slaughter(fao_combined)
 
   # 6. Primary dataset (crops + livestock, no game meat — see .fix_production)
   primary_raw <- .combine_primary_raw(fao_combined, fao_liv_all)
@@ -1406,7 +1403,7 @@ build_primary_production <- function(
     dplyr::filter(value > 0)
 }
 
-.split_slaughter_by_shares <- function(slaughter_raw, years) {
+.split_slaughter_by_shares <- function(slaughter_raw) {
   split_parents <- whep::animals_codes |>
     dplyr::count(Item_Code) |>
     dplyr::filter(n > 1) |>
@@ -1429,7 +1426,7 @@ build_primary_production <- function(
   # QCL's most recent years, mirroring the value_st fill in
   # .combine_livestock(). Without this the inner_join drops those years and
   # cattle/swine/chicken slaughtered_heads silently vanish.
-  shares <- .compute_stock_shares(years) |>
+  shares <- .compute_stock_shares() |>
     .carry_forward_shares(sort(unique(needs_split$year)))
   split_result <- needs_split |>
     dplyr::select(-item_cbs_code) |>
@@ -1464,8 +1461,16 @@ build_primary_production <- function(
     dplyr::select(year, area_code, area, Item_Code, item_cbs_code, share)
 }
 
-.compute_stock_shares <- function(years) {
-  fao_stocks <- .read_livestock_stocks(years = years)
+.compute_stock_shares <- function() {
+  # Read the stock series over its full span rather than the caller's window.
+  # `.carry_forward_shares()` fills these shares along the year axis precisely
+  # because the pin lags QCL slaughter, so it needs the years either side of the
+  # requested window to fill from; a scoped read leaves it nothing to carry and
+  # the inner_join in `.split_slaughter_by_shares()` then drops the row (#665).
+  # This is safe because a share is a within-year ratio: extra years add rows
+  # without changing any existing year's value, and that join restricts the
+  # result to the requested years anyway.
+  fao_stocks <- .read_livestock_stocks(years = NULL)
   split_parents <- whep::animals_codes |>
     dplyr::count(Item_Code) |>
     dplyr::filter(n > 1) |>
@@ -1499,12 +1504,12 @@ build_primary_production <- function(
     dplyr::select(year, area_code, area, Item_Code, item_cbs_code, share)
 }
 
-.build_livestock_slaughter <- function(fao_combined, years = NULL) {
+.build_livestock_slaughter <- function(fao_combined) {
   cli::cli_progress_step("Building livestock slaughter counts")
   items <- whep::items_cbs
   smap <- .build_slaughter_map()
   raw <- .read_slaughter_raw(fao_combined, smap)
-  result <- .split_slaughter_by_shares(raw, years)
+  result <- .split_slaughter_by_shares(raw)
 
   result |>
     dplyr::left_join(

--- a/tests/testthat/test_stock_share_territory_key.R
+++ b/tests/testthat/test_stock_share_territory_key.R
@@ -45,7 +45,7 @@ testthat::test_that(".compute_stock_shares keys shares by reporting territory", 
     .read_livestock_stocks = function(years = NULL) .two_territory_stocks()
   )
 
-  result <- whep:::.compute_stock_shares(2015L)
+  result <- whep:::.compute_stock_shares()
 
   # `area` is half the key and must survive to the caller: without it the
   # downstream join cannot tell the two territories apart.
@@ -112,4 +112,26 @@ testthat::test_that(".carry_forward_shares keeps two territories in one bucket a
   sums <- result |>
     dplyr::summarise(total = sum(share), .by = c(year, area_code, area))
   testthat::expect_equal(sums$total, rep(1, 4))
+})
+
+# .compute_stock_shares reads its own span (issue #665) -----------------------
+
+testthat::test_that(".compute_stock_shares does not scope the stock read", {
+  # The shares are carried along the year axis by `.carry_forward_shares()`,
+  # because the faostat-emissions-livestock pin lags QCL slaughter by 1-2 years.
+  # A read scoped to the caller's window leaves that fill nothing to carry from,
+  # and the inner_join in `.split_slaughter_by_shares()` then drops the slaughter
+  # row outright -- 2 Singapore rows at 2010 (#665). Assert the read is asked for
+  # the whole series, since that is the property the fix turns on.
+  asked_for <- "unset"
+  testthat::local_mocked_bindings(
+    .read_livestock_stocks = function(years = NULL) {
+      asked_for <<- years
+      .two_territory_stocks()
+    }
+  )
+
+  whep:::.compute_stock_shares()
+
+  testthat::expect_null(asked_for)
 })


### PR DESCRIPTION
Closes #665. First of the three defects split out of #625.

**Classification: mechanical.** A scoped build must not silently return fewer
rows than the full build filtered to the same years. Full-range output is
unchanged.

## The bug

`.compute_stock_shares()` read the livestock stock series scoped to the caller's
year window. But `.carry_forward_shares()` then fills those shares **along the
year axis**, and the comment above the call explains exactly why:

> Stock shares come from the faostat-emissions-livestock pin, which lags QCL
> slaughter by 1-2 years. Carry the latest known share forward … **Without this
> the inner_join drops those years and cattle/swine/chicken slaughtered_heads
> silently vanish.**

A window narrower than that lag leaves the fill nothing to carry from, the share
comes out `NA`, and the `inner_join` in `.split_slaughter_by_shares()` drops the
slaughter row outright.

Same shape as the fodder defect in #626: a quantity reconstructed across the
year axis cannot be reconstructed inside a one-year window.

## Evidence

Measured at 2010, 2 rows lost, both `source = FAOSTAT_prod`:

| area_code | item_prod_code | item | unit | value |
| --- | --- | --- | --- | --- |
| 200 (Singapore) | 1049 | Pigs (swine, market) | `slaughtered_heads` | 260,013.6 |
| 200 (Singapore) | 1051 | Hogs (swine, breeding) | `slaughtered_heads` | 28,890.4 |

Localised by probing the private chain stage by stage rather than guessing:

| stage | narrow | full |
| --- | --- | --- |
| `.build_livestock_stocks()` | 2/2 | 2/2 |
| **`.build_livestock_slaughter()`** | **0/2** | **2/2** |

## The fix

Read the stock series over its full span. Safe because a share is a
**within-year ratio** — extra years add rows without changing any existing
year's value, and the join restricts the result to the requested years anyway.
Cheap too: 3.3 s for 191,146 rows.

`years` then has no remaining use in `.compute_stock_shares()`,
`.split_slaughter_by_shares()` or `.build_livestock_slaughter()`, so it is
dropped rather than left as an unused argument — the slaughter rows are already
scoped by `fao_combined`.

## Verification, on real data

| | before | after |
| --- | --- | --- |
| `slaughtered_heads` relative difference | 4.7104e-06 | **exactly 0** |
| rows, scoped vs full | 1751 / 1753 | **1753 / 1753** |
| Singapore rows in the scoped build | 0 | **2** |
| full-range data payload | — | **`identical()`** |

The only differences in the full-range comparison are inside the diagnostic
`.cb_extracts` attribute's row order — 32 of them, **none in the data**. That
ordering is pre-existing nondeterminism: two runs of *unmodified* `main` produce
it too (confirmed earlier while verifying #626).

`devtools::test()` on the touched files: 136 pass, 0 failed.

## Test

The new test asserts the property the fix turns on — that the reader is asked
for the whole series, not a window — by capturing the `years` argument through
the existing mock, so it stays offline.

## Not fixed here

The other two clusters from #625 are untouched and still open: **#666** (duck
products, 9 rows, synthesised by `.compute_yields()`) and **#667** (crop `t_ha`,
5 rows, dropped in `.finalise_primary()`). After this PR the remaining
year-scoping residual is 2.954e-04, all of it those two.

🤖 Generated with [Claude Code](https://claude.com/claude-code)