### PR TITLE
fix(data-io): break the ISO3 area tie on the polities database, not row order

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,19 @@
 # whep (development version)
 
+* **An ISO3 code naming two FAOSTAT areas no longer resolves by row order, so
+  Ethiopian ISO3-keyed input stops being stamped with a country that dissolved
+  in 1993.** FAOSTAT keeps a pre-split entity beside its successor, so `ETH`
+  names both 62 ("Ethiopia PDR") and 238 ("Ethiopia"), and `SDN` names both 206
+  and 276. `.iso3_to_fao_area_code()` broke that tie with
+  `unique(bridge, by = "iso3c")` — row order, which kept the lowest code, i.e.
+  the dissolved 62 for `ETH`, in every year. The tie is now broken on the
+  polities database instead: the area code that IS its polity's
+  `polity_area_code` wins, which picks 238 for `ETH` and leaves `SDN` at 206;
+  an ISO3 still ambiguous after that rule aborts rather than being guessed.
+  Exactly one of the 263 ISO3 codes changes. **No published values move**: both
+  live callers reduce to `polity_code`, which is the same either way, and the
+  population totals the historical CBS proxy fill sees are byte-identical.
+
 * **The polity a row belongs to is now carried from where it is resolved
   instead of re-derived at the end of every output.**
   `.aggregate_to_polities()` has always resolved the bucket's polity in order

--- a/R/read_raw_inputs.R
+++ b/R/read_raw_inputs.R
@@ -7,17 +7,36 @@
 # -- Area code conversion ------------------------------------------------------
 
 #' Convert ISO3 area_code to FAOSTAT numeric area_code
+#'
+#' @details
+#' An ISO3 code can name more than one FAOSTAT reporting area, because FAOSTAT
+#' keeps the pre-split entity alongside its successor: `ETH` names both 62
+#' ("Ethiopia PDR", dissolved 1993) and 238 ("Ethiopia"), and `SDN` names both
+#' 206 ("Sudan (former)") and 276 ("Sudan").
+#'
+#' The tie used to be broken with `unique(bridge, by = "iso3c")`, i.e. on row
+#' order. `.current_area_lookup()` happens to order by `area_code`, so that kept
+#' the LOWEST code, which for `ETH` is the dissolved 62 — for every year, 2021
+#' included.
+#'
+#' The tie is now broken on the polities database instead: prefer the area code
+#' that IS its polity's `polity_area_code`, i.e. the canonical reporting area
+#' WHEP aggregates that polity to. That picks 238 for `ETH` and leaves `SDN` at
+#' 206 (276 folds into bucket 206, so 206 is the canonical one).
+#'
+#' ISO3 codes with no canonical area are the territories that fold into an
+#' aggregate bucket, whose code never equals their own. Each of those names
+#' exactly one area, so they need no tie-break — but rather than assume it, all
+#' rows are kept for such an ISO3 and the function aborts if any is still
+#' ambiguous, instead of guessing as before.
+#'
 #' @noRd
 .iso3_to_fao_area_code <- function(df) {
   if (!data.table::is.data.table(df)) {
     data.table::setDT(df)
   }
   dt <- df
-  bridge <- .current_area_lookup(include_unmapped = FALSE)[
-    !is.na(area_iso3c),
-    .(iso3c = area_iso3c, area_code_fao = area_code)
-  ]
-  bridge <- unique(bridge, by = "iso3c")
+  bridge <- .iso3_area_code_bridge()
 
   dt <- merge(
     dt,
@@ -30,6 +49,40 @@
   dt[, area_code := NULL]
   data.table::setnames(dt, "area_code_fao", "area_code")
   dt
+}
+
+# One FAOSTAT `area_code` per ISO3, with the tie broken on the polities
+# database rather than on row order. See `.iso3_to_fao_area_code()`.
+.iso3_area_code_bridge <- function() {
+  bridge <- .current_area_lookup(include_unmapped = FALSE)[
+    !is.na(area_iso3c),
+    .(
+      iso3c = area_iso3c,
+      area_code_fao = area_code,
+      is_canonical = !is.na(polity_area_code) & area_code == polity_area_code
+    )
+  ]
+  bridge <- unique(bridge)
+  # Keep the canonical rows for an ISO3 when it has any, all of them otherwise.
+  bridge[, keep := if (any(is_canonical)) is_canonical else TRUE, by = "iso3c"]
+  bridge <- bridge[keep == TRUE][, c("is_canonical", "keep") := NULL]
+
+  ambiguous <- sort(unique(bridge$iso3c[duplicated(bridge$iso3c)]))
+  if (length(ambiguous) > 0L) {
+    cli::cli_abort(
+      c(
+        "Cannot map {length(ambiguous)} ISO3 code{?s} to one FAOSTAT area.",
+        x = "Still ambiguous after the canonical-area rule: {.val {ambiguous}}.",
+        i = paste(
+          "Give the intended reporting area a matching",
+          "{.field polity_area_code} in the polities database, rather than",
+          "letting row order decide."
+        )
+      ),
+      class = "whep_ambiguous_iso3_area"
+    )
+  }
+  bridge
 }
 
 #' Convert FAOSTAT numeric area_code to ISO3 area_code and add area name

--- a/R/utils.R
+++ b/R/utils.R
@@ -1817,6 +1817,10 @@ utils::globalVariables(
     "bucket_area",
     "member_code",
     # build_cbs.R (#580) — .cbs_area_labels() data.table NSE column
-    "label_source_rank"
+    "label_source_rank",
+    # read_raw_inputs.R (#586) — .iso3_area_code_bridge() data.table NSE
+    # columns for the canonical-area tie-break
+    "is_canonical",
+    "keep"
   )
 )

