### PR TITLE
fix(energy): read the crosswalk through .polity_crosswalk(), not the raw table

### DIFF
--- a/R/energy_co2_extension.R
+++ b/R/energy_co2_extension.R
@@ -216,14 +216,17 @@ build_energy_co2_extension <- function(
 # as least-developed, so this file asserts a classification for a country the
 # table it joins against cannot represent.
 #
-# whep#415 lists Bermuda, Guam and Palau alongside those two. They are no longer
-# named here because the crosswalk now folds all three into FABIO bucket 999, so
-# they are no longer self-reporting. MEASURED on the real
-# `get_primary_production()` output (6,170,595 rows, 194 distinct reporting
-# areas): area codes 17, 88 and 180 carry ZERO rows, so this code path cannot
-# reach them individually at all -- bucket 999 carries their production, and it
-# has no GLEAM row either. That loss is whep#492 and is reported by size in
-# `.report_unpriced_meat()`; whether the three should be unfolded is whep#419.
+# whep#415 lists Bermuda, Guam and Palau alongside those two, and they are still
+# not named here -- but the REASON changed with whep#628 and the note that used
+# to stand here (that bucket 999 carries their production) is no longer true.
+# Since the Rest-of-World fold was lifted they DO report under their own area
+# codes: `.energy_self_reporting_gaps()` now contains all three. What keeps them
+# out is the `polity_type` filter below. `.unfold_rest_of_world()` promotes
+# `polity_area_code` only, so their polity is still the ROW aggregate, and the
+# crosswalk gives that polity `continent = "World"`, which is not in
+# `.energy_scheme_continents()` -- so `unclassified = "polity_region"` could not
+# group them even if the warning named them. Giving a promoted Rest-of-World
+# member a polity and a continent of its own is a crosswalk question, whep#646.
 #
 # The source table is not edited: it is parsed from the GLEAM Excel workbook, so
 # adding rows would make this package's copy diverge from the published source
@@ -231,18 +234,11 @@ build_energy_co2_extension <- function(
 # grouping consumer-side, from the polity crosswalk, and the default still only
 # warns.
 .areas_gleam_cannot_group <- function() {
-  # `area_code == polity_area_code` keeps the areas that report as themselves,
-  # dropping those aggregated into a FABIO bucket under another code.
-  polity_area_crosswalk |>
-    tibble::as_tibble() |>
+  .energy_self_reporting_gaps() |>
     dplyr::filter(
-      !is.na(.data$area_code),
-      !is.na(.data$area_iso3c),
-      .data$area_code == .data$polity_area_code,
       .data$polity_type != "aggregate",
       !is.na(.data$polity_end_year),
-      .data$polity_end_year >= 2020,
-      !.data$area_iso3c %in% gleam_geographic_hierarchy$iso3
+      .data$polity_end_year >= 2020
     ) |>
     dplyr::distinct(
       .data$area_code,
@@ -250,6 +246,42 @@ build_energy_co2_extension <- function(
       .data$area_iso3c,
       .data$polity_area_code,
       .data$continent
+    )
+}
+
+# The crosswalk AS THE REST OF THE PIPELINE SEES IT.
+#
+# `.polity_crosswalk()` is the one place `.unfold_rest_of_world()` is applied
+# (`R/polities.R`), so reading the shipped `polity_area_crosswalk` object here
+# would give this file a fold state nothing else has used since whep#628 made
+# `whep.unfold_rest_of_world = "all"` the default. That matters precisely
+# because the gate below is `area_code == polity_area_code`, which is the one
+# column the unfold moves: on the shipped table every Rest-of-World member still
+# carries 999 and so never counts as reporting as itself. See whep#646.
+#
+# `as.data.frame()` before `as_tibble()` drops the data.table self-reference
+# `.polity_crosswalk()` returns, which would otherwise ride along on every frame
+# derived from it.
+.energy_crosswalk <- function() {
+  .polity_crosswalk() |>
+    as.data.frame() |>
+    tibble::as_tibble()
+}
+
+# The reporting areas that report as THEMSELVES and have no row in
+# `gleam_geographic_hierarchy`. Both the live gap above and the dissolved
+# entities further down are filters on this set, and each used to spell the gate
+# out separately against a different read of the crosswalk.
+#
+# `area_code == polity_area_code` keeps the areas that report as themselves,
+# dropping those aggregated into a FABIO bucket under another code.
+.energy_self_reporting_gaps <- function() {
+  .energy_crosswalk() |>
+    dplyr::filter(
+      !is.na(.data$area_code),
+      !is.na(.data$area_iso3c),
+      .data$area_code == .data$polity_area_code,
+      !.data$area_iso3c %in% gleam_geographic_hierarchy$iso3
     )
 }
 
@@ -405,17 +437,13 @@ build_energy_co2_extension <- function(
 # separates them from the live omissions (Nauru, Tuvalu) and from the aggregate
 # buckets 901-906 and 999, whose periods all run to the open end. Derived rather
 # than listed so a crosswalk revision cannot leave a hardcoded list behind.
+#
+# `open_end` is read off the same unfolded crosswalk the gate uses, so the two
+# cannot come from tables in different fold states (whep#646).
 .energy_dissolved_areas <- function() {
-  crosswalk <- tibble::as_tibble(polity_area_crosswalk)
-  open_end <- max(crosswalk$polity_end_year, na.rm = TRUE)
-  crosswalk |>
-    dplyr::filter(
-      !is.na(.data$area_code),
-      !is.na(.data$area_iso3c),
-      !is.na(.data$polity_end_year),
-      .data$area_code == .data$polity_area_code,
-      !.data$area_iso3c %in% gleam_geographic_hierarchy$iso3
-    ) |>
+  open_end <- max(.energy_crosswalk()$polity_end_year, na.rm = TRUE)
+  .energy_self_reporting_gaps() |>
+    dplyr::filter(!is.na(.data$polity_end_year)) |>
     dplyr::summarise(
       last_year = max(.data$polity_end_year),
       .by = c(
@@ -834,9 +862,12 @@ build_energy_co2_extension <- function(
 # reporting area, constant across the polity periods sharing an `area_code`
 # (checked: one distinct value for each of the 265 mapped codes), so this needs
 # no tie-breaking between those periods.
+#
+# Neither column is touched by the Rest-of-World unfold, so this reads the same
+# either way; it goes through `.energy_crosswalk()` anyway so that no helper in
+# this file has its own private idea of what the crosswalk is (whep#646).
 .energy_area_iso3 <- function() {
-  polity_area_crosswalk |>
-    tibble::as_tibble() |>
+  .energy_crosswalk() |>
     dplyr::filter(!is.na(.data$area_code), !is.na(.data$area_iso3c)) |>
     dplyr::distinct(area_code = .data$area_code, iso3 = .data$area_iso3c)
 }

--- a/tests/testthat/test_energy_co2_extension.R
+++ b/tests/testthat/test_energy_co2_extension.R
@@ -119,25 +119,75 @@ testthat::test_that("areas GLEAM cannot classify are named, not dropped mutely",
   testthat::expect_match(areas, "Tuvalu", all = FALSE)
 })
 
-testthat::test_that("Bermuda, Guam and Palau cannot be reached individually", {
-  # whep#415 names five live areas; three of them no longer report as themselves.
-  # Measured on the real `get_primary_production()` output (6,170,595 rows, 194
-  # distinct reporting areas): area codes 17, 88 and 180 carry ZERO rows, so no
-  # treatment on this code path can reach them -- bucket 999 carries their
-  # production. This pins the crosswalk state that makes that true, so if
-  # whep#419 ever unfolds them the omission stops being silent.
-  folded <- whep::polity_area_crosswalk |>
+testthat::test_that("the crosswalk read follows the Rest-of-World unfold", {
+  # whep#646. This file used to read the shipped `polity_area_crosswalk` object
+  # directly, while every other consumer reads it through `.polity_crosswalk()`,
+  # the one place `.unfold_rest_of_world()` is applied. The gate the energy
+  # helpers use is `area_code == polity_area_code`, which is exactly the column
+  # the unfold moves, so the two reads disagree about which areas report as
+  # themselves for all 61 Rest-of-World members.
+  #
+  # Bermuda (17), Guam (88) and Palau (180) are the three whep#415 named. On the
+  # shipped table they still carry `polity_area_code == 999`; under the default
+  # `whep.unfold_rest_of_world = "all"` (whep#628) they carry their own code.
+  shipped <- whep::polity_area_crosswalk |>
     tibble::as_tibble() |>
     dplyr::filter(.data$area_code %in% c(17L, 88L, 180L)) |>
-    dplyr::distinct(.data$area_code, .data$polity_area_code, .data$polity_type)
+    dplyr::distinct(.data$area_code, .data$polity_area_code)
+  testthat::expect_equal(nrow(shipped), 3L)
+  testthat::expect_true(all(shipped$polity_area_code == 999L))
 
-  testthat::expect_equal(nrow(folded), 3L)
-  testthat::expect_true(all(folded$polity_area_code == 999L))
-  testthat::expect_true(all(folded$polity_type == "aggregate"))
-  # ... which is exactly why the warning above does not name them.
+  gaps <- .energy_self_reporting_gaps()
+  testthat::expect_true(all(c(17L, 88L, 180L) %in% gaps$area_code))
+
+  # ... and re-folding takes them straight back out, which a read of the shipped
+  # table could not do either: it is invariant to the option.
+  withr::local_options(whep.unfold_rest_of_world = "none")
+  refolded <- suppressWarnings(.energy_self_reporting_gaps())
+  testthat::expect_false(any(c(17L, 88L, 180L) %in% refolded$area_code))
+})
+
+testthat::test_that("Bermuda, Guam and Palau still cannot be grouped", {
+  # They report as themselves now (previous test), so the OLD reason recorded
+  # here -- "bucket 999 carries their production" -- is gone. What keeps them
+  # out is that `.unfold_rest_of_world()` promotes `polity_area_code` only: the
+  # polity is still the Rest-of-World aggregate, and the crosswalk gives that
+  # polity `continent = "World"`, which is not one of the four continents the
+  # GLEAM scheme rules can settle. So the warning does not name them and
+  # `unclassified = "polity_region"` could not group them if it did. Whether a
+  # promoted member should carry a polity and a continent of its own is a
+  # crosswalk question, whep#646.
+  rows <- .energy_self_reporting_gaps() |>
+    dplyr::filter(.data$area_code %in% c(17L, 88L, 180L))
+
+  testthat::expect_equal(nrow(rows), 3L)
+  testthat::expect_true(all(rows$polity_type == "aggregate"))
+  testthat::expect_true(all(rows$continent == "World"))
+  testthat::expect_false(
+    .energy_gleam_continent("World") %in% .energy_scheme_continents()
+  )
+
   testthat::expect_false(any(
     c(17L, 88L, 180L) %in% .areas_gleam_cannot_group()$area_code
   ))
+  grouped <- suppressMessages(.energy_hierarchy("polity_region"))
+  testthat::expect_false(any(c("BMU", "GUM", "PLW") %in% grouped$iso3))
+})
+
+testthat::test_that("the unfold does not move what the energy file reads", {
+  # The whep#646 fix is a correctness fix with no numbers behind it TODAY, and
+  # this is that claim as a guard rather than as a sentence in a PR body: the
+  # three surfaces the crosswalk feeds are identical under both fold states, so
+  # the first time a promoted Rest-of-World member starts mattering, this fails
+  # instead of the change being silent.
+  gaps <- .areas_gleam_cannot_group()
+  dissolved <- .energy_dissolved_areas()
+  iso3 <- .energy_area_iso3()
+
+  withr::local_options(whep.unfold_rest_of_world = "none")
+  testthat::expect_equal(suppressWarnings(.areas_gleam_cannot_group()), gaps)
+  testthat::expect_equal(suppressWarnings(.energy_dissolved_areas()), dissolved)
+  testthat::expect_equal(suppressWarnings(.energy_area_iso3()), iso3)
 })
 
 testthat::test_that("polity_region groups an omitted area like its GLEAM peers", {


### PR DESCRIPTION
## What was wrong

`R/energy_co2_extension.R` read the **shipped** `polity_area_crosswalk` object in three places — `.areas_gleam_cannot_group()`, `.energy_dissolved_areas()` and `.energy_area_iso3()` — instead of going through `.polity_crosswalk()`, which is the one place `.unfold_rest_of_world()` is applied (`R/polities.R:8`). #646 named two of the three; `.energy_dissolved_areas()` is a third, added by #553 after the issue was filed.

Since #628 the default is `whep.unfold_rest_of_world = "all"`, so the pipeline promotes every Rest-of-World member to its own `polity_area_code` while the shipped table still folds it under 999. The gate two of those helpers use is `area_code == polity_area_code` — exactly the column the unfold moves — so this file and the rest of the pipeline disagreed about which areas report as themselves.

## Evidence it reproduced BEFORE the change

At `45231d03`, on the shipped `polity_area_crosswalk` vs `.polity_crosswalk()`:

```
raw rows: 596   unfolded rows: 596
rows where polity_area_code differs: 61
of those 61 rows, area_code == polity_area_code on the raw table: 0
```

Bermuda (17), Guam (88), Palau (180), Greenland (85), Syria (212), North Macedonia (154), Eswatini (209) and 54 more. So the pre-fix `.areas_gleam_cannot_group()` and `.energy_dissolved_areas()` classified all 61 as "aggregated into a bucket under another code", which has not been true in the pipeline since #628.

### …but #646's headline consequence does NOT reproduce, and I am not claiming it

The issue says 44 areas become visible to the #415 warning once the read is fixed. **They do not**, and this is worth stating because it is the interesting part:

```
.areas_gleam_cannot_group() on the raw table:        2 rows (Nauru, Tuvalu)
.areas_gleam_cannot_group() on .polity_crosswalk():  2 rows (Nauru, Tuvalu)
NEW rows visible only after the unfold:               0
```

The reason is one line further down in the same filter. `.unfold_rest_of_world()` promotes `polity_area_code` **only**, so a promoted member still carries `polity_code = "ROW-1850-2025"`, `polity_type = "aggregate"` and `continent = "World"` — measured, all 61 of them, and identical on the crosswalk shipped at `de7e2ff9` when the issue was filed, so this is not drift. `.areas_gleam_cannot_group()` filters `polity_type != "aggregate"`, which removes all 61 in either fold state. The read really was wrong; the 44 it was supposed to expose were being filtered out by `polity_type` regardless.

That identity gap — and the fact that it makes `build_trade.R`'s `.aggregate_polity_codes()` go from 11 aggregate codes to 72 if it is fixed the same way — is filed as #717.

## What I changed

- One `.energy_crosswalk()` helper: `.polity_crosswalk()`, so every read in the file has the same fold state as the rest of the pipeline. `as.data.frame()` before `as_tibble()` drops the data.table self-reference that would otherwise ride along on every derived frame.
- One `.energy_self_reporting_gaps()` helper holding the `area_code == polity_area_code` + "no GLEAM row" gate that `.areas_gleam_cannot_group()` and `.energy_dissolved_areas()` each spelled out separately, against a different read.
- `.energy_area_iso3()` reads the same helper. Neither of its columns is touched by the unfold, so it reads the same either way; it goes through the helper so no function in the file keeps a private idea of what the crosswalk is.
- Rewrote the stale comment and the stale test that both said Bermuda/Guam/Palau are absent because "bucket 999 carries their production". They report as themselves now; what keeps them out is `polity_type`/`continent`, which is a different fact with a different fix.
- No science decision. I did **not** give a promoted member a continent — that is #717's question and inventing one here would be inventing a result-affecting value.

## How I verified

**Real data, real function.** `get_primary_production()` at 6,310,390 rows / 217 areas, then `build_energy_co2_extension(data = list(primary_prod = pp))` at all four `unclassified` treatments, before and after, sorted and compared with `identical()`:

```
                    rows     areas   sum(impact_u)          identical(before, after)
drop                181831   197     6.5308638565e+12       TRUE
polity_region       182209   199     6.5308645708e+12       TRUE
historical_region   183021   204     6.6875498931e+12       TRUE
global_mean         183021   204     6.7209624938e+12       TRUE
```

The **warning surface is identical too**, captured with `capture_warnings()` on a real default build: the same three warnings, same text — "GLEAM cannot classify 2 live reporting areas … Nauru and Tuvalu", "no row for 7 reporting areas, so 569.4 Mt (3.33%)", "67342 country-year meat groups lack slaughtered-head counts". #646 asked for proof that the fix still costs nothing; this is it, and it says the warning surface does not change, not that it does.

Structural checks: rows, distinct `area_code`, and the full column set are unchanged (`identical()` covers all of them). There is no `area` label column in this output to split — it carries `polity_area_code`, `reporting_polity_code`, `reporting_polity_name`, `reporting_polity_has_geometry` — and the 197 area codes map to 245 `(area_code, reporting_polity_code)` pairs before and after alike, which is the year-aware resolution working, not a split.

Helper-level, byte-identical before/after: `.areas_gleam_cannot_group()`, `.energy_dissolved_areas()`, `.energy_area_iso3()`, `.energy_hierarchy()` under all three modes, `.energy_country_grouping()`, `.energy_intensity_by_country()`.

**Proving the guards are load-bearing.** Three new tests, each re-checked by re-introducing a defect and confirming the failure, then restoring:

1. *"the crosswalk read follows the Rest-of-World unfold"* — point `.energy_crosswalk()` back at the shipped object (the exact bug): **FAIL 1**, at the assertion that 17/88/180 report as themselves. Restored: FAIL 0.
2. *"Bermuda, Guam and Palau still cannot be grouped"* — first version PASSED that injection vacuously, because with the bug the filtered frame is empty and `all()` on an empty vector is `TRUE`. Added `expect_equal(nrow(rows), 3L)` and re-injected: **FAIL 2**. That one is only load-bearing because it was widened.
3. *"the unfold does not move what the energy file reads"* — this one cannot fail on the read bug (both states agree today, which is the claim it encodes). Proved load-bearing differently: drop the `polity_type != "aggregate"` filter from `.areas_gleam_cannot_group()` so a promoted member starts mattering, and it fails at `test_energy_co2_extension.R:188` alongside four older tests. So it is the guard that fires the first time #717 changes something.

Gates, all on `Rscript --vanilla`:

- `air format .` — clean (no diff).
- `devtools::document()` — no `man/` change; the edits are private helpers and comments, so no new topics and no `_pkgdown.yml` entry.
- `lintr::lint_package(...)` with the four disabled linters — `No lints found.`
- `devtools::test(filter = "energy_co2_extension")` — FAIL 0, PASS 123 (was 122).
- `devtools::test()` — `[ FAIL 0 | WARN 47 | SKIP 9 | PASS 6908 ]`. `test_join_audit.R` green (14).
- No new NSE symbols, so `utils::globalVariables()` is untouched.
- `R/join_audit.R`: no join added or removed; the baseline and its cap are untouched.

## Moves published values

**No.** Every one of the four `unclassified` treatments is `identical()` before and after on a real 6.3 M-row `get_primary_production()`, and so is the warning text. No `NEWS.md` entry: nothing user-visible changes, which is what makes this the safe time to fix the read rather than after it starts costing tonnes.

## What I deliberately did not do

- **Did not decide what continent a promoted Rest-of-World member should carry.** #646's second half. It is a `polity_area_crosswalk` question and probably an upstream `lbm364dl/whep-polities` one; filed as #717 with the `.aggregate_polity_codes()` 11→72 measurement that shows why it matters beyond this file.
- **Did not fix the same read elsewhere.** Four more helpers build a `polity_area_code` bridge from the shipped table — `arable_permanent_land.R:180` and `:292`, `crop_soil_n2o_extension.R:224`, `feed_intake_redistribute.R:1104` — where 61 area codes and 61 ISO3 codes map to a different bucket than the pipeline uses. Filed as #716 rather than widened into this PR, because each needs its own before/after on pins or `WHEP_*` rasters. `feed_intake_build.R:361` reads the shipped table too but only for `area_code`/`region`, which the unfold does not touch.
- **Did not touch `.aggregate_polity_codes()` in `build_trade.R`**, which reads the same table: changing it *would* move numbers (11 → 72 aggregate codes, so self-loops on promoted members stop counting as self-trade). That is a decision, not a fix.

## The open decision

Should a promoted Rest-of-World member carry a polity of its own, or is `"World"` the package saying "modelled in its own right for aggregation, not groupable for anything else"? The owner's rule says the former — data exists → a polity exists → a polygon exists — which points at giving each of the 61 an upstream polity rather than at teaching `.unfold_rest_of_world()` to invent one downstream. I have not implemented either; #717 states the choice with the numbers behind it.

Closes #646.
Part of the polity migration epic #458.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
