### PR TITLE
Say which side of its period a coverage gap fell on, and measure #414's share of it

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,26 @@
 # whep (development version)
 
+* **`polity_coverage_gaps()` now says which direction a stand-in fell in, and
+  the two directions are not the same defect.** The new `gap_kind` column takes
+  `"polity_ended"` (the polity had ended by the row's year, so the value covers
+  a territory that entity no longer describes — whep#414's case) or
+  `"polity_not_started"` (the polity begins later, which is mostly WHEP's
+  documented pre-1961 back-cast onto the anchor-year territory). No published
+  value changes; this is a diagnostic gaining a column.
+  Measured on a real full-range `get_primary_production()` (6.3M rows), 7,247
+  rows — 0.115% — are attributed to a polity that was not live in the row's
+  year, and they split **3,285 rows across 3 areas** `"polity_ended"` against
+  **3,962 rows across 16 areas** `"polity_not_started"`. Bucket 206 is 2,938 of
+  the ended ones, 89%; the other two, FAOSTAT area 178 Eritrea (123 rows,
+  `ERI-1889-1952`) and area 273 Montenegro (224 rows, `MNE-1913-1918`), were
+  not previously named anywhere.
+  The classification is read at the year the resolver actually matched on, not
+  the row's year, because `backcast_anchor` floors the lookup year: a
+  pre-anchor row is matched as 1961 and can land on a polity that had already
+  ended by then. That is exactly 165 rows of areas 178 and 273, which the
+  raw-year comparison a caller could write for itself would label
+  `"polity_not_started"` instead.
+
 * **Every join that keys on a territory but not on a year is now classified,
   and the list can only shrink.** A key of `area_code` with no `year` spans
   every period of a territory's history, so it asserts that the area means one

--- a/R/polities.R
+++ b/R/polities.R
@@ -454,6 +454,27 @@ add_polity_code <- function(
 #' as a coverage gap: the polygon, population and period of the returned polity
 #' describe a different year than the value does.
 #'
+#' The two directions are not the same defect, so `gap_kind` names which one a
+#' row is:
+#'
+#' - `"polity_not_started"`: the polity begins after the row's year. This is
+#'   mostly WHEP's own back-cast convention rather than a hole -- pre-1961
+#'   series are back-cast onto the anchor-year territory, so a Soviet
+#'   republic's 1900 land is attributed to the republic that reports it today.
+#' - `"polity_ended"`: the polity had ended by the row's year, so the value
+#'   covers a territory that entity no longer describes. This is the harder
+#'   case, and the one whep#414 is about: FAOSTAT areas 276 Sudan and 277 South
+#'   Sudan fold into bucket 206, whose label `SUD-1956-2011` ended at the
+#'   secession, and no live polity means "Sudan and South Sudan".
+#'
+#' `gap_kind` is not derivable from the returned columns, which is why it is
+#' returned rather than left to the caller. The comparison is against the year
+#' the resolver actually matched on, which the back-cast anchor floors at
+#' `backcast_anchor`: an 1850 row for FAOSTAT area 273 Montenegro is matched as
+#' 1961 and lands on `MNE-1913-1918`, so it is `"polity_ended"`, while
+#' `year < polity_start_year` on the same row would call it
+#' `"polity_not_started"`.
+#'
 #' The resolution here is the same one the builds use, including the back-cast
 #' anchor, so it reports what the table actually got rather than a second
 #' reading of the crosswalk. The area column may hold either a FAOSTAT
@@ -471,10 +492,10 @@ add_polity_code <- function(
 #'
 #' @returns A tibble with one row per `(area_code, year)` resolved by a
 #'   stand-in, ordered by area code and year, carrying `area_code`, `year`,
-#'   `polity_code`, `polity_name`, `polity_start_year`, `polity_end_year` and
-#'   `n_rows`, the number of rows of `table` that pair carries. Zero rows means
-#'   every row of `table` landed inside its polity's period, which is the
-#'   intended state.
+#'   `polity_code`, `polity_name`, `polity_start_year`, `polity_end_year`,
+#'   `gap_kind` (`"polity_not_started"` or `"polity_ended"`) and `n_rows`, the
+#'   number of rows of `table` that pair carries. Zero rows means every row of
+#'   `table` landed inside its polity's period, which is the intended state.
 #'
 #' @seealso [add_polity_code()] for the resolution itself, and
 #'   [polity_bucket_coverage()] for the different defect of a bucket whose
@@ -531,7 +552,36 @@ polity_coverage_gaps <- function(
     )
   ] |>
     tibble::as_tibble() |>
+    dplyr::mutate(
+      gap_kind = .polity_gap_kind(
+        .data$year,
+        .data$polity_start_year,
+        backcast_anchor
+      ),
+      .before = "n_rows"
+    ) |>
     dplyr::arrange(.data$area_code, .data$year)
+}
+
+# Which side of its polity's period a stand-in fell on.
+#
+# The comparison is against the year the resolver matched on, not the row's
+# year: `.add_polity_columns_dt()` floors the lookup year at `backcast_anchor`,
+# so a pre-anchor row is matched as the anchor year and can land on a polity
+# that had already ENDED by then (FAOSTAT area 273 Montenegro back-casts onto
+# `MNE-1913-1918`). Comparing the raw year would call every such row
+# `"polity_not_started"` -- 165 rows of a real `get_primary_production()`,
+# areas 178 and 273.
+#
+# A polity with no published start year cannot be one this row precedes, so it
+# is reported as ended: `mapping_status == "out_of_span"` already established
+# that the row is outside the period in one direction or the other.
+.polity_gap_kind <- function(year, polity_start_year, backcast_anchor) {
+  match_year <- pmax(as.numeric(year), as.numeric(backcast_anchor))
+  not_started <- !is.na(polity_start_year) &
+    !is.na(match_year) &
+    match_year < polity_start_year
+  data.table::fifelse(not_started, "polity_not_started", "polity_ended")
 }
 
 # ---- ISO3 -> numeric area_code -----------------------------------------

--- a/man/polity_coverage_gaps.Rd
+++ b/man/polity_coverage_gaps.Rd
@@ -27,10 +27,10 @@ passed to the same resolution \code{\link[=add_polity_code]{add_polity_code()}} 
 \value{
 A tibble with one row per \verb{(area_code, year)} resolved by a
 stand-in, ordered by area code and year, carrying \code{area_code}, \code{year},
-\code{polity_code}, \code{polity_name}, \code{polity_start_year}, \code{polity_end_year} and
-\code{n_rows}, the number of rows of \code{table} that pair carries. Zero rows means
-every row of \code{table} landed inside its polity's period, which is the
-intended state.
+\code{polity_code}, \code{polity_name}, \code{polity_start_year}, \code{polity_end_year},
+\code{gap_kind} (\code{"polity_not_started"} or \code{"polity_ended"}) and \code{n_rows}, the
+number of rows of \code{table} that pair carries. Zero rows means every row of
+\code{table} landed inside its polity's period, which is the intended state.
 }
 \description{
 \code{\link[=add_polity_code]{add_polity_code()}} reports a nearest-period stand-in as
@@ -46,6 +46,28 @@ the area needs the missing period added to the crosswalk, or that the
 reporting area outlived (or predates) every polity mapped to it, so treat it
 as a coverage gap: the polygon, population and period of the returned polity
 describe a different year than the value does.
+
+The two directions are not the same defect, so \code{gap_kind} names which one a
+row is:
+\itemize{
+\item \code{"polity_not_started"}: the polity begins after the row's year. This is
+mostly WHEP's own back-cast convention rather than a hole -- pre-1961
+series are back-cast onto the anchor-year territory, so a Soviet
+republic's 1900 land is attributed to the republic that reports it today.
+\item \code{"polity_ended"}: the polity had ended by the row's year, so the value
+covers a territory that entity no longer describes. This is the harder
+case, and the one whep#414 is about: FAOSTAT areas 276 Sudan and 277 South
+Sudan fold into bucket 206, whose label \code{SUD-1956-2011} ended at the
+secession, and no live polity means "Sudan and South Sudan".
+}
+
+\code{gap_kind} is not derivable from the returned columns, which is why it is
+returned rather than left to the caller. The comparison is against the year
+the resolver actually matched on, which the back-cast anchor floors at
+\code{backcast_anchor}: an 1850 row for FAOSTAT area 273 Montenegro is matched as
+1961 and lands on \code{MNE-1913-1918}, so it is \code{"polity_ended"}, while
+\code{year < polity_start_year} on the same row would call it
+\code{"polity_not_started"}.
 
 The resolution here is the same one the builds use, including the back-cast
 anchor, so it reports what the table actually got rather than a second

--- a/tests/testthat/test_polities.R
+++ b/tests/testthat/test_polities.R
@@ -654,6 +654,79 @@ testthat::test_that("polity_coverage_gaps agrees with the resolver", {
   ))
 })
 