--- a/tests/testthat/test_read_raw_inputs.R
+++ b/tests/testthat/test_read_raw_inputs.R
@@ -165,3 +165,83 @@ test_that("the aggregator labels a bucket from the bucket's own code", {
     ][[1]]
   )
 })
+
+# -- .iso3_to_fao_area_code tie-break (#586) -----------------------------------
+
+test_that("an ISO3 naming two areas resolves to the canonical one", {
+  # FAOSTAT keeps a pre-split entity beside its successor, so two ISO3 codes
+  # name two reporting areas each: ETH is 62 ("Ethiopia PDR", dissolved 1993)
+  # and 238 ("Ethiopia"); SDN is 206 ("Sudan (former)") and 276 ("Sudan").
+  # The tie used to be broken by `unique(bridge, by = "iso3c")` -- row order --
+  # and `.current_area_lookup()` orders by `area_code`, so it kept the LOWEST,
+  # which for ETH is the dissolved 62, for every year.
+  bridge <- whep:::.iso3_area_code_bridge()
+
+  expect_equal(bridge$area_code_fao[bridge$iso3c == "ETH"], 238L)
+  # 276 folds into bucket 206, so 206 is the canonical area for SDN and this
+  # one was already right; it is pinned so the fix cannot move it.
+  expect_equal(bridge$area_code_fao[bridge$iso3c == "SDN"], 206L)
+  expect_equal(bridge$area_code_fao[bridge$iso3c == "SSD"], 277L)
+})
+
+test_that("the ISO3 bridge is one row per ISO3 and never the dissolved area", {
+  # An invariant rather than two hand-picked codes: whenever an ISO3 names any
+  # area that IS its polity's `polity_area_code`, that is the one chosen. This
+  # is what row order got wrong, and it holds for every ISO3, not just ETH.
+  bridge <- whep:::.iso3_area_code_bridge()
+  expect_false(any(duplicated(bridge$iso3c)))
+
+  lookup <- whep:::.current_area_lookup(include_unmapped = FALSE)
+  lookup <- lookup[!is.na(lookup$area_iso3c), ]
+  canonical <- lookup[
+    !is.na(lookup$polity_area_code) &
+      lookup$area_code == lookup$polity_area_code,
+    c("area_iso3c", "area_code")
+  ]
+  data.table::setnames(
+    canonical,
+    c("area_iso3c", "area_code"),
+    c("iso3c", "canonical_code")
+  )
+  checked <- merge(bridge, canonical, by = "iso3c")
+  expect_gt(nrow(checked), 0L)
+  expect_equal(checked$area_code_fao, checked$canonical_code)
+})
+
+test_that(".iso3_to_fao_area_code stamps the canonical code on real rows", {
+  dt <- data.table::data.table(
+    area_code = c("ETH", "SDN", "ESP"),
+    year = c(2000L, 2000L, 2000L),
+    value = c(1, 2, 3)
+  )
+
+  out <- whep:::.iso3_to_fao_area_code(dt)
+  out <- out[order(out$value), ]
+
+  expect_equal(out$area_code, c(238L, 206L, 203L))
+  # The values ride along untouched: this helper only restamps the key.
+  expect_equal(out$value, c(1, 2, 3))
+  expect_equal(nrow(out), 3L)
+})
+
+test_that("an ISO3 still ambiguous after the rule aborts instead of guessing", {
+  # The ISO3 codes that fold into an aggregate have no canonical area at all,
+  # so the rule cannot decide for them. Today each names exactly one area, but
+  # that is a property of the data, not a guarantee -- so the function must
+  # refuse rather than silently take whichever row came first.
+  fake <- data.table::data.table(
+    area_code = c(900L, 901L),
+    area_iso3c = c("XXX", "XXX"),
+    polity_area_code = c(999L, 999L),
+    polity_code = c("ROW-1850-2025", "ROW-1850-2025")
+  )
+  testthat::local_mocked_bindings(
+    .current_area_lookup = function(...) fake,
+    .package = "whep"
+  )
+
+  expect_error(
+    whep:::.iso3_area_code_bridge(),
+    class = "whep_ambiguous_iso3_area"
+  )
+})


### PR DESCRIPTION
## What was wrong

`.iso3_to_fao_area_code()` (`R/read_raw_inputs.R`) broke the ISO3 tie with
`unique(bridge, by = "iso3c")` — row order. FAOSTAT keeps a pre-split entity
beside its successor, so two ISO3 codes name two reporting areas each:

```
 iso3c  area_code  area_name        polity_area_code  canonical?
   ETH         62  Ethiopia PDR                  238  FALSE   <- dissolved 1993
   ETH        238  Ethiopia                      238  TRUE
   SDN        206  Sudan (former)                206  TRUE
   SDN        276  Sudan                         206  FALSE
```

`.current_area_lookup()` sorts by `area_code`, so `unique(by = "iso3c")` kept
the **lowest** code: **62 for ETH**, the entity that stopped existing in 1993,
for every year including 2021.

**The issue's premise is stale in the maintainer's favour.** #586 says the
helper has **no callers** and proposes deleting it. On today's `main` it has
**two live callers**, both in `R/build_cbs.R`, added after the issue was filed:

- `.canonicalise_gdp_pop_area()` (line 765), via `.read_gdp_pop()` — commit
  `2210d05d`
- `.proxy_polity_key()` (line 2408), via `.fill_with_proxies()` — commit
  `8ff88042`

So this is not dead code carrying a latent defect; it is **live code carrying
an active one**. Option 1 (delete) is off the table; option 2 (fix the
tie-break) is what this PR does.

## Evidence it reproduced BEFORE the change

At base commit `45231d03`, driving the real helpers over `whep::polities` /
`whep::polity_area_crosswalk` and the real `gdp-population` pin:

```
=== what unique(by='iso3c') returns ===
 iso3c  area_code  polity_code     polity_area_code  area_code == polity_area_code
   ETH         62  ETH-1993-2025                238  FALSE
   SDN        206  SUD-1956-2011                206  TRUE
```

Through the two live callers, on the real pin (29,676 rows):

| | before | after |
|---|---|---|
| `.proxy_polity_key()` ETH `area_code` | **62** (172 rows) | 238 |
| `.canonicalise_gdp_pop_area()` ETH labels | `Ethiopia` × 172 | `Ethiopia (1952-1993)` × 143, `Ethiopia` × 29 |

`.canonicalise_gdp_pop_area()` filters on `area_code == polity_area_code`, and
ETH failed that filter *because of the bug* — so Ethiopia was silently excluded
from the canonicalisation the function exists to perform.

## What I changed

Extracted the bridge into `.iso3_area_code_bridge()` and broke the tie on the
polities database instead of on row order: **prefer the area code that IS its
polity's `polity_area_code`**, keeping all rows for an ISO3 that has no
canonical area (the territories folding into an aggregate bucket, whose code
never equals their own). If any ISO3 is still ambiguous after that rule, the
function **aborts** (`class = "whep_ambiguous_iso3_area"`) instead of guessing.

This is the logic the closed `polities-integration` branch had, salvaged as
#586 suggested, with `NA`-safe canonicality and a condition class added.

**Exactly one of 263 ISO3 codes moves: ETH 62 → 238.** No ISO3 is gained or
lost; the bridge stays one row per ISO3.

## How I verified

