### PR TITLE
feat(water-balance): select consumptive water by CFT band (#107)

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,31 @@
 # whep (development version)
 
+* **`build_water_balance()` can now charge a single crop's water, and the
+  per-CFT consumptive-water cubes are readable at all.** `read_lpjml_hydrology()`
+  gains `"cft_consump_water_b"` / `"cft_consump_water_g"`, and
+  `build_water_balance(bands = )` restricts the consumptive-water and
+  `cft_nir` terms to named crop-functional-type bands, e.g.
+  `bands = "rainfed grassland"` to charge a grazing footprint the grassland
+  water alone rather than every crop in the cell. Bands are selected by the
+  `band_name` the file itself carries, never by index, so a run configured with
+  a different band set aborts instead of silently charging the wrong crop.
+  `bands = NULL` (the default) totals every band, so existing callers are
+  unaffected. Three fixes were needed to get there, each of which would have
+  produced wrong numbers rather than an error:
+  * The `cft_nir` map entry named `mcft_nir.nc` holding a monthly `cft_nir`
+    variable. **No WHEP run has ever written that file**: all nine runs, 5.9.7
+    and 6.1.1 alike, write `cft_nir.nc` holding annual `nir`. Reading it would
+    simply have failed; nothing called it yet.
+  * The reader assumed twelve time steps per year for every variable. The
+    per-CFT consumptive-water cubes are annual (`nstep` 1, mm/yr), so their
+    time axis was decoded as months, mapping year *y* to year 1901 + (y-1901)/12
+    and slicing the wrong years out of the file entirely.
+  * `ncvar_get()` drops length-1 dimensions, so slicing one year out of an
+    annual per-CFT cube returned a 3-D slab whose *band* axis was then decoded
+    as *time* — scrambling crops into years. Now read with
+    `collapse_degen = FALSE`. Monthly cubes never hit this, because a one-year
+    slice is still twelve steps.
+
 * **`build_carbon_balance()` is about a quarter faster, with output unchanged
   to the last bit.** The RothC/HSOC climate modifier is now computed for every
   cell-year at once instead of once per (cell, year, land use) -- roughly 1.2e6

--- a/R/lpjml_hydrology.R
+++ b/R/lpjml_hydrology.R
@@ -12,9 +12,25 @@
 #       mrunoff.nc -> "runoff", mdischarge.nc -> "discharge"
 #     mswc.nc -> "SWC" (4-D lon x lat x layer[6] x time, fractional saturation
 #       0-1; layers at 200/500/1000/2000/3000/13000 mm).
-#     mcft_nir.nc -> "cft_nir" (net irrigation requirement, mm/month, per-CFT
-#       band dimension; the blue-water net-demand BW_net analogue).
-# - Monthly time index for year y, month m = (y - first_year) * 12 + m.
+#     cft_nir.nc -> "nir" (net irrigation requirement, mm/yr, per-CFT band
+#       dimension; the blue-water net-demand BW_net analogue). NOT "mcft_nir.nc"
+#       holding "cft_nir" monthly, as this map claimed until 2026-08: no WHEP
+#       run has ever written that file. Checked every run under
+#       LPJmL_runs/ (nine runs, 5.9.7 and 6.1.1 alike): all write cft_nir.nc,
+#       var "nir", nstep 1, 32 bands. The wrong entry never surfaced because
+#       nothing calls this variable yet (see the TODO in R/water_balance.R).
+#     cft_consump_water_b.nc holds var "consump_water_b", and
+#       cft_consump_water_g.nc holds "consump_water_g" (consumptive blue and
+#       green water, mm/yr, per-CFT band). Inspected in a completed 6.1.1
+#       run: these are ANNUAL outputs (nstep 1, timestep 1, units mm/yr), not
+#       monthly, so their time axis is one step per year, not twelve.
+# - The per-CFT cubes carry 32 bands, named in the file's NamePFT variable:
+#   bands 1-16 rainfed, 17-32 irrigated, in the same crop order; "rainfed
+#   grassland" is band 14 and "irrigated grassland" band 30. Select bands by
+#   name (band_name) rather than by index, so a run configured with a different
+#   band set fails loudly instead of silently charging the wrong crop.
+# - Monthly time index for year y, month m = (y - first_year) * 12 + m; annual
+#   variables index simply as y - first_year + 1.
 # - Local dev run dir is read from Sys.getenv("WHEP_LPJML_RUN_DIR"); never
 #   hardcode an absolute path in committed code.
 
@@ -31,7 +47,10 @@
 #'
 #' @param var Logical variable name, one of `"drainage"`, `"transp"`,
 #'   `"evap"`, `"interc"`, `"aet"`, `"prec"`, `"rain"`, `"irrig"`, `"runoff"`,
-#'   `"discharge"`, `"swc"` or `"cft_nir"` (per-CFT net irrigation requirement).
+#'   `"discharge"`, `"swc"`, `"cft_nir"` (per-CFT net irrigation requirement)
+#'   or the per-CFT consumptive-water cubes `"cft_consump_water_b"` (blue) and
+#'   `"cft_consump_water_g"` (green). The per-CFT variables keep their `band`
+#'   dimension, and carry `band_name` when the file names its bands.
 #' @param run_dir Path to the LPJmL run output directory. Defaults to
 #'   `Sys.getenv("WHEP_LPJML_RUN_DIR")`.
 #' @param years Optional integer vector of calendar years to keep. `NULL`
@@ -39,7 +58,10 @@
 #' @param first_year First calendar year of the run's monthly time axis.
 #' @param monthly If `TRUE`, return one row per cell-month; if `FALSE`,
 #'   aggregate the 12 months of each year per cell (flux variables summed,
-#'   soil water content averaged).
+#'   soil water content averaged). Immaterial for the annual per-CFT
+#'   consumptive-water variables, which LPJmL writes one step per year: they
+#'   carry no `month` column either way, and aggregating them groups rows that
+#'   are already one per cell-year-band.
 #' @param agg Annual aggregation for `monthly = FALSE`, `"sum"` (flux default)
 #'   or `"mean"` (soil-water default).
 #' @param data Optional pre-read tibble (`lon`, `lat`, `year`, `month`,
@@ -48,8 +70,9 @@
 #' @param example If `TRUE`, return a small fixture instead of reading remote
 #'   data. Defaults to `FALSE`.
 #' @return A tibble with columns `lon`, `lat`, `year`, `value` (plus `month`
-#'   when `monthly = TRUE`, `layer` for `"swc"`, and `band` for
-#'   `"cft_nir"`).
+#'   for the monthly variables when `monthly = TRUE`, `layer` for `"swc"`, and
+#'   `band` plus `band_name` for the per-CFT variables). The annual per-CFT
+#'   consumptive-water variables never carry `month`.
 #' @export
 #' @examples
 #' read_lpjml_hydrology(example = TRUE)
@@ -66,7 +89,9 @@ read_lpjml_hydrology <- function(
     "runoff",
     "discharge",
     "swc",
-    "cft_nir"
+    "cft_nir",
+    "cft_consump_water_b",
+    "cft_consump_water_g"
   ),
   run_dir = NULL,
   years = NULL,
@@ -88,22 +113,42 @@ read_lpjml_hydrology <- function(
   if (monthly) long else .aggregate_hydro_annual(long, var, agg)
 }
 
-# Logical name -> (file, in-file variable) for each LPJmL hydrology output.
+# Logical name -> (file, in-file variable, time steps per year) for each LPJmL
+# hydrology output. `steps_per_year` is 12 for the monthly outputs and 1 for the
+# annual per-CFT consumptive-water cubes (see the header facts).
 .hydro_var_map <- function() {
   tibble::tribble(
-    ~var, ~file, ~netcdf_var,
-    "drainage", "mseepage.nc", "seepage",
-    "transp", "mtransp.nc", "transp",
-    "evap", "mevap.nc", "evap",
-    "interc", "minterc.nc", "interc",
-    "prec", "mprec.nc", "prec",
-    "rain", "mrain.nc", "rain",
-    "irrig", "mirrig.nc", "irrig",
-    "runoff", "mrunoff.nc", "runoff",
-    "discharge", "mdischarge.nc", "discharge",
-    "swc", "mswc.nc", "SWC",
-    "cft_nir", "mcft_nir.nc", "cft_nir"
+    ~var, ~file, ~netcdf_var, ~steps_per_year,
+    "drainage", "mseepage.nc", "seepage", 12L,
+    "transp", "mtransp.nc", "transp", 12L,
+    "evap", "mevap.nc", "evap", 12L,
+    "interc", "minterc.nc", "interc", 12L,
+    "prec", "mprec.nc", "prec", 12L,
+    "rain", "mrain.nc", "rain", 12L,
+    "irrig", "mirrig.nc", "irrig", 12L,
+    "runoff", "mrunoff.nc", "runoff", 12L,
+    "discharge", "mdischarge.nc", "discharge", 12L,
+    "swc", "mswc.nc", "SWC", 12L,
+    "cft_nir", "cft_nir.nc", "nir", 1L,
+    "cft_consump_water_b", "cft_consump_water_b.nc", "consump_water_b", 1L,
+    "cft_consump_water_g", "cft_consump_water_g.nc", "consump_water_g", 1L
   )
+}
+
+# The logical variables whose third dimension is a per-CFT band rather than a
+# soil layer.
+.hydro_band_vars <- function() {
+  c("cft_nir", "cft_consump_water_b", "cft_consump_water_g")
+}
+
+# Time steps per year for a logical variable; 12 (monthly) unless mapped
+# otherwise. The synthetic "aet" is built from monthly components.
+.hydro_steps_per_year <- function(var) {
+  if (var == "aet") {
+    return(12L)
+  }
+  spec <- .hydro_var_map()
+  spec$steps_per_year[[match(var, spec$var)]]
 }
 
 # LPJmL 6.x renames some output variables to their CF short names, so the name
@@ -115,7 +160,12 @@ read_lpjml_hydrology <- function(
 # byte-identical in name between 5.9.7 and 6.1.1, verified against completed
 # runs of both.
 .hydro_var_aliases <- function() {
-  list(prec = "pr")
+  list(
+    prec = "pr",
+    nir = "cft_nir",
+    consump_water_b = "cft_consump_water_b",
+    consump_water_g = "cft_consump_water_g"
+  )
 }
 
 # The in-file name for a mapped variable, tolerating the 6.x renames.
@@ -173,7 +223,8 @@ read_lpjml_hydrology <- function(
     file.path(run_dir, spec$file),
     spec$netcdf_var,
     first_year,
-    years
+    years,
+    spec$steps_per_year
   )
 }
 
@@ -187,7 +238,8 @@ read_lpjml_hydrology <- function(
       file.path(run_dir, row$file),
       row$netcdf_var,
       first_year,
-      years
+      years,
+      row$steps_per_year
     )
   })
   data.table::rbindlist(parts) |>