+testthat::test_that("polity_coverage_gaps names the direction of the gap", {
+  # The two directions are different defects and #414 is only one of them, so
+  # a consumer counting "rows attributed to a polity that did not exist" needs
+  # to be able to separate them. Bucket 206 post-secession is the `"ended"`
+  # case: the label `SUD-1956-2011` stopped at the secession while the bucket
+  # keeps summing both successors. Area 1 Armenia before 1991 is the
+  # `"not_started"` case, which is WHEP's documented back-cast convention.
+  gaps <- whep::polity_coverage_gaps(
+    tibble::tibble(area_code = c(206L, 1L), year = c(2015L, 1900L))
+  )
+
+  testthat::expect_equal(
+    gaps$gap_kind[gaps$area_code == 206L],
+    "polity_ended"
+  )
+  testthat::expect_equal(
+    gaps$gap_kind[gaps$area_code == 1L],
+    "polity_not_started"
+  )
+  testthat::expect_true(all(
+    gaps$gap_kind %in% c("polity_ended", "polity_not_started")
+  ))
+})
+
+testthat::test_that("the gap direction is read at the back-cast anchor", {
+  # The load-bearing half: `gap_kind` is NOT `year < polity_start_year`, and
+  # cannot be, because `.add_polity_columns_dt()` floors the lookup year at
+  # `backcast_anchor`. FAOSTAT area 273 Montenegro in 1850 is matched as 1961
+  # and lands on `MNE-1913-1918`, a polity that had ENDED by the year the
+  # resolver used -- so the raw-year comparison would mislabel it. On a real
+  # `get_primary_production()` that is 165 rows, areas 178 and 273.
+  anchored <- whep::polity_coverage_gaps(
+    tibble::tibble(area_code = 273L, year = 1850L)
+  )
+  testthat::expect_equal(anchored$polity_code, "MNE-1913-1918")
+  testthat::expect_lt(anchored$polity_end_year, 1961L)
+  testthat::expect_equal(anchored$gap_kind, "polity_ended")
+  # And the raw-year reading is what the same row gives once the anchor is
+  # switched off, which is the pair of answers the column exists to keep apart.
+  raw <- whep::polity_coverage_gaps(
+    tibble::tibble(area_code = 273L, year = 1850L),
+    backcast_anchor = -Inf
+  )
+  testthat::expect_gt(raw$polity_start_year, 1850L)
+  testthat::expect_equal(raw$gap_kind, "polity_not_started")
+})
+
+testthat::test_that("gap_kind agrees with the anchored comparison", {
+  # An invariant over the whole shipped crosswalk rather than two hand-picked
+  # areas: whatever upstream re-syncs do to the polity set, `gap_kind` must
+  # stay the answer to "was the matched year before this polity started?".
+  crosswalk <- whep::polity_area_crosswalk
+  grid <- expand.grid(
+    area_code = sort(unique(stats::na.omit(crosswalk$area_code))),
+    year = c(1850L, 1900L, 1961L, 1990L, 2015L, 2025L)
+  )
+  gaps <- whep::polity_coverage_gaps(grid)
+  expected <- ifelse(
+    !is.na(gaps$polity_start_year) &
+      pmax(gaps$year, 1961L) < gaps$polity_start_year,
+    "polity_not_started",
+    "polity_ended"
+  )
+
+  testthat::expect_gt(nrow(gaps), 0L)
+  testthat::expect_equal(gaps$gap_kind, expected)
+  # Both directions really occur, so neither branch is untested by accident.
+  testthat::expect_setequal(
+    unique(gaps$gap_kind),
+    c("polity_ended", "polity_not_started")
+  )
+})
+
 testthat::test_that("polity_coverage_gaps needs the area column", {
   testthat::expect_error(
     whep::polity_coverage_gaps(tibble::tibble(year = 2015L)),


### PR DESCRIPTION
## What was wrong

#414 asks whose territory a bucket-206 value describes. The diagnostics that
answer it — `polity_bucket_coverage()` for the fold, `polity_coverage_gaps()`
for the stand-in — already exist, and `polity_coverage_gaps()` is the one a
consumer of a *built* table reaches for. But it reported every nearest-period
stand-in as one undifferentiated class, and the two directions it lumps
together are not the same defect:

* **the polity had ended** by the row's year, so the value covers a territory
  that entity no longer describes. This is #414: bucket 206 sums FAOSTAT 276
  Sudan and 277 South Sudan under `SUD-1956-2011`, which stopped at the
  secession.
* **the polity had not started** yet, which is overwhelmingly WHEP's own
  documented back-cast convention — pre-1961 series are back-cast onto the
  anchor-year territory, so a Soviet republic's 1900 land is booked to the
  republic that reports it today.

So "rows attributed to a polity that did not exist that year" was a number
nobody could break down, and #414's share of it was unmeasured.

## Evidence it reproduced BEFORE the change

At base `bd46a0e9`, through the real pipeline.

**#414 still reproduces exactly as stated, on published output.** A real
`get_primary_production(years = 2015L)` (48,189 rows) publishes 246 rows under
`area_code` 206, and every one carries `reporting_polity_code`
`SUD-1956-2011` / `"Sudan (1956-2011)"` with `reporting_polity_has_geometry`
`TRUE` — a polity that ended in 2011, with a polygon a consumer will happily
take. `polity_coverage_gaps()` on that frame returns exactly one row:

```
 area_code year   polity_code       polity_name polity_start_year polity_end_year n_rows
       206 2015 SUD-1956-2011 Sudan (1956-2011)              1956            2011    246
```

and `polity_bucket_coverage(years = 2015L)` reports bucket 206 folding
`SDN-2011-2025, SSD-2011-2025, SUD-1956-2011` with
`bucket_mapping_status == "out_of_span"`. Whole-crosswalk run: 65 rows, all
bucket 206, all `"partial"`.

**And the full-range measurement, which did not exist.** A real full-range
`get_primary_production()` (6.3M rows, 1850-2023) run through
`polity_coverage_gaps()`: **2,301 (area, year) pairs / 7,247 rows — 0.115% —
are attributed to a polity that was not live in the row's year.** Split by
direction:

| direction | areas | pairs | rows |
|---|---|---|---|
| polity had **ended** | 3 | 247 | **3,285** |
| polity had **not started** | 16 | 2,054 | 3,962 |

The ended side, in full:

| `area_code` | polity | years | rows |
|---|---|---|---|
| 206 | `SUD-1956-2011` | 2012-2023 | **2,938** |
| 273 Montenegro | `MNE-1913-1918` | 1850-1961 | 224 |
| 178 Eritrea | `ERI-1889-1952` | 1850-1972 | 123 |

So bucket 206 is **89% of the class #414 is about** — the epic's "last hole"
framing is right in substance — but it is not the only member, and areas 178
and 273 were not named anywhere before. Filed as #705 rather than fixed here.

## What I changed

`R/polities.R` only, plus its docs, `NEWS.md` and tests.

`polity_coverage_gaps()` gains a `gap_kind` column, `"polity_ended"` or
`"polity_not_started"`, computed by a new private `.polity_gap_kind()`.

The one thing that makes this worth a column rather than a note: **the caller
cannot compute it.** The classification has to be read at the year the
resolver actually matched on, and `.add_polity_columns_dt()` floors that year
at `backcast_anchor`, so a pre-anchor row is matched as 1961 and can land on a
polity that had already **ended** by then. FAOSTAT area 273 in 1850 resolves
to `MNE-1913-1918` — matched as 1961, and `MNE-1913-1918` was over by 1961.
The obvious `year < polity_start_year` a consumer would write calls that
`"polity_not_started"`. Measured against the real full-range build, the two
readings disagree on **165 rows**: area 178 over 1850-1888 (39) and area 273
over 1850-1912 (126).

I did **not** decide the science. No live polity means "Sudan and South
Sudan"; this makes the report say precisely what is wrong with the rows that
have one anyway. It does not fill the hole.

## How I verified

Gates, all `Rscript --vanilla`, on the rebased tree:

* `air format .` (the binary) — clean, no diff.
* `devtools::document()` — `man/polity_coverage_gaps.Rd` only.
* `lintr::lint_package(...)` with the four project exclusions — **No lints
  found.**
* `devtools::test()` — **`[ FAIL 0 | WARN 46 | SKIP 9 | PASS 6769 ]`**.
* pkgdown: every `man/*.Rd` still in `_pkgdown.yml`, empty `comm` output. No
  new topic — `.polity_gap_kind()` is private.
* Non-ASCII: 0 in `R/polities.R` and `man/polity_coverage_gaps.Rd`.

Structural checks:

* **No published value can change.** The only callers of
  `polity_coverage_gaps()` anywhere in `R/` are its own file and
  `R/polity_columns_doc.R`, both cross-references in roxygen; nothing on a
  build path calls it. The diff adds a column to a diagnostic and a private
  helper, and touches no resolver, crosswalk or aggregation code.
* One `area_code` → one `area` label: unaffected, and re-checked on the real
  2015 build — 0 `area_code` values resolving to more than one
  `reporting_polity_code`, before and after.
* The zero-row case still returns the same column set, which an existing test
  already pins (`names(clean) == names(gaps)`), so a caller binding results
  needs no special case.

**Proving the guard load-bearing.** I re-introduced the exact defect the
column exists to prevent — replaced `match_year <- pmax(as.numeric(year),
as.numeric(backcast_anchor))` with `match_year <- as.numeric(year)`, i.e. the
raw-year comparison — and re-ran:

```
Failure ('test_polities.R:693:3'): the gap direction is read at the back-cast anchor
Failure ('test_polities.R:721:3'): gap_kind agrees with the anchored comparison
[ FAIL 2 | WARN 0 | SKIP 1 | PASS 118 ]
```

Both new anchored tests fail; restored, `[ FAIL 0 | PASS 120 ]` again. The
third test (`names the direction of the gap`) pins the two classes on the two
canonical areas and would fail on any constant or inverted classification.

The invariant test is deliberately a restatement over the **whole shipped
crosswalk** at six years rather than two hand-picked areas, and asserts both
classes really occur, so neither branch can go untested by an upstream
re-sync.

## Moves published values

**No.** A diagnostic gains a column; `NEWS.md` says so explicitly. Nothing on
a build path calls the function.

## What I deliberately did not do

* **Did not mint a polity downstream.** #414's option 2 needs an upstream row
  (`F206-2011-2025`, `"Sudan (combined reporting: ...)"`, `type = aggregate`),
  and whep-polities is the source of truth for territorial identities. It is
  already proposed there as lbm364dl/whep-polities#139, still open, and the
  shipped `polities` snapshot (751 rows) has no such entity — I checked rather
  than assumed. Note the shape is not quite the `F237` (Vietnam) / `F249`
  (Yemen) precedent: those combine territories that reported *together* and
  separated later, whereas FAOSTAT reports 276 and 277 separately from 2012
  and it is WHEP's own FABIO-inherited fold that re-sums them, so the
  aggregate would be live simultaneously with both its members.
* **Did not un-fold 276/277.** #680 already costs that option on a real build
  and it is not mass-neutral; nothing I measured changes that.
* **Did not touch `polity_bucket_coverage()` or `R/polity_folds.R`.** #690 is
  open against exactly that function and is a better home for anything there.
* **Did not repair areas 178 and 273.** They are a genuinely new finding, they
  are 347 rows against bucket 206's 2,938, and the repair is a crosswalk
  question (FAOSTAT area 178 has no mapped polity for 1953-1992, when Eritrea
  was inside Ethiopia; area 273 none for 1919-2005, when Montenegro was inside
  Yugoslavia). Filed with the numbers instead of widened into this PR.
* **Did not turn on `options(whep.polity_mapping_status)` by default.** That
  changes the schema of ~100 outputs and #545 deliberately left it to the
  owner.

## The open decision

Unchanged, and this PR does not touch it: **no live polity means "Sudan and
South Sudan"**, and the three options in #414 stand — mint the aggregate
upstream (changes no WHEP value, blocked on whep-polities#139), un-fold
276/277 (costed in #680, not mass-neutral), or leave it and report it
honestly, which is what this makes possible.

What this PR does add to the decision is its size, measured rather than
asserted: **2,938 published rows of `get_primary_production()`, 89% of every
row in the package attributed to a polity that had ended.** The second
question it raises — whether areas 178 and 273 should be repaired in the
crosswalk or accepted as back-cast stand-ins — is a separate one, and mine to
file rather than answer.

Refs #414 — deliberately **not** `Closes`. #414 is already closed (by #547),
and #690 is open against the fold diagnostic with its own `Closes #414`. This
PR neither duplicates nor supersedes it: #690 corrects
`polity_bucket_coverage()` in `R/polity_folds.R`, this classifies
`polity_coverage_gaps()` in `R/polities.R`, and the two files do not overlap.

Part of the polity migration epic #458.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