**Gates** (`Rscript --vanilla`): `air format .` clean · `devtools::document()`
no `man/` change · `lintr::lint_package()` **0 lints** · `devtools::test()`
**FAIL 0 | WARN 47 | SKIP 9 | PASS 6909** (+4 tests). Local `rcmdcheck` reports
`0 warnings | 0 notes`; its one ERROR is this machine missing the `archive` /
`RSQLite` Suggests, unrelated to the diff — CI has them. New NSE symbols
(`is_canonical`, `keep`) appended to `utils::globalVariables()`. No new
documented topics, so `_pkgdown.yml` is untouched.

**The join audit passes unchanged** — `test_join_audit.R` 14/14, and the cap
stays at 58. The extracted helper contains no join verb; the single `merge()`
stayed where it was, so `.territorial_join_baseline()` needed no new row.

**Structural checks, on the real pin, before vs after:**

- rows in = rows out = 29,676 on both callers; **no rows added or removed**
- `polity_code` vector `identical()` **TRUE**
- total population `531,324,989` **identical**
- one `area_code` → one `area` label: holds; the ETH label change is
  `Ethiopia` → `Ethiopia (1952-1993)` on the pre-1993 rows, which is the
  *polity name for those years* and the vocabulary the CBS frame carries

**Proving the guards load-bearing.** I restored the exact original two lines
(`unique(bridge, by = "iso3c")`) and re-ran the file. **All four new tests
fail**, each on the real defect:

```
Failure: an ISO3 naming two areas resolves to the canonical one
  actual: 62   expected: 238
Failure: the ISO3 bridge is one row per ISO3 and never the dissolved area
  actual[70:76]: 205 203 63  62 67 66 65
expected[70:76]: 205 203 63 238 67 66 65
Failure: .iso3_to_fao_area_code stamps the canonical code on real rows
  actual: 62 206 203   expected: 238 206 203
Failure: an ISO3 still ambiguous after the rule aborts instead of guessing
  did not throw an error with class <whep_ambiguous_iso3_area>
[ FAIL 4 | WARN 0 | SKIP 0 | PASS 20 ]
```

Then restored, parse-checked, and re-ran: 24/24 green. The second test is an
invariant over **every** ISO3, not the two hand-picked ones, so it would catch
a third pre-split entity arriving upstream.

## Moves published values

**No.** Both live callers reduce to `polity_code`, which is the same whether
ETH enters as 62 or 238 (both crosswalk rows resolve year-aware to
`ETH-1952-1993` / `ETH-1993-2025`), and `.fill_with_proxies()` aggregates the
proxy to `(year, polity_code)` before joining, so the 143 relabelled rows land
in a column that is dropped before the join. The value of the change is that
the identity is now correct and a future consumer of `area_code` — the filter
`area_code == polity_area_code` in both callers already reads it — cannot
inherit the dissolved entity.

## What I deliberately did not do

- **Did not delete the helper.** It has two live callers now.
- **Did not touch `.resolve_hist_trade_polities()`** (`R/build_cbs.R:889`),
  which carries the *same* row-order tie-break and *is* wrong on output — see
  the follow-up below. `R/build_cbs.R` has two sibling agents in it (#698,
  #709), so I filed rather than widened.
- **Did not touch `.canonicalise_gdp_pop_area()`**, whose relabelling I found
  is now inert — filed separately.
- **Did not change SDN.** The canonical-area rule returns 206 for SDN, exactly
  as row order did, so the bucket-206 question (#690 / #704) is untouched.

**Pattern hunt, as asked.** I checked the other three `unique(..., by = "iso3c")`
sites for the same defect and measured each:

| site | verdict |
|---|---|
| `R/arable_permanent_land.R:296` | **safe** — selects `polity_area_code`; 0 ISO3 have >1 distinct value |
| `R/build_production.R:456` | **safe** — same reason, 0 ISO3 ambiguous |
| `R/build_cbs.R:889` | **DEFECTIVE** — selects the raw `area_code` *and* `area_name` |

## The open decision

None — this is **mechanical**. "The dissolved entity is the wrong answer for
2021" has no defensible alternative, and the rule is read off the polities
database rather than chosen. The one judgement call is the *failure mode* for a
future over-determined ISO3: I chose **abort** over picking a documented order,
on the grounds that guessing silently is what caused this. That is reversible
and visible in the condition class.

Closes #586

Part of the polity migration epic #458.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