@@ -208,7 +260,13 @@ read_lpjml_hydrology <- function(
 # (called by the caller after this returns) narrows it down to the exact
 # requested years as a post-hoc safety net -- a deliberate, acceptable scope
 # boundary, not a full general solution.
-.read_hydro_one <- function(path, netcdf_var, first_year, years = NULL) {
+.read_hydro_one <- function(
+  path,
+  netcdf_var,
+  first_year,
+  years = NULL,
+  steps_per_year = 12L
+) {
   if (!file.exists(path)) {
     cli::cli_abort("LPJmL hydrology file not found: {.file {path}}.")
   }
@@ -217,21 +275,54 @@ read_lpjml_hydrology <- function(
   netcdf_var <- .hydro_resolve_var(nc, netcdf_var, path)
   lon <- ncdf4::ncvar_get(nc, "lon")
   lat <- ncdf4::ncvar_get(nc, "lat")
-  slice <- .hydro_time_slice(nc, netcdf_var, first_year, years)
+  slice <- .hydro_time_slice(
+    nc,
+    netcdf_var,
+    first_year,
+    years,
+    steps_per_year
+  )
+  # collapse_degen = FALSE keeps length-1 dimensions. Without it, slicing a
+  # single year out of an annual per-CFT cube drops the time axis, leaving a
+  # 3-D slab whose band dimension the decoder would read as time -- silently
+  # scrambling crop bands into years. Monthly cubes never hit this (a one-year
+  # slice is still 12 steps), which is why it only surfaced with annual data.
   slab <- if (is.null(slice)) {
-    ncdf4::ncvar_get(nc, netcdf_var)
+    ncdf4::ncvar_get(nc, netcdf_var, collapse_degen = FALSE)
   } else {
     ncdf4::ncvar_get(
       nc,
       netcdf_var,
       start = slice$start,
-      count = slice$count
+      count = slice$count,
+      collapse_degen = FALSE
     )
   }
-  n_time <- if (is.null(slice)) nc$dim[["time"]]$len else slice$n_months
+  n_time <- if (is.null(slice)) nc$dim[["time"]]$len else slice$n_steps
   slab_first_year <- if (is.null(slice)) first_year else slice$slab_first_year
-  dt <- .hydro_slab_to_long(slab, lon, lat, n_time, slab_first_year)
-  tibble::as_tibble(dt)
+  dt <- .hydro_slab_to_long(
+    slab,
+    lon,
+    lat,
+    n_time,
+    slab_first_year,
+    steps_per_year
+  )
+  .hydro_attach_band_names(tibble::as_tibble(dt), nc)
+}
+
+# Attach the file's own band names to a per-CFT cube, so callers select a band
+# by name ("rainfed grassland") instead of by a positional index that a
+# differently configured run would silently redefine. Runs here at the raw
+# decoder's `layer` name, before .hydro_name_band() renames it to `band`.
+# Files without the NamePFT variable (every non-CFT output, soil water content
+# included) pass through unchanged.
+.hydro_attach_band_names <- function(long, nc) {
+  if (!rlang::has_name(long, "layer") || !("NamePFT" %in% names(nc$var))) {
+    return(long)
+  }
+  names_pft <- as.character(ncdf4::ncvar_get(nc, "NamePFT"))
+  dplyr::mutate(long, band_name = names_pft[.data$layer])
 }
 
 # Compute the ncvar_get() start=/count= slice covering min(years):max(years),
@@ -239,33 +330,49 @@ read_lpjml_hydrology <- function(
 # .hydro_slab_to_long() decodes year/month correctly for a slab that no
 # longer starts at the file's own first_year). Returns NULL when years is
 # NULL (caller then falls back to the full, unsliced read).
-.hydro_time_slice <- function(nc, netcdf_var, first_year, years) {
+.hydro_time_slice <- function(
+  nc,
+  netcdf_var,
+  first_year,
+  years,
+  steps_per_year = 12L
+) {
   if (is.null(years)) {
     return(NULL)
   }
   slab_first_year <- min(years)
   last_year <- max(years)
-  time_start <- (slab_first_year - first_year) * 12L + 1L
-  n_months <- (last_year - slab_first_year + 1L) * 12L
+  time_start <- (slab_first_year - first_year) * steps_per_year + 1L
+  n_steps <- (last_year - slab_first_year + 1L) * steps_per_year
   ndims <- nc$var[[netcdf_var]]$ndims
   if (ndims == 4L) {
     start <- c(1, 1, 1, time_start)
-    count <- c(-1, -1, -1, n_months)
+    count <- c(-1, -1, -1, n_steps)
   } else {
     start <- c(1, 1, time_start)
-    count <- c(-1, -1, n_months)
+    count <- c(-1, -1, n_steps)
   }
   list(
     start = start,
     count = count,
-    n_months = n_months,
+    n_steps = n_steps,
     slab_first_year = slab_first_year
   )
 }
 
 # Reshape a (lon, lat, [layer,] time) array into a long data.table with the
-# monthly time axis decomposed into calendar year and month.
-.hydro_slab_to_long <- function(slab, lon, lat, n_time, first_year) {
+# time axis decomposed into calendar year and, for monthly cubes, month.
+# Annual cubes (steps_per_year = 1) carry one step per year and so get no
+# month column: there is no month to report, and inventing one would let a
+# caller sum twelve copies of an annual mm/yr value.
+.hydro_slab_to_long <- function(
+  slab,
+  lon,
+  lat,
+  n_time,
+  first_year,
+  steps_per_year = 12L
+) {
   has_layer <- length(dim(slab)) == 4L
   n_layer <- if (has_layer) dim(slab)[3] else 1L
   dt <- data.table::data.table(
@@ -278,13 +385,26 @@ read_lpjml_hydrology <- function(
     ),
     value = as.vector(slab)
   )
-  dt[, year := first_year + (time_index - 1L) %/% 12L]
-  dt[, month := ((time_index - 1L) %% 12L) + 1L]
-  if (has_layer) {
-    dt[, .(lon, lat, year, month, layer, value)]
-  } else {
-    dt[, .(lon, lat, year, month, value)]
+  dt[, year := first_year + (time_index - 1L) %/% steps_per_year]
+  if (steps_per_year == 1L) {
+    return(.hydro_select_long(dt, has_layer, monthly = FALSE))
   }
+  dt[, month := ((time_index - 1L) %% steps_per_year) + 1L]
+  .hydro_select_long(dt, has_layer, monthly = TRUE)
+}
+
+# Select the long-form output columns, keeping `layer` only for cubes that have
+# one and `month` only for monthly cubes.
+.hydro_select_long <- function(dt, has_layer, monthly) {
+  keep <- c(
+    "lon",
+    "lat",
+    "year",
+    if (monthly) "month",
+    if (has_layer) "layer",
+    "value"
+  )
+  dt[, .SD, .SDcols = keep]
 }
 
 # The generic 4-D decoder calls the third dimension `layer`, which is correct
@@ -293,7 +413,8 @@ read_lpjml_hydrology <- function(
 # `band` passes through unchanged.
 .hydro_name_band <- function(long, var) {
   if (
-    var == "cft_nir" &&
+    var %in%
+      .hydro_band_vars() &&
       rlang::has_name(long, "layer") &&
       !rlang::has_name(long, "band")
   ) {
@@ -310,7 +431,7 @@ read_lpjml_hydrology <- function(
     "lon",
     "lat",
     "year",
-    intersect(c("layer", "band"), names(long))
+    intersect(c("layer", "band", "band_name"), names(long))
   )
   reducer <- if (agg == "mean") base::mean else base::sum
   dplyr::summarise(

--- a/R/water_balance.R
+++ b/R/water_balance.R
@@ -37,7 +37,8 @@
 #' blue-water volume), which satisfy `water_input_mm = prec_mm + irrig_mm`;
 #' `blue_consump_mm` and `green_consump_mm`, the LPJmL-native consumptive blue
 #' and green water (the per-CFT `cft_consump_water_b` / `cft_consump_water_g`
-#' totals when supplied, otherwise the blue and green AET); and `cft_nir_mm`,
+#' cubes when supplied, summed over the bands `bands` selects, otherwise the
+#' blue and green AET); and `cft_nir_mm`,
 #' the net irrigation requirement (LPJmL `cft_nir`), the net blue-water demand,
 #' summed to cell level when `data$cft_nir` is supplied and `NA` otherwise.
 #' Potential evapotranspiration (`pet_mm`) comes from the CRU climate forcing
@@ -53,6 +54,16 @@
 #'   left out take their default.
 #' @param resolution `"grid"` (per cell, default) or `"polity"` (aggregated to
 #'   `year` and `area_code`).
+#' @param bands Optional character vector of LPJmL crop-functional-type band
+#'   names restricting which bands the per-CFT consumptive-water and net
+#'   irrigation terms are summed over, e.g. `"rainfed grassland"` to charge a
+#'   grazing footprint the grassland water alone. `NULL` (default) sums every
+#'   band, the whole-cell total. Bands are matched on the `band_name` the file
+#'   itself carries, so an unknown name aborts rather than silently returning
+#'   the whole-cell total; the band index is never used, because which crop a
+#'   given index denotes is a property of how the run was configured. Only the
+#'   consumptive-water and `cft_nir` terms are per-CFT, so this leaves the
+#'   water budget itself (AET, runoff, drainage) untouched.
 #' @param data Optional named list of pre-loaded inputs to avoid NetCDF reads:
 #'   hydrology tibbles `transp`, `evap`, `interc`, `prec`, `irrig`, `runoff`
 #'   and `seepage` (each `lon`, `lat`, `year`, `value`; annual-summed
@@ -65,6 +76,9 @@
 #'   and a `cell_polity` crosswalk (`lon`, `lat`, `area_code`, `polity_frac`,
 #'   `cell_area_ha`). Each falls back to [read_lpjml_hydrology()] when absent,
 #'   except `cft_nir` (see Details), `pet` and the consumptive-water inputs.
+#'   Read the latter with
+#'   `read_lpjml_hydrology("cft_consump_water_g", monthly = FALSE)`, which
+#'   names their CFT bands so `bands` can select among them.
 #' @param example If `TRUE`, return a small fixture instead of reading data.
 #'   Defaults to `FALSE`.
 #' @return A tibble. For `resolution = "grid"`: `lon`, `lat`, `area_code`,
@@ -81,6 +95,7 @@ build_water_balance <- function(
   method = list(),
   resolution = c("grid", "polity"),
   data = list(),
+  bands = NULL,
   example = FALSE
 ) {
   resolution <- rlang::arg_match(resolution)
@@ -88,7 +103,7 @@ build_water_balance <- function(
   if (isTRUE(example)) {
     return(.wb_example(method, resolution))
   }
-  .wb_read_inputs(data, method) |>
+  .wb_read_inputs(data, method, bands) |>
     .wb_compute_terms(method) |>
     .wb_blue_green(method) |>
     .wb_attach_polity(data) |>
@@ -211,7 +226,7 @@ get_soc_climate_drivers <- function(
 # it and join on the cell-year key into one wide tibble. The seepage term uses
 # the reader's logical "drainage" var (mseepage.nc) but the data override key is
 # `seepage`. The soil-water-change term is appended from the layered swc.
-.wb_read_inputs <- function(data, method) {
+.wb_read_inputs <- function(data, method, bands = NULL) {
   # name -> reader logical var; data overrides use the name (e.g. data$seepage).
   flux_vars <- c(
     transp = "transp",
@@ -237,7 +252,7 @@ get_soc_climate_drivers <- function(
     dplyr::inner_join,
     by = c("lon", "lat", "year")
   )
-  .wb_attach_cft_consump(wide, data)
+  .wb_attach_cft_consump(wide, data, bands)
 }
 
 # Attach cell-level blue/green consumptive water and net irrigation requirement
@@ -245,26 +260,59 @@ get_soc_climate_drivers <- function(
 # `cft_nir` inputs, summing the crop-band values per cell-year. Columns are NA
 # when the corresponding per-CFT input is not supplied; the all-NA blue/green
 # consumptive columns make the cft_native split fall back (see .wb_blue_green()).
-.wb_attach_cft_consump <- function(wide, data) {
+# `bands` restricts which CFT bands are summed (see .wb_filter_bands()).
+.wb_attach_cft_consump <- function(wide, data, bands = NULL) {
   band_inputs <- list(
     consump_blue_mm = data$cft_consump_water_b,
     consump_green_mm = data$cft_consump_water_g,
     cft_nir_mm = data$cft_nir
   )
   purrr::reduce2(
-    band_inputs,
+    purrr::map(band_inputs, .wb_filter_bands, bands = bands),
     names(band_inputs),
     .wb_join_cell_band,
     .init = wide
   )
 }
 
+# Keep only the named CFT bands of a per-CFT input before it is summed to the
+# cell. `bands = NULL` keeps every band, the whole-cell total.
+#
+# Selection is by `band_name` ("rainfed grassland"), never by band index: the
+# index is a property of how a run was configured, so a positional filter would
+# keep charging band 14 even in a run whose band 14 is a different crop. An
+# input without `band_name` therefore cannot be filtered, and asking to filter
+# one is an error rather than a silent whole-cell total.
+.wb_filter_bands <- function(raw, bands) {
+  if (is.null(raw) || is.null(bands)) {
+    return(raw)
+  }
+  if (!rlang::has_name(raw, "band_name")) {
+    cli::cli_abort(c(
+      "Cannot select CFT bands from an input without {.field band_name}.",
+      i = "{.arg bands} was {.val {bands}}.",
+      i = "Read the input with {.fun read_lpjml_hydrology}, which names the \\
+           bands from the file, or drop {.arg bands} to total every band."
+    ))
+  }
+  missing <- setdiff(bands, unique(raw$band_name))
+  if (length(missing) > 0L) {
+    cli::cli_abort(c(
+      "CFT band{?s} {.val {missing}} {?is/are} not in this input.",
+      i = "Available: {.val {sort(unique(raw$band_name))}}."
+    ))
+  }
+  dplyr::filter(raw, .data$band_name %in% bands)
+}
+
 # Join one per-CFT band input summed to cell-year as `out_col`, or add an all-NA
 # column when the input is absent.
-# TODO(cft_nir): optionally wire read_lpjml_hydrology("cft_nir") here once
-# build_water_balance() has a run-directory/year contract. Until then
-# cft_nir_mm is NA unless `data$cft_nir` is supplied as a cell-year (or
-# per-band) `lon`,`lat`,`year`,`value` tibble.
+# cft_nir stays opt-in: read_lpjml_hydrology("cft_nir") now resolves (its map
+# entry was corrected in 2026-08, having named a file no run ever wrote), but
+# the cube is ~3 GB and nothing consumes cft_nir_mm yet, so reading it by
+# default would cost every caller for an unused column. cft_nir_mm is NA unless
+# `data$cft_nir` is supplied as a cell-year (or per-band) `lon`,`lat`,`year`,
+# `value` tibble.
 .wb_join_cell_band <- function(wide, raw, out_col) {
   summed <- .wb_cell_consump(raw, out_col)
   if (is.null(summed)) {

--- a/man/build_water_balance.Rd
+++ b/man/build_water_balance.Rd
@@ -8,6 +8,7 @@ build_water_balance(
   method = list(),
   resolution = c("grid", "polity"),
   data = list(),
+  bands = NULL,
   example = FALSE
 )
 }
@@ -34,7 +35,21 @@ net-irrigation-requirement input (\code{lon}, \code{lat}, \code{year}, \code{val
 summed to cell level when supplied; exposed as \code{cft_nir_mm}, else \code{NA})
 and a \code{cell_polity} crosswalk (\code{lon}, \code{lat}, \code{area_code}, \code{polity_frac},
 \code{cell_area_ha}). Each falls back to \code{\link[=read_lpjml_hydrology]{read_lpjml_hydrology()}} when absent,
-except \code{cft_nir} (see Details), \code{pet} and the consumptive-water inputs.}
+except \code{cft_nir} (see Details), \code{pet} and the consumptive-water inputs.
+Read the latter with
+\code{read_lpjml_hydrology("cft_consump_water_g", monthly = FALSE)}, which
+names their CFT bands so \code{bands} can select among them.}
+
+\item{bands}{Optional character vector of LPJmL crop-functional-type band
+names restricting which bands the per-CFT consumptive-water and net
+irrigation terms are summed over, e.g. \code{"rainfed grassland"} to charge a
+grazing footprint the grassland water alone. \code{NULL} (default) sums every
+band, the whole-cell total. Bands are matched on the \code{band_name} the file
+itself carries, so an unknown name aborts rather than silently returning
+the whole-cell total; the band index is never used, because which crop a
+given index denotes is a property of how the run was configured. Only the
+consumptive-water and \code{cft_nir} terms are per-CFT, so this leaves the
+water budget itself (AET, runoff, drainage) untouched.}
 
 \item{example}{If \code{TRUE}, return a small fixture instead of reading data.
 Defaults to \code{FALSE}.}
@@ -67,7 +82,8 @@ The output also exposes the footprint-relevant terms folded into the budget:
 blue-water volume), which satisfy \code{water_input_mm = prec_mm + irrig_mm};
 \code{blue_consump_mm} and \code{green_consump_mm}, the LPJmL-native consumptive blue
 and green water (the per-CFT \code{cft_consump_water_b} / \code{cft_consump_water_g}
-totals when supplied, otherwise the blue and green AET); and \code{cft_nir_mm},
+cubes when supplied, summed over the bands \code{bands} selects, otherwise the
+blue and green AET); and \code{cft_nir_mm},
 the net irrigation requirement (LPJmL \code{cft_nir}), the net blue-water demand,
 summed to cell level when \code{data$cft_nir} is supplied and \code{NA} otherwise.
 Potential evapotranspiration (\code{pet_mm}) comes from the CRU climate forcing

--- a/man/read_lpjml_hydrology.Rd
+++ b/man/read_lpjml_hydrology.Rd
@@ -6,7 +6,8 @@
 \usage{
 read_lpjml_hydrology(
   var = c("drainage", "transp", "evap", "interc", "aet", "prec", "rain", "irrig",
-    "runoff", "discharge", "swc", "cft_nir"),
+    "runoff", "discharge", "swc", "cft_nir", "cft_consump_water_b",
+    "cft_consump_water_g"),
   run_dir = NULL,
   years = NULL,
   first_year = 1901L,
@@ -19,7 +20,10 @@ read_lpjml_hydrology(
 \arguments{
 \item{var}{Logical variable name, one of \code{"drainage"}, \code{"transp"},
 \code{"evap"}, \code{"interc"}, \code{"aet"}, \code{"prec"}, \code{"rain"}, \code{"irrig"}, \code{"runoff"},
-\code{"discharge"}, \code{"swc"} or \code{"cft_nir"} (per-CFT net irrigation requirement).}
+\code{"discharge"}, \code{"swc"}, \code{"cft_nir"} (per-CFT net irrigation requirement)
+or the per-CFT consumptive-water cubes \code{"cft_consump_water_b"} (blue) and
+\code{"cft_consump_water_g"} (green). The per-CFT variables keep their \code{band}
+dimension, and carry \code{band_name} when the file names its bands.}
 
 \item{run_dir}{Path to the LPJmL run output directory. Defaults to
 \code{Sys.getenv("WHEP_LPJML_RUN_DIR")}.}
@@ -31,7 +35,10 @@ keeps every year present in the file.}
 
 \item{monthly}{If \code{TRUE}, return one row per cell-month; if \code{FALSE},
 aggregate the 12 months of each year per cell (flux variables summed,
-soil water content averaged).}
+soil water content averaged). Immaterial for the annual per-CFT
+consumptive-water variables, which LPJmL writes one step per year: they
+carry no \code{month} column either way, and aggregating them groups rows that
+are already one per cell-year-band.}
 
 \item{agg}{Annual aggregation for \code{monthly = FALSE}, \code{"sum"} (flux default)
 or \code{"mean"} (soil-water default).}
@@ -45,8 +52,9 @@ data. Defaults to \code{FALSE}.}
 }
 \value{
 A tibble with columns \code{lon}, \code{lat}, \code{year}, \code{value} (plus \code{month}
-when \code{monthly = TRUE}, \code{layer} for \code{"swc"}, and \code{band} for
-\code{"cft_nir"}).
+for the monthly variables when \code{monthly = TRUE}, \code{layer} for \code{"swc"}, and
+\code{band} plus \code{band_name} for the per-CFT variables). The annual per-CFT
+consumptive-water variables never carry \code{month}.
 }
 \description{
 Reads one monthly LPJmL hydrology output (drainage, evapotranspiration

--- a/tests/testthat/test_lpjml_hydrology.R
+++ b/tests/testthat/test_lpjml_hydrology.R
@@ -302,3 +302,102 @@ testthat::test_that("an unresolvable variable name aborts naming the file", {
     "totally_new"
   )
 })
+
+# Write a tiny annual per-CFT NetCDF (2 lon x 2 lat x 3 band x n_years), the
+# shape LPJmL writes for cft_consump_water_*: one time step per year, mm/yr,
+# with the band names carried in NamePFT the way a real run does.
+.lpjml_hydro_cft_fixture <- function(
+  var_name = "consump_water_g",
+  file = "cft_consump_water_g.nc",
+  first_year = 1901L,
+  n_years = 3L,
+  band_names = c("rainfed maize", "rainfed grassland", "irrigated grassland")
+) {
+  dir <- withr::local_tempdir(.local_envir = parent.frame())
+  lon <- c(-179.75, -179.25)
+  lat <- c(0.25, 0.75)
+  dim_lon <- ncdf4::ncdim_def("lon", "degrees_east", lon)
+  dim_lat <- ncdf4::ncdim_def("lat", "degrees_north", lat)
+  dim_pft <- ncdf4::ncdim_def("pft", "", seq_along(band_names))
+  dim_len <- ncdf4::ncdim_def("len", "", seq_len(max(nchar(band_names))))
+  dim_time <- ncdf4::ncdim_def("time", "years", seq_len(n_years))
+  var <- ncdf4::ncvar_def(
+    var_name,
+    "mm/yr",
+    list(dim_lon, dim_lat, dim_pft, dim_time),
+    missval = -9999
+  )
+  name_var <- ncdf4::ncvar_def(
+    "NamePFT",
+    "",
+    list(dim_len, dim_pft),
+    prec = "char"
+  )
+  path <- file.path(dir, file)
+  nc <- ncdf4::nc_create(path, list(var, name_var))
+  # value = band * 100 + year offset, so band and year are both identifiable.
+  vals <- array(
+    rep(seq_along(band_names) * 100, each = length(lon) * length(lat)) +
+      rep(
+        seq_len(n_years) - 1L,
+        each = length(lon) * length(lat) * length(band_names)
+      ),
+    dim = c(length(lon), length(lat), length(band_names), n_years)
+  )
+  ncdf4::ncvar_put(nc, var, vals)
+  ncdf4::ncvar_put(nc, name_var, band_names)
+  ncdf4::nc_close(nc)
+  list(dir = dir, n_cells = length(lon) * length(lat), band_names = band_names)
+}
+
+testthat::test_that("annual per-CFT cube decodes years, not months", {
+  cube <- .lpjml_hydro_cft_fixture(n_years = 3L)
+
+  result <- whep::read_lpjml_hydrology(
+    "cft_consump_water_g",
+    run_dir = cube$dir,
+    first_year = 1901L
+  )
+
+  # One row per cell-band-year, and no month axis invented from an annual file.
+  testthat::expect_false("month" %in% names(result))
+  testthat::expect_setequal(result$year, 1901:1903)
+  testthat::expect_equal(nrow(result), cube$n_cells * 3L * 3L)
+})
+
+testthat::test_that("per-CFT bands are named from the file, not by index", {
+  cube <- .lpjml_hydro_cft_fixture()
+
+  result <- whep::read_lpjml_hydrology(
+    "cft_consump_water_g",
+    run_dir = cube$dir,
+    first_year = 1901L
+  )
+
+  testthat::expect_true(all(c("band", "band_name") %in% names(result)))
+  testthat::expect_setequal(result$band_name, cube$band_names)
+  # Band 2 is grassland here; its value encodes band 2 (200 + year offset).
+  grass <- dplyr::filter(
+    result,
+    band_name == "rainfed grassland",
+    year == 1901L
+  )
+  testthat::expect_equal(unique(grass$value), 200)
+  testthat::expect_equal(unique(grass$band), 2L)
+})
+
+testthat::test_that("years= slices an annual cube on the annual time axis", {
+  cube <- .lpjml_hydro_cft_fixture(first_year = 1901L, n_years = 5L)
+
+  result <- whep::read_lpjml_hydrology(
+    "cft_consump_water_g",
+    run_dir = cube$dir,
+    first_year = 1901L,
+    years = 1903L
+  )
+
+  # A monthly time index would have read the wrong slice entirely.
+  testthat::expect_setequal(result$year, 1903L)
+  grass <- dplyr::filter(result, band_name == "rainfed grassland")
+  testthat::expect_equal(unique(grass$value), 202)
+})

--- a/tests/testthat/test_water_balance.R
+++ b/tests/testthat/test_water_balance.R
@@ -593,6 +593,71 @@ testthat::test_that("blue/green consumptive equal the per-CFT mm summed", {
   )
 })
 
+testthat::test_that("bands selects which CFT bands are summed", {
+  syn <- .wb_synthetic_monthly()
+  cells <- dplyr::distinct(syn$inputs$prec, lon, lat, year)
+  syn$inputs$cft_consump_water_g <- dplyr::bind_rows(
+    dplyr::mutate(cells, band = 3L, band_name = "rainfed maize", value = 180),
+    dplyr::mutate(
+      cells,
+      band = 14L,
+      band_name = "rainfed grassland",
+      value = 100
+    )
+  )
+  syn$inputs$cft_consump_water_b <- dplyr::mutate(
+    cells,
+    band = 14L,
+    band_name = "rainfed grassland",
+    value = 20
+  )
+
+  grass <- whep::build_water_balance(
+    data = syn$inputs,
+    bands = "rainfed grassland"
+  )
+  # Grassland alone (100), not the whole-cell total (100 + 180).
+  testthat::expect_equal(
+    grass$green_consump_mm,
+    rep(100, nrow(grass)),
+    tolerance = 1e-8
+  )
+
+  # The default still totals every band, so existing callers are unaffected.
+  all_bands <- whep::build_water_balance(data = syn$inputs)
+  testthat::expect_equal(
+    all_bands$green_consump_mm,
+    rep(280, nrow(all_bands)),
+    tolerance = 1e-8
+  )
+})
+
+testthat::test_that("an unknown or unnameable band aborts", {
+  syn <- .wb_synthetic_monthly()
+  cells <- dplyr::distinct(syn$inputs$prec, lon, lat, year)
+  named <- dplyr::mutate(
+    cells,
+    band = 14L,
+    band_name = "rainfed grassland",
+    value = 100
+  )
+  syn$inputs$cft_consump_water_b <- named
+  syn$inputs$cft_consump_water_g <- named
+
+  testthat::expect_error(
+    whep::build_water_balance(data = syn$inputs, bands = "rainfed sorghum"),
+    "not in this input"
+  )
+
+  # A band-name-less input cannot be filtered: aborting beats silently
+  # returning the whole-cell total under a grassland-only request.
+  syn$inputs$cft_consump_water_g <- dplyr::select(named, -band_name)
+  testthat::expect_error(
+    whep::build_water_balance(data = syn$inputs, bands = "rainfed grassland"),
+    "band_name"
+  )
+})
+
 testthat::test_that("polity resolution carries the new footprint columns", {
   pol <- whep::build_water_balance(resolution = "polity", example = TRUE)
   pointblank::expect_col_exists(


### PR DESCRIPTION
Prepares the ground for #116 (the water footprint extension, #107) by making
main's `build_water_balance()` able to answer the question that extension asks.

### The problem

`build_water_balance()` reads the per-CFT consumptive-water cubes and
immediately sums them over every crop band, so the only figure it can report is
the whole-cell total. A grazing water footprint needs **the grassland band
alone** — charging grazing the whole-cell total adds every wheat field and rice
paddy in the cell to the pasture.

### The change

`bands =` restricts the consumptive-water and `cft_nir` terms to named bands.
`NULL` (default) totals every band, so **existing callers are unaffected**.

```r
build_water_balance(bands = "rainfed grassland", data = ...)
```

Selection is by the `band_name` the file carries in `NamePFT`, **never by
index**: which crop a given index denotes is a property of how the run was
configured, so a positional filter would keep charging band 14 in a run whose
band 14 is a different crop. An unknown name — or an input with no band names
to match on — aborts rather than silently returning the whole-cell total.

### Three reader bugs found on the way

Each would have produced **wrong numbers rather than an error**:

| | |
|---|---|
| `cft_nir` mapped to `mcft_nir.nc` holding monthly `cft_nir` | **No WHEP run has ever written that file.** All nine runs under `LPJmL_runs/`, 5.9.7 and 6.1.1 alike, write `cft_nir.nc` holding annual `nir`, 32 bands. Never surfaced because nothing calls it yet. |
| Reader assumed 12 time steps/year for every variable | The per-CFT consumptive cubes are **annual** (`nstep` 1, mm/yr). Their time axis was decoded as months, so `years=` sliced the wrong range out of the file. |
| `ncvar_get()` drops length-1 dimensions | A single-year slice of an annual per-CFT cube came back 3-D and its **band** axis was decoded as **time**, scrambling crops into years. Now `collapse_degen = FALSE`. Monthly cubes never hit this — a one-year slice is still 12 steps. |

### Verification

Facts checked against the 6.1.1 production run
(`global_1901-2023_spinup_300_our_inputs_lpjml611`), not guessed: vars
`consump_water_b` / `consump_water_g`, `nstep` 1, mm/yr, 32 bands, band 14
`rainfed grassland`, band 30 `irrigated grassland`. The `mcft_nir.nc` claim was
checked against every run in the archive.

- 8 new tests (annual decode, band naming from file, annual `years=` slicing,
  band filtering, both abort paths).
- Full suite `[ FAIL 0 | PASS 6632 ]` · `air format` clean · lint clean ·
  `rcmdcheck` 0 errors / 0 warnings / 0 notes.

Only `bands = NULL` paths run today, so nothing in main changes numerically.

### Follow-up

#116 rebases onto this, drops its `water-grazing-green` pin (a country-aggregated
copy of exactly this LPJmL layer) and reads the grassland band from here
instead, per [[reuse what main already has]]. **Note for @eduaguilera:** that
extension charges grazing the *full* managed-grassland ET, consistent with
`build_grassland_land_extension(grassland_metric = "occupation")`. The
alternative — only the area needed to feed the animals, as in Schyns et al.
(2019) — is ~6x smaller and drives ~72% of the green water total. Proceeding on
the occupation basis for consistency with land, but it is your call to confirm.

🤖 Generated with [Claude Code](https://claude.com/claude-code)