### PR TITLE
feat(polity): extend the cell-year validity check to the other cell_polity consumers (#675)

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,23 @@
 # whep (development version)
 
+* **Six more gridded builds now say when a cell-year names a polity that did
+  not exist.** `build_water_balance()` and `get_soc_climate_drivers()` gained
+  `polity_validity = c("keep", "flag", "drop")` in whep#462; every other
+  consumer of the same year-less `data$cell_polity` grid had the same defect
+  silently. `build_n_deposition()`, `build_urban_n()`,
+  `build_ag_land_support()`, `aggregate_grass_to_polity()`,
+  `spatialize_country_n_to_crops()` and `build_carbon_balance()` now take the
+  same argument, with the same three values, the same `"keep"` default and the
+  same warning, routed through one shared helper so the eight entry points
+  cannot drift apart. The HWSD clay/pH readers (`read_soil_ph()`,
+  `read_soil_hydraulic()`) are documented as exempt: they use the crosswalk as
+  a spatial extent and their output has neither `year` nor `area_code`.
+  **No published value changes on the default path** — `"keep"` reproduces
+  today's rows and numbers and only adds a warning, and `"flag"` adds one
+  logical column. `"drop"` does move values and is opt-in: measured on the real
+  58,795-cell country grid, it removes 3,181 of 30,438 `(area_code, year)` keys
+  over 1850-2020 (22 of 178 area codes, 21.4% of cell-years), and 34 of 3,738
+  keys over 2000-2020 alone.
 * **The polity a row belongs to is now carried from where it is resolved
   instead of re-derived at the end of every output.**
   `.aggregate_to_polities()` has always resolved the bucket's polity in order

--- a/R/ag_land_support.R
+++ b/R/ag_land_support.R
@@ -60,6 +60,7 @@
 #'   LUH2 classes through [read_luh2_landuse()] and agrees with it where they
 #'   overlap, but stops at 2015. `"none"` returns cropland-only support, an
 #'   explicit choice rather than a silent gap.
+#' @inheritParams build_water_balance
 #' @param data Optional named list of pre-loaded inputs to avoid remote reads:
 #'   `cell_polity` (the [build_cell_polity()] crosswalk), `type_cropland`
 #'   (`lon`, `lat`, `year`, `luh2_type`, `type_ha`), `crop_patterns` (`lon`,
@@ -73,7 +74,8 @@
 #'
 #' @return A tibble with `lon`, `lat`, `area_code`, `item_cbs_code`, `year`,
 #'   `land_use` (`"cropland"` or `"grassland"`) and positive `area_ha`, plus the
-#'   polity columns below.
+#'   polity columns below, plus `reporting_polity_out_of_span` when
+#'   `polity_validity = "flag"`.
 #' @inheritSection whep_polity_columns Polity columns
 #' @export
 #' @examples
@@ -81,12 +83,17 @@
 build_ag_land_support <- function(
   years = NULL,
   grassland = c("gridded_pasture", "luh2", "none"),
+  polity_validity = c("keep", "flag", "drop"),
   data = list(),
   example = FALSE
 ) {
   grassland <- rlang::arg_match(grassland)
+  polity_validity <- rlang::arg_match(polity_validity)
   if (isTRUE(example)) {
-    return(.example_ag_land_support())
+    return(.resolve_polity_validity(
+      .example_ag_land_support(),
+      polity_validity
+    ))
   }
   cell_polity <- data$cell_polity %||% build_cell_polity()
   .check_columns(
@@ -99,7 +106,7 @@ build_ag_land_support <- function(
     cropland,
     .als_grassland_support(data, cell_polity, cropland, grassland)
   ) |>
-    .add_reporting_polity_columns()
+    .resolve_polity_validity(polity_validity)
 }
 
 # ---- Cropland support ------------------------------------------------------

--- a/R/carbon_balance.R
+++ b/R/carbon_balance.R
@@ -20,6 +20,15 @@
 #' transfer, and derive the soil-organic-nitrogen change from the carbon rate
 #' via asymmetric soil carbon-to-nitrogen ratios.
 #'
+#' @details
+#' \code{polity_validity} governs this function's own output. The internal
+#' \code{\link{get_soc_climate_drivers}} read it falls back on always keeps its
+#' rows: the march needs a climate modifier for every cell-year it steps
+#' through, so dropping driver rows for an anachronistic polity label would
+#' break the trajectory rather than relabel it. The driver read therefore warns
+#' on its own key space (whep#462) while this argument decides the fate of the
+#' balance rows.
+#'
 #' @param model Turnover model: one of \code{"hsoc"} (default), \code{"rothc"},
 #'   \code{"icbm"}, \code{"amg"} or \code{"century"}.
 #' @param resolution \code{"grid"} (default, per cell and land-use class) or
@@ -31,6 +40,7 @@
 #'   (\code{\link{read_luh2_landuse}}, \code{\link{get_soc_climate_drivers}} and
 #'   \code{\link{build_carbon_inputs}}); ignored for inputs supplied via
 #'   \code{data}.
+#' @inheritParams build_water_balance
 #' @param data Named list of pre-loaded inputs, each falling back to its reader
 #'   when absent: \code{c_inputs} (per cell, land-use class and year, with
 #'   \code{c_input_mgc_ha_yr} and \code{humified_fraction}); \code{land_use}
@@ -56,7 +66,9 @@
 #'   \code{"grid"} resolution (or \code{(area_code, year)} at \code{"polity"}),
 #'   with \code{stock_mgc_ha}, \code{mineralization_mgc_ha}, \code{c_input_mgc_ha},
 #'   \code{luc_transfer_mgc_ha}, \code{rate_mgc_ha}, \code{son_change_kgn_ha},
-#'   \code{area_ha} and \code{method_soc}, plus the polity columns below.
+#'   \code{area_ha} and \code{method_soc}, plus the polity columns below, plus
+#'   \code{reporting_polity_out_of_span} when
+#'   \code{polity_validity = "flag"}.
 #' @inheritSection whep_polity_columns Polity columns
 #' @source Aguilera, E. et al. (2018). Embodied energy in agricultural inputs.
 #'   \doi{10.1016/j.scitotenv.2018.03.118}; land-use-change carbon transfer
@@ -67,12 +79,17 @@
 build_carbon_balance <- function(
   model = c("hsoc", "rothc", "icbm", "amg", "century"),
   resolution = c("grid", "polity"),
+  polity_validity = c("keep", "flag", "drop"),
   data = list(),
   years = NULL,
   example = FALSE
 ) {
+  polity_validity <- rlang::arg_match(polity_validity)
   if (isTRUE(example)) {
-    return(.example_carbon_balance())
+    return(.resolve_polity_validity(
+      .example_carbon_balance(),
+      polity_validity
+    ))
   }
   model <- rlang::arg_match(model)
   resolution <- rlang::arg_match(resolution)
@@ -97,7 +114,7 @@ build_carbon_balance <- function(
     .cb_derive_son() |>
     dplyr::mutate(method_soc = model) |>
     .cb_finalise(resolution) |>
-    .add_reporting_polity_columns()
+    .resolve_polity_validity(polity_validity)
 }
 
 # -- Input resolution ---------------------------------------------------------
@@ -1311,6 +1328,10 @@ build_carbon_balance <- function(
 # (cropped to `cell_polity`) via the shared HWSD aggregation helper. Reuses the
 # HWSD attribute/raster path read_soil_hydraulic() uses so the clay driver is
 # consistent with the hydraulic drivers.
+#
+# EXEMPT from the `polity_validity` year-check (whep#675), for the reason given
+# in R/soil_ph.R: `cell_polity` is a spatial extent here, the output has no
+# `year` and no `area_code`, so no row can name a polity that did not exist.
 .cb_hwsd_clay <- function(cell_polity) {
   rlang::check_installed("terra")
   hwsd_dir <- .resolve_hwsd_dir(NULL)

--- a/R/feed_lpjml.R
+++ b/R/feed_lpjml.R
@@ -152,7 +152,11 @@ grass_access_shares <- function(
 #' @param cell_polity Cell-to-polity mapping with `lon`, `lat`, `area_code` and
 #'   `polity_frac` (the cell's land-area fraction in the polity; pass 1 for a
 #'   majority assignment, e.g. from `country_grid`).
-#' @return A tibble with `area_code`, `year` and `grass_avail_dm_t`.
+#' @inheritParams build_water_balance
+#' @return A tibble with `area_code`, `year` and `grass_avail_dm_t`, plus
+#'   `reporting_polity_out_of_span` when `polity_validity = "flag"`. This
+#'   output carries no reporting-polity columns, so the flag is attached
+#'   directly rather than derived from them.
 #' @export
 #' @examples
 #' grass <- build_grass_availability(method = "lpjml", example = TRUE)
@@ -163,7 +167,12 @@ grass_access_shares <- function(
 #'   polity_frac = 1
 #' )
 #' aggregate_grass_to_polity(grass, cp)
-aggregate_grass_to_polity <- function(grass, cell_polity) {
+aggregate_grass_to_polity <- function(
+  grass,
+  cell_polity,
+  polity_validity = c("keep", "flag", "drop")
+) {
+  polity_validity <- rlang::arg_match(polity_validity)
   grass |>
     dplyr::mutate(lon = round(lon, 2), lat = round(lat, 2)) |>
     dplyr::inner_join(
@@ -174,7 +183,8 @@ aggregate_grass_to_polity <- function(grass, cell_polity) {
     dplyr::summarise(
       grass_avail_dm_t = sum(grass_avail_dm_t * polity_frac, na.rm = TRUE),
       .by = c("area_code", "year")
-    )
+    ) |>
+    .apply_polity_validity(polity_validity, attach_flag = TRUE)
 }
 
 #' Read natural-grass productivity from an LPJmL run.

--- a/R/n_balance_spatialize.R
+++ b/R/n_balance_spatialize.R
@@ -133,6 +133,7 @@ build_cell_polity <- function(
 #'   `year`/`area_code`/`item_cbs_code` totals only) or `"grid"` (also
 #'   distributes to `lon`/`lat` grid cells; requires `crop_patterns` and
 #'   `type_cropland` in `data`).
+#' @inheritParams build_water_balance
 #' @param data Optional named list of pre-loaded grid inputs, used only when
 #'   `resolution = "grid"`: `crop_patterns` (`lon`, `lat`, `item_prod_code`,
 #'   `harvest_fraction`) and `type_cropland` (`lon`, `lat`, `year`,
@@ -144,7 +145,10 @@ build_cell_polity <- function(
 #'   [build_crop_land_extension()] uses).
 #' @return A tibble. For `resolution = "polity_crop"`: `year`, `area_code`,
 #'   `item_cbs_code`, `n_t`. For `resolution = "grid"`: `lon`, `lat`,
-#'   `area_code`, `year`, `item_cbs_code`, `n_t`.
+#'   `area_code`, `year`, `item_cbs_code`, `n_t`. Either gains
+#'   `reporting_polity_out_of_span` when `polity_validity = "flag"`; this
+#'   output carries no reporting-polity columns, so the flag is attached
+#'   directly rather than derived from them.
 #' @export
 #' @examples
 #' spatialize_country_n_to_crops(
@@ -165,20 +169,27 @@ spatialize_country_n_to_crops <- function(
   crop_shares,
   cell_polity,
   resolution = c("polity_crop", "grid"),
+  polity_validity = c("keep", "flag", "drop"),
   data = list()
 ) {
   resolution <- rlang::arg_match(resolution)
+  polity_validity <- rlang::arg_match(polity_validity)
   .n_check_totals_shares(country_totals, crop_shares)
   polity_crop <- .n_polity_crop_totals(country_totals, crop_shares)
   if (resolution == "polity_crop") {
-    return(polity_crop)
+    return(.apply_polity_validity(
+      polity_crop,
+      polity_validity,
+      attach_flag = TRUE
+    ))
   }
   .check_columns(
     cell_polity,
     c("lon", "lat", "area_code", "polity_frac", "cell_area_ha"),
     "cell_polity"
   )
-  .n_grid_totals(polity_crop, cell_polity, data)
+  .n_grid_totals(polity_crop, cell_polity, data) |>
+    .apply_polity_validity(polity_validity, attach_flag = TRUE)
 }
 
 # ---- Private helpers --------------------------------------------------

--- a/R/n_deposition.R
+++ b/R/n_deposition.R
@@ -68,6 +68,7 @@ read_n_deposition <- function(
 #'
 #' @param years Optional integer vector of calendar years to keep. `NULL`
 #'   keeps every year the inputs cover.
+#' @inheritParams build_water_balance
 #' @param data Optional named list of pre-loaded inputs: `nhx` and `noy`
 #'   (each `lon`, `lat`, `year`, `value_g`, falling back to
 #'   [read_n_deposition()] when absent) and `cell_polity` (`lon`, `lat`,
@@ -76,14 +77,24 @@ read_n_deposition <- function(
 #'   Defaults to `FALSE`.
 #' @return A tibble with `lon`, `lat`, `area_code`, `year`,
 #'   `deposition_kgn_ha`, `deposition_n_t` and `method_deposition`, plus the
-#'   polity columns below.
+#'   polity columns below, plus `reporting_polity_out_of_span` when
+#'   `polity_validity = "flag"`.
 #' @inheritSection whep_polity_columns Polity columns
 #' @export
 #' @examples
 #' build_n_deposition(example = TRUE)
-build_n_deposition <- function(years = NULL, data = list(), example = FALSE) {
+build_n_deposition <- function(
+  years = NULL,
+  polity_validity = c("keep", "flag", "drop"),
+  data = list(),
+  example = FALSE
+) {
+  polity_validity <- rlang::arg_match(polity_validity)
   if (isTRUE(example)) {
-    return(.example_n_deposition())
+    return(.resolve_polity_validity(
+      .example_n_deposition(),
+      polity_validity
+    ))
   }
   nhx <- data$nhx %||% read_n_deposition("nhx", years = years)
   noy <- data$noy %||% read_n_deposition("noy", years = years)
@@ -95,7 +106,7 @@ build_n_deposition <- function(years = NULL, data = list(), example = FALSE) {
     c("area_code", "polity_frac", "cell_area_ha")
   )
   .nd_assemble(nhx, noy, polity) |>
-    .add_reporting_polity_columns()
+    .resolve_polity_validity(polity_validity)
 }
 
 # ---- Private helpers --------------------------------------------------

--- a/R/n_urban.R
+++ b/R/n_urban.R
@@ -41,6 +41,7 @@
 #'
 #' @param years Optional integer vector of calendar years to keep. `NULL`
 #'   keeps every year `data$urban_population` covers.
+#' @inheritParams build_water_balance
 #' @param data Optional named list of pre-loaded inputs: `urban_population`
 #'   (`lon`, `lat`, `year`, `urban_pop`, falling back to
 #'   [read_hyde_population()] when absent), `cell_polity` (`lon`, `lat`,
@@ -53,14 +54,21 @@
 #' @param example If `TRUE`, return a small fixture instead of reading data.
 #'   Defaults to `FALSE`.
 #' @return A tibble with `lon`, `lat`, `area_code`, `year`, `urban_n_t` and
-#'   `method_urban`, plus the polity columns below.
+#'   `method_urban`, plus the polity columns below, plus
+#'   `reporting_polity_out_of_span` when `polity_validity = "flag"`.
 #' @inheritSection whep_polity_columns Polity columns
 #' @export
 #' @examples
 #' build_urban_n(example = TRUE)
-build_urban_n <- function(years = NULL, data = list(), example = FALSE) {
+build_urban_n <- function(
+  years = NULL,
+  polity_validity = c("keep", "flag", "drop"),
+  data = list(),
+  example = FALSE
+) {
+  polity_validity <- rlang::arg_match(polity_validity)
   if (isTRUE(example)) {
-    return(.example_urban_n())
+    return(.resolve_polity_validity(.example_urban_n(), polity_validity))
   }
   urban_pop <- data$urban_population %||% read_hyde_population(years = years)
   urban_pop <- .urban_filter_years(urban_pop, years)
@@ -76,7 +84,7 @@ build_urban_n <- function(years = NULL, data = list(), example = FALSE) {
   sink_cells <- .urban_sink_cells(cropland)
   flows <- allocate_manure_transport(source_cells, sink_cells)
   .urban_finalise(flows) |>
-    .add_reporting_polity_columns()
+    .resolve_polity_validity(polity_validity)
 }
 
 # ---- Private helpers --------------------------------------------------

--- a/R/polity_validity.R
+++ b/R/polity_validity.R
@@ -1,0 +1,111 @@
+# Year-validity of a year-less cell -> polity crosswalk -----------------------
+#
+# `data$cell_polity` is a present-day rasterization with NO year dimension
+# (whep#460, whep#579), while polity validity IS year-scoped. So a cell carrying
+# `area_code` 52 (Azerbaijan) is labelled that in 1901 as readily as in 2009,
+# and `.add_reporting_polity_columns()` then resolves 1901 to the nearest
+# period, `AZE-1991-2025`, a state that did not exist. That substitution is
+# already recorded as `mapping_status == "out_of_span"` inside
+# `.add_polity_columns_dt()`, but the column is dropped from published outputs,
+# so without these helpers it is silent.
+#
+# MEASURED on the real 58,795-cell `spatialize-country-grid` (178 area codes):
+# 3,181 of 30,438 (area_code, year) pairs over 1850-2020, 22 of 178 area codes,
+# 15,100 of 58,795 cells -- the post-Soviet and post-Yugoslav successors, plus
+# Sudan and South Sudan. Even a modern-only module is exposed: over 2000-2020
+# it is still 34 pairs over codes 272, 273, 276 and 277.
+#
+# The rows are usually not wrong about the physics; the cells are real
+# territory and the quantity is per cell. Only the polity NAME is anachronistic.
+# Dropping them therefore deletes valid data, which is why `"keep"` is the
+# default everywhere this is offered (whep#462, whep#675).
+
+# Every entry point spells the argument the same way --
+# `polity_validity = c("keep", "flag", "drop")`, default `"keep"` -- and routes
+# through one of the two helpers below, so the ~8 of them cannot drift apart.
+#
+# Report -- and, per `polity_validity`, drop or flag -- the rows whose
+# (area_code, year) resolves to a polity that did not exist in that year, then
+# attach the reporting-polity columns. For consumers whose tail already is
+# `.add_reporting_polity_columns()`; the flag comes from the resolver's own
+# `mapping_status`, exactly as whep#674 shipped it.
+.resolve_polity_validity <- function(table, polity_validity) {
+  status <- if (polity_validity == "flag") "flag" else NULL
+  .apply_polity_validity(table, polity_validity) |>
+    .add_reporting_polity_columns(mapping_status = status)
+}
+
+# The same three modes for a table that carries no reporting-polity columns:
+# there is no `mapping_status` to derive the flag from, so `attach_flag = TRUE`
+# attaches it here from the same gap set instead. The column name and the
+# warning are identical either way -- that is the whole point of one helper.
+.apply_polity_validity <- function(
+  table,
+  polity_validity,
+  attach_flag = FALSE
+) {
+  gaps <- .polity_validity_gaps(table)
+  .warn_polity_validity(table, gaps, polity_validity)
+  if (polity_validity == "drop" && nrow(gaps) > 0L) {
+    return(dplyr::anti_join(table, gaps, by = c("area_code", "year")))
+  }
+  if (polity_validity == "flag" && attach_flag) {
+    return(.mark_polity_validity(table, gaps))
+  }
+  table
+}
+
+# The (area_code, year) pairs of `table` whose polity is a nearest-period
+# stand-in. Resolved on the DISTINCT pairs, not the rows: a gridded table is
+# millions of rows over at most a few thousand pairs, and
+# `polity_coverage_gaps()` resolves whatever it is handed. Using the exported
+# diagnostic rather than a second hand-rolled lookup is what guarantees the
+# report describes the rows `.add_reporting_polity_columns()` really substituted.
+.polity_validity_gaps <- function(table) {
+  if (!all(c("area_code", "year") %in% names(table))) {
+    return(tibble::tibble(area_code = integer(0), year = integer(0)))
+  }
+  dplyr::distinct(table, area_code, year) |>
+    polity_coverage_gaps() |>
+    dplyr::select(area_code, year)
+}
+
+# The per-row logical `"flag"` promises, for a table with no polity tail.
+.mark_polity_validity <- function(table, gaps) {
+  if (!all(c("area_code", "year") %in% names(table)) || nrow(gaps) == 0L) {
+    return(dplyr::mutate(table, reporting_polity_out_of_span = FALSE))
+  }
+  flagged <- dplyr::mutate(gaps, reporting_polity_out_of_span = TRUE)
+  table |>
+    dplyr::left_join(flagged, by = c("area_code", "year")) |>
+    dplyr::mutate(
+      reporting_polity_out_of_span = !is.na(
+        .data$reporting_polity_out_of_span
+      )
+    )
+}
+
+# Name what the stand-ins are. The message says whether the rows were kept,
+# flagged or dropped, so a log line is self-explanatory about which of the
+# three ran.
+.warn_polity_validity <- function(table, gaps, polity_validity) {
+  if (nrow(gaps) == 0L) {
+    return(invisible(NULL))
+  }
+  n_rows <- nrow(dplyr::semi_join(table, gaps, by = c("area_code", "year")))
+  codes <- sort(unique(gaps$area_code))
+  fate <- c(
+    keep = "kept as-is",
+    flag = "kept and flagged in reporting_polity_out_of_span",
+    drop = "dropped"
+  )[[polity_validity]]
+  cli::cli_warn(c(
+    "!" = "{n_rows} row{?s} over {length(codes)} area code{?s} resolve to a
+      polity that did not exist in that row's year (years
+      {min(gaps$year)}-{max(gaps$year)}); they are {fate}.",
+    i = "The cell-polity crosswalk has no year dimension, so an early cell
+      carries its present-day territory. Area codes: {codes}.",
+    i = "{.fn polity_coverage_gaps} names the polity each one landed on;
+      {.code polity_validity = \"drop\"} removes them."
+  ))
+}

--- a/R/soil_ph.R
+++ b/R/soil_ph.R
@@ -22,6 +22,14 @@
 #   static coefficient tables (e.g. `whep::soil_cn_ratios`).
 # - Local dev data dir is read from Sys.getenv("WHEP_HWSD_DIR"); never
 #   hardcode an absolute path in committed code.
+#
+# EXEMPT from the `polity_validity` year-check (whep#675). These readers take
+# `data$cell_polity` as a spatial EXTENT and gap-fill target only: they never
+# join a territory onto a year, and their output carries neither `year` nor
+# `area_code`. There is therefore no (area_code, year) pair that could name a
+# polity which did not exist -- a soil property is about the place, not the
+# state, which is #671's option 3. The same holds for `.cb_hwsd_clay()` in
+# R/carbon_balance.R, which reuses `.aggregate_hwsd()` the same way.
 
 #' Read gridded soil pH onto WHEP's grid.
 #'

--- a/R/water_balance.R
+++ b/R/water_balance.R
@@ -121,7 +121,7 @@ build_water_balance <- function(
     .wb_blue_green(method) |>
     .wb_attach_polity(data) |>
     .wb_finalise(method, resolution) |>
-    .wb_resolve_polity_validity(polity_validity)
+    .resolve_polity_validity(polity_validity)
 }
 
 #' Assemble monthly SOC climate drivers from CRU climate and LPJmL hydrology.
@@ -207,7 +207,7 @@ get_soc_climate_drivers <- function(
 ) {
   polity_validity <- rlang::arg_match(polity_validity)
   if (isTRUE(example)) {
-    return(.wb_resolve_polity_validity(
+    return(.resolve_polity_validity(
       .example_soc_climate_drivers(),
       polity_validity
     ))
@@ -219,7 +219,7 @@ get_soc_climate_drivers <- function(
   polity <- .wb_require_input(data$cell_polity, "cell_polity", c("area_code"))
   hydraulic <- .socd_soil_hydraulic(data)
   .assemble_soc_drivers(swc, monthly, clay, polity, hydraulic) |>
-    .wb_resolve_polity_validity(polity_validity)
+    .resolve_polity_validity(polity_validity)
 }
 
 # ---- Private helpers --------------------------------------------------
@@ -518,72 +518,6 @@ get_soc_climate_drivers <- function(
   )
 }
 
-# Attach the reporting-polity columns, after reporting -- and optionally
-# removing -- the cell-years the crosswalk cannot honestly place in time.
-#
-# `data$cell_polity` is a present-day rasterization with NO year dimension
-# (whep#460, whep#579), while polity validity IS year-scoped. So a cell carrying
-# `area_code` 52 (Azerbaijan) is labelled that in 1901 as readily as in 2009,
-# and `.add_reporting_polity_columns()` then resolves 1901 to the nearest
-# period, `AZE-1991-2025`, a state that did not exist. That substitution is
-# already recorded as `mapping_status == "out_of_span"` inside
-# `.add_polity_columns_dt()`, but the column is dropped from published outputs,
-# so today it is silent. MEASURED on the deployed
-# `cell_polity_fraction.parquet` over the 1901-2009 LPJmL run: 1,948 of 19,838
-# (area_code, year) pairs, 21 of 182 area codes, 14,761 of 58,791 cells -- the
-# post-Soviet and post-Yugoslav successors plus South Sudan.
-#
-# The rows are not wrong about the water; the cells are real territory and the
-# physics is per cell. Only the polity NAME is anachronistic. Dropping them
-# therefore deletes valid hydrology, which is why `"keep"` stays the default.
-.wb_resolve_polity_validity <- function(table, polity_validity) {
-  gaps <- .wb_polity_gaps(table)
-  .wb_warn_polity_gaps(table, gaps, polity_validity)
-  if (polity_validity == "drop" && nrow(gaps) > 0L) {
-    table <- dplyr::anti_join(table, gaps, by = c("area_code", "year"))
-  }
-  status <- if (polity_validity == "flag") "flag" else NULL
-  .add_reporting_polity_columns(table, mapping_status = status)
-}
-
-# The (area_code, year) pairs of `table` whose polity is a nearest-period
-# stand-in. Resolved on the DISTINCT pairs, not the rows: a gridded water
-# balance is millions of rows over at most a few thousand pairs, and
-# `polity_coverage_gaps()` resolves whatever it is handed.
-.wb_polity_gaps <- function(table) {
-  if (!all(c("area_code", "year") %in% names(table))) {
-    return(tibble::tibble(area_code = integer(0), year = integer(0)))
-  }
-  dplyr::distinct(table, area_code, year) |>
-    polity_coverage_gaps() |>
-    dplyr::select(area_code, year)
-}
-
-# Name what the stand-ins are, in the style of .wb_warn_uncovered_cells(). The
-# message says whether the rows were kept, flagged or dropped, so a log line is
-# self-explanatory about which of the three ran.
-.wb_warn_polity_gaps <- function(table, gaps, polity_validity) {
-  if (nrow(gaps) == 0L) {
-    return(invisible(NULL))
-  }
-  n_rows <- nrow(dplyr::semi_join(table, gaps, by = c("area_code", "year")))
-  codes <- sort(unique(gaps$area_code))
-  fate <- c(
-    keep = "kept as-is",
-    flag = "kept and flagged in reporting_polity_out_of_span",
-    drop = "dropped"
-  )[[polity_validity]]
-  cli::cli_warn(c(
-    "!" = "{n_rows} row{?s} over {length(codes)} area code{?s} resolve to a
-      polity that did not exist in that row's year (years
-      {min(gaps$year)}-{max(gaps$year)}); they are {fate}.",
-    i = "The cell-polity crosswalk has no year dimension, so an early cell
-      carries its present-day territory. Area codes: {codes}.",
-    i = "{.fn polity_coverage_gaps} names the polity each one landed on;
-      {.code polity_validity = \"drop\"} removes them."
-  ))
-}
-
 # Attach area_code, polity_frac and cell_area_ha from the cell-polity crosswalk.
 .wb_attach_polity <- function(terms, data) {
   crosswalk <- data$cell_polity
@@ -761,7 +695,7 @@ get_soc_climate_drivers <- function(
   } else {
     .wb_aggregate_polity(grid)
   }
-  .wb_resolve_polity_validity(out, polity_validity)
+  .resolve_polity_validity(out, polity_validity)
 }
 
 # Topsoil soil-water saturation per cell-month, from data$swc, the pinned

--- a/man/aggregate_grass_to_polity.Rd
+++ b/man/aggregate_grass_to_polity.Rd
@@ -4,7 +4,11 @@
 \alias{aggregate_grass_to_polity}
 \title{Aggregate gridded grass availability to polity totals.}
 \usage{
-aggregate_grass_to_polity(grass, cell_polity)
+aggregate_grass_to_polity(
+  grass,
+  cell_polity,
+  polity_validity = c("keep", "flag", "drop")
+)
 }
 \arguments{
 \item{grass}{Gridded grass availability from \code{\link[=build_grass_availability]{build_grass_availability()}},
@@ -13,9 +17,23 @@ with \code{lon}, \code{lat}, \code{year} and \code{grass_avail_dm_t}.}
 \item{cell_polity}{Cell-to-polity mapping with \code{lon}, \code{lat}, \code{area_code} and
 \code{polity_frac} (the cell's land-area fraction in the polity; pass 1 for a
 majority assignment, e.g. from \code{country_grid}).}
+
+\item{polity_validity}{What to do with a row whose \verb{(area_code, year)}
+resolves to a polity that did not exist in that year (the cell-polity
+crosswalk has no year dimension, so an early-20th-century cell is labelled
+with its present-day territory). \code{"keep"} (default) keeps every row, which
+is the historical behaviour, and warns naming the rows, years and area
+codes involved. \code{"flag"} keeps them and adds the per-row logical
+\code{reporting_polity_out_of_span}, marking exactly which rows are stand-ins.
+\code{"drop"} removes them. All three warn; only \code{"drop"} changes the numbers.
+See \code{\link[=polity_coverage_gaps]{polity_coverage_gaps()}}, which reports the same rows for an
+already-built table.}
 }
 \value{
-A tibble with \code{area_code}, \code{year} and \code{grass_avail_dm_t}.
+A tibble with \code{area_code}, \code{year} and \code{grass_avail_dm_t}, plus
+\code{reporting_polity_out_of_span} when \code{polity_validity = "flag"}. This
+output carries no reporting-polity columns, so the flag is attached
+directly rather than derived from them.
 }
 \description{
 Sums gridded grass availability to polity (country, or subnational where

--- a/man/build_ag_land_support.Rd
+++ b/man/build_ag_land_support.Rd
@@ -7,6 +7,7 @@
 build_ag_land_support(
   years = NULL,
   grassland = c("gridded_pasture", "luh2", "none"),
+  polity_validity = c("keep", "flag", "drop"),
   data = list(),
   example = FALSE
 )
@@ -21,6 +22,17 @@ the cropland surface's grid and 1851-2023 span. \code{"luh2"} reads the same
 LUH2 classes through \code{\link[=read_luh2_landuse]{read_luh2_landuse()}} and agrees with it where they
 overlap, but stops at 2015. \code{"none"} returns cropland-only support, an
 explicit choice rather than a silent gap.}
+
+\item{polity_validity}{What to do with a row whose \verb{(area_code, year)}
+resolves to a polity that did not exist in that year (the cell-polity
+crosswalk has no year dimension, so an early-20th-century cell is labelled
+with its present-day territory). \code{"keep"} (default) keeps every row, which
+is the historical behaviour, and warns naming the rows, years and area
+codes involved. \code{"flag"} keeps them and adds the per-row logical
+\code{reporting_polity_out_of_span}, marking exactly which rows are stand-ins.
+\code{"drop"} removes them. All three warn; only \code{"drop"} changes the numbers.
+See \code{\link[=polity_coverage_gaps]{polity_coverage_gaps()}}, which reports the same rows for an
+already-built table.}
 
 \item{data}{Optional named list of pre-loaded inputs to avoid remote reads:
 \code{cell_polity} (the \code{\link[=build_cell_polity]{build_cell_polity()}} crosswalk), \code{type_cropland}
@@ -37,7 +49,8 @@ data. Defaults to \code{FALSE}.}
 \value{
 A tibble with \code{lon}, \code{lat}, \code{area_code}, \code{item_cbs_code}, \code{year},
 \code{land_use} (\code{"cropland"} or \code{"grassland"}) and positive \code{area_ha}, plus the
-polity columns below.
+polity columns below, plus \code{reporting_polity_out_of_span} when
+\code{polity_validity = "flag"}.
 }
 \description{
 Assembles the physical agricultural land support that \code{\link[=build_n_inputs]{build_n_inputs()}}

--- a/man/build_carbon_balance.Rd
+++ b/man/build_carbon_balance.Rd
@@ -12,6 +12,7 @@ ported from the Spain historical pipeline.
 build_carbon_balance(
   model = c("hsoc", "rothc", "icbm", "amg", "century"),
   resolution = c("grid", "polity"),
+  polity_validity = c("keep", "flag", "drop"),
   data = list(),
   years = NULL,
   example = FALSE
@@ -23,6 +24,17 @@ build_carbon_balance(
 
 \item{resolution}{\code{"grid"} (default, per cell and land-use class) or
 \code{"polity"} (aggregated to \code{area_code} conserving carbon mass).}
+
+\item{polity_validity}{What to do with a row whose \verb{(area_code, year)}
+resolves to a polity that did not exist in that year (the cell-polity
+crosswalk has no year dimension, so an early-20th-century cell is labelled
+with its present-day territory). \code{"keep"} (default) keeps every row, which
+is the historical behaviour, and warns naming the rows, years and area
+codes involved. \code{"flag"} keeps them and adds the per-row logical
+\code{reporting_polity_out_of_span}, marking exactly which rows are stand-ins.
+\code{"drop"} removes them. All three warn; only \code{"drop"} changes the numbers.
+See \code{\link[=polity_coverage_gaps]{polity_coverage_gaps()}}, which reports the same rows for an
+already-built table.}
 
 \item{data}{Named list of pre-loaded inputs, each falling back to its reader
 when absent: \code{c_inputs} (per cell, land-use class and year, with
@@ -60,7 +72,9 @@ A tibble keyed by \code{(lon, lat, area_code, land_use, year)} at
 \code{"grid"} resolution (or \code{(area_code, year)} at \code{"polity"}),
 with \code{stock_mgc_ha}, \code{mineralization_mgc_ha}, \code{c_input_mgc_ha},
 \code{luc_transfer_mgc_ha}, \code{rate_mgc_ha}, \code{son_change_kgn_ha},
-\code{area_ha} and \code{method_soc}, plus the polity columns below.
+\code{area_ha} and \code{method_soc}, plus the polity columns below, plus
+\code{reporting_polity_out_of_span} when
+\code{polity_validity = "flag"}.
 }
 \description{
 Reconstruct per-cell soil-organic-carbon stock trajectories: run the selected
@@ -70,6 +84,15 @@ land-use fractions, march forward on yearly per-cell per-land-use areas
 applying the model annual update plus a carbon-conserving land-use-change
 transfer, and derive the soil-organic-nitrogen change from the carbon rate
 via asymmetric soil carbon-to-nitrogen ratios.
+}
+\details{
+\code{polity_validity} governs this function's own output. The internal
+\code{\link{get_soc_climate_drivers}} read it falls back on always keeps its
+rows: the march needs a climate modifier for every cell-year it steps
+through, so dropping driver rows for an anachronistic polity label would
+break the trajectory rather than relabel it. The driver read therefore warns
+on its own key space (whep#462) while this argument decides the fate of the
+balance rows.
 }
 \section{Polity columns}{
 

--- a/man/build_n_deposition.Rd
+++ b/man/build_n_deposition.Rd
@@ -4,11 +4,27 @@
 \alias{build_n_deposition}
 \title{Build gridded atmospheric nitrogen deposition inputs.}
 \usage{
-build_n_deposition(years = NULL, data = list(), example = FALSE)
+build_n_deposition(
+  years = NULL,
+  polity_validity = c("keep", "flag", "drop"),
+  data = list(),
+  example = FALSE
+)
 }
 \arguments{
 \item{years}{Optional integer vector of calendar years to keep. \code{NULL}
 keeps every year the inputs cover.}
+
+\item{polity_validity}{What to do with a row whose \verb{(area_code, year)}
+resolves to a polity that did not exist in that year (the cell-polity
+crosswalk has no year dimension, so an early-20th-century cell is labelled
+with its present-day territory). \code{"keep"} (default) keeps every row, which
+is the historical behaviour, and warns naming the rows, years and area
+codes involved. \code{"flag"} keeps them and adds the per-row logical
+\code{reporting_polity_out_of_span}, marking exactly which rows are stand-ins.
+\code{"drop"} removes them. All three warn; only \code{"drop"} changes the numbers.
+See \code{\link[=polity_coverage_gaps]{polity_coverage_gaps()}}, which reports the same rows for an
+already-built table.}
 
 \item{data}{Optional named list of pre-loaded inputs: \code{nhx} and \code{noy}
 (each \code{lon}, \code{lat}, \code{year}, \code{value_g}, falling back to
@@ -21,7 +37,8 @@ Defaults to \code{FALSE}.}
 \value{
 A tibble with \code{lon}, \code{lat}, \code{area_code}, \code{year},
 \code{deposition_kgn_ha}, \code{deposition_n_t} and \code{method_deposition}, plus the
-polity columns below.
+polity columns below, plus \code{reporting_polity_out_of_span} when
+\code{polity_validity = "flag"}.
 }
 \description{
 Combines HaNi NHx and NOy deposition into a total nitrogen deposition rate

--- a/man/build_urban_n.Rd
+++ b/man/build_urban_n.Rd
@@ -4,11 +4,27 @@
 \alias{build_urban_n}
 \title{Build gridded urban/human-excreta nitrogen inputs to agriculture.}
 \usage{
-build_urban_n(years = NULL, data = list(), example = FALSE)
+build_urban_n(
+  years = NULL,
+  polity_validity = c("keep", "flag", "drop"),
+  data = list(),
+  example = FALSE
+)
 }
 \arguments{
 \item{years}{Optional integer vector of calendar years to keep. \code{NULL}
 keeps every year \code{data$urban_population} covers.}
+
+\item{polity_validity}{What to do with a row whose \verb{(area_code, year)}
+resolves to a polity that did not exist in that year (the cell-polity
+crosswalk has no year dimension, so an early-20th-century cell is labelled
+with its present-day territory). \code{"keep"} (default) keeps every row, which
+is the historical behaviour, and warns naming the rows, years and area
+codes involved. \code{"flag"} keeps them and adds the per-row logical
+\code{reporting_polity_out_of_span}, marking exactly which rows are stand-ins.
+\code{"drop"} removes them. All three warn; only \code{"drop"} changes the numbers.
+See \code{\link[=polity_coverage_gaps]{polity_coverage_gaps()}}, which reports the same rows for an
+already-built table.}
 
 \item{data}{Optional named list of pre-loaded inputs: \code{urban_population}
 (\code{lon}, \code{lat}, \code{year}, \code{urban_pop}, falling back to
@@ -25,7 +41,8 @@ Defaults to \code{FALSE}.}
 }
 \value{
 A tibble with \code{lon}, \code{lat}, \code{area_code}, \code{year}, \code{urban_n_t} and
-\code{method_urban}, plus the polity columns below.
+\code{method_urban}, plus the polity columns below, plus
+\code{reporting_polity_out_of_span} when \code{polity_validity = "flag"}.
 }
 \description{
 Estimates the nitrogen from urban human excreta and municipal waste

--- a/man/spatialize_country_n_to_crops.Rd
+++ b/man/spatialize_country_n_to_crops.Rd
@@ -9,6 +9,7 @@ spatialize_country_n_to_crops(
   crop_shares,
   cell_polity,
   resolution = c("polity_crop", "grid"),
+  polity_validity = c("keep", "flag", "drop"),
   data = list()
 )
 }
@@ -30,6 +31,17 @@ crop-area-share helper.}
 distributes to \code{lon}/\code{lat} grid cells; requires \code{crop_patterns} and
 \code{type_cropland} in \code{data}).}
 
+\item{polity_validity}{What to do with a row whose \verb{(area_code, year)}
+resolves to a polity that did not exist in that year (the cell-polity
+crosswalk has no year dimension, so an early-20th-century cell is labelled
+with its present-day territory). \code{"keep"} (default) keeps every row, which
+is the historical behaviour, and warns naming the rows, years and area
+codes involved. \code{"flag"} keeps them and adds the per-row logical
+\code{reporting_polity_out_of_span}, marking exactly which rows are stand-ins.
+\code{"drop"} removes them. All three warn; only \code{"drop"} changes the numbers.
+See \code{\link[=polity_coverage_gaps]{polity_coverage_gaps()}}, which reports the same rows for an
+already-built table.}
+
 \item{data}{Optional named list of pre-loaded grid inputs, used only when
 \code{resolution = "grid"}: \code{crop_patterns} (\code{lon}, \code{lat}, \code{item_prod_code},
 \code{harvest_fraction}) and \code{type_cropland} (\code{lon}, \code{lat}, \code{year},
@@ -43,7 +55,10 @@ of \code{crop_patterns} via \link{items_prod_full} (the same crosswalk
 \value{
 A tibble. For \code{resolution = "polity_crop"}: \code{year}, \code{area_code},
 \code{item_cbs_code}, \code{n_t}. For \code{resolution = "grid"}: \code{lon}, \code{lat},
-\code{area_code}, \code{year}, \code{item_cbs_code}, \code{n_t}.
+\code{area_code}, \code{year}, \code{item_cbs_code}, \code{n_t}. Either gains
+\code{reporting_polity_out_of_span} when \code{polity_validity = "flag"}; this
+output carries no reporting-polity columns, so the flag is attached
+directly rather than derived from them.
 }
 \description{
 Promotes a single polity-total nitrogen input (one row per \code{year},

--- a/tests/testthat/test_ag_land_support.R
+++ b/tests/testthat/test_ag_land_support.R
@@ -281,3 +281,50 @@ testthat::test_that("cropland cells with no pattern warn instead of vanishing", 
   )
   testthat::expect_equal(nrow(out), 0L)
 })
+
+# ---- polity_validity (#675) -------------------------------------------
+
+# The same fixture re-keyed onto area 277 (South Sudan, SSD-2011-2025), whose
+# polity postdates the fixture's 2010 year.
+.alsf_out_of_span_data <- function() {
+  data <- .alsf_data()
+  data$cell_polity <- tibble::tribble(
+    ~lon, ~lat, ~area_code, ~polity_frac,
+    0.25, 50.25, 277L, 1
+  )
+  data
+}
+
+testthat::test_that("build_ag_land_support names an anachronistic polity", {
+  testthat::expect_warning(
+    out <- whep::build_ag_land_support(data = .alsf_out_of_span_data()),
+    "did not exist in that row's year"
+  )
+
+  testthat::expect_gt(nrow(out), 0L)
+  testthat::expect_true(all(out$reporting_polity_code == "SSD-2011-2025"))
+})
+
+testthat::test_that("build_ag_land_support honours drop and flag", {
+  testthat::expect_warning(
+    dropped <- whep::build_ag_land_support(
+      data = .alsf_out_of_span_data(),
+      polity_validity = "drop"
+    )
+  )
+  testthat::expect_warning(
+    flagged <- whep::build_ag_land_support(
+      data = .alsf_out_of_span_data(),
+      polity_validity = "flag"
+    )
+  )
+
+  testthat::expect_equal(nrow(dropped), 0L)
+  testthat::expect_true(all(flagged$reporting_polity_out_of_span))
+})
+
+testthat::test_that("build_ag_land_support is silent on an in-span polity", {
+  testthat::expect_no_warning(
+    whep::build_ag_land_support(data = .alsf_data())
+  )
+})

--- a/tests/testthat/test_carbon_balance.R
+++ b/tests/testthat/test_carbon_balance.R
@@ -1048,3 +1048,67 @@ testthat::test_that("vectorised RothC modifier is indistinguishable from the ref
   testthat::expect_false(".internal.selfref" %in% names(attributes(fast)))
   testthat::expect_equal(sorted(fast), sorted(slow), tolerance = 0)
 })
+
+# ---- polity_validity (#675) -------------------------------------------
+
+# One cell over two years on area 277 (South Sudan, SSD-2011-2025): the 2000
+# rows name a state that did not exist that year, the 2020 rows do not.
+.cbpv_data <- function() {
+  keys <- tidyr::expand_grid(
+    lon = 0.25,
+    lat = 0.25,
+    area_code = 277L,
+    year = c(2000L, 2020L)
+  )
+  list(
+    land_use = dplyr::mutate(keys, land_use = "cropland", area_ha = 100),
+    c_inputs = dplyr::mutate(
+      keys,
+      land_use = "cropland",
+      c_input_mgc_ha_yr = 2.5,
+      humified_fraction = 0.3
+    ),
+    climate = dplyr::mutate(keys, climate_modifier = 1),
+    clay = tibble::tribble(~lon, ~lat, ~clay_pct, 0.25, 0.25, 20)
+  )
+}
+
+testthat::test_that("build_carbon_balance names an anachronistic polity", {
+  testthat::expect_warning(
+    out <- whep::build_carbon_balance(data = .cbpv_data()),
+    "did not exist in that row's year"
+  )
+
+  # "keep" is the default: both years survive and the stocks do not move.
+  testthat::expect_setequal(out$year, c(2000L, 2020L))
+  testthat::expect_true(all(out$reporting_polity_code == "SSD-2011-2025"))
+})
+
+testthat::test_that("build_carbon_balance honours drop and flag", {
+  testthat::expect_warning(
+    kept <- whep::build_carbon_balance(data = .cbpv_data())
+  )
+  testthat::expect_warning(
+    dropped <- whep::build_carbon_balance(
+      data = .cbpv_data(),
+      polity_validity = "drop"
+    )
+  )
+  testthat::expect_warning(
+    flagged <- whep::build_carbon_balance(
+      data = .cbpv_data(),
+      polity_validity = "flag"
+    )
+  )
+
+  testthat::expect_equal(unique(dropped$year), 2020L)
+  testthat::expect_equal(
+    flagged$reporting_polity_out_of_span,
+    flagged$year == 2000L
+  )
+  # "flag" is "keep" plus one logical column: no number moves.
+  testthat::expect_equal(
+    dplyr::select(flagged, -"reporting_polity_out_of_span"),
+    kept
+  )
+})

--- a/tests/testthat/test_feed_lpjml.R
+++ b/tests/testthat/test_feed_lpjml.R
@@ -169,6 +169,61 @@ test_that("aggregate_grass_to_polity splits a border cell by polity_frac", {
   expect_equal(agg$grass_avail_dm_t[agg$area_code == 2L], 30)
 })
 
+# ---- polity_validity (#675) -------------------------------------------
+
+# Area 277 is South Sudan (SSD-2011-2025); a 2000 grass row on a cell the
+# present-day crosswalk labels 277 names a state that did not exist then.
+.fl_out_of_span_grass <- function() {
+  tibble::tibble(
+    lon = c(0.25, 0.25),
+    lat = c(0.25, 0.25),
+    year = c(2000L, 2020L),
+    grass_avail_dm_t = c(100, 200)
+  )
+}
+
+.fl_out_of_span_cp <- function() {
+  tibble::tibble(lon = 0.25, lat = 0.25, area_code = 277L, polity_frac = 1)
+}
+
+test_that("aggregate_grass_to_polity names an anachronistic polity", {
+  expect_warning(
+    agg <- whep::aggregate_grass_to_polity(
+      .fl_out_of_span_grass(),
+      .fl_out_of_span_cp()
+    ),
+    "did not exist in that row's year"
+  )
+
+  # "keep" is the default: both years survive and the totals do not move.
+  expect_equal(nrow(agg), 2L)
+  expect_equal(sum(agg$grass_avail_dm_t), 300)
+})
+
+test_that("aggregate_grass_to_polity honours drop and flag", {
+  expect_warning(
+    dropped <- whep::aggregate_grass_to_polity(
+      .fl_out_of_span_grass(),
+      .fl_out_of_span_cp(),
+      polity_validity = "drop"
+    )
+  )
+  expect_warning(
+    flagged <- whep::aggregate_grass_to_polity(
+      .fl_out_of_span_grass(),
+      .fl_out_of_span_cp(),
+      polity_validity = "flag"
+    )
+  )
+
+  expect_equal(dropped$year, 2020L)
+  expect_equal(dropped$grass_avail_dm_t, 200)
+  # The flag arrives without dragging polity columns onto an output whose
+  # published schema has none.
+  expect_equal(flagged$reporting_polity_out_of_span, flagged$year == 2000L)
+  expect_false("reporting_polity_code" %in% names(flagged))
+})
+
 test_that("read_lpjml_grass_productivity(example = TRUE) returns the tidy schema", {
   gp <- whep::read_lpjml_grass_productivity(example = TRUE)
   expect_s3_class(gp, "tbl_df")

--- a/tests/testthat/test_n_balance_spatialize.R
+++ b/tests/testthat/test_n_balance_spatialize.R
@@ -546,3 +546,82 @@ testthat::test_that("an ambiguous crosswalk names the offending area codes", {
   testthat::expect_error(.cell_polity_bucket_lookup(), "Ambiguous area code")
   testthat::expect_error(.cell_polity_bucket_lookup(), "41")
 })
+
+# ---- polity_validity (#675) -------------------------------------------
+
+# The same fixtures re-keyed onto area 277 (South Sudan, SSD-2011-2025),
+# whose polity postdates the fixture's 2010 year.
+.nbs_out_of_span_totals <- function() {
+  dplyr::mutate(.nbs_country_totals(), area_code = 277L)
+}
+
+.nbs_out_of_span_shares <- function() {
+  dplyr::mutate(.nbs_crop_shares(), area_code = 277L)
+}
+
+testthat::test_that("polity_crop resolution names an anachronistic polity", {
+  testthat::expect_warning(
+    result <- whep::spatialize_country_n_to_crops(
+      country_totals = .nbs_out_of_span_totals(),
+      crop_shares = .nbs_out_of_span_shares(),
+      cell_polity = NULL,
+      resolution = "polity_crop"
+    ),
+    "did not exist in that row's year"
+  )
+
+  # "keep" is the default: every row and the whole 100 t survive.
+  testthat::expect_equal(sum(result$n_t), 100)
+})
+
+testthat::test_that("spatialize_country_n_to_crops honours drop and flag", {
+  testthat::expect_warning(
+    dropped <- whep::spatialize_country_n_to_crops(
+      country_totals = .nbs_out_of_span_totals(),
+      crop_shares = .nbs_out_of_span_shares(),
+      cell_polity = NULL,
+      resolution = "polity_crop",
+      polity_validity = "drop"
+    )
+  )
+  testthat::expect_warning(
+    flagged <- whep::spatialize_country_n_to_crops(
+      country_totals = .nbs_out_of_span_totals(),
+      crop_shares = .nbs_out_of_span_shares(),
+      cell_polity = NULL,
+      resolution = "polity_crop",
+      polity_validity = "flag"
+    )
+  )
+
+  testthat::expect_equal(nrow(dropped), 0L)
+  testthat::expect_true(all(flagged$reporting_polity_out_of_span))
+})
+
+testthat::test_that("grid resolution reports validity too", {
+  cell_polity <- dplyr::mutate(.nbs_cell_polity(), area_code = 277L)
+
+  testthat::expect_warning(
+    result <- whep::spatialize_country_n_to_crops(
+      country_totals = .nbs_out_of_span_totals(),
+      crop_shares = .nbs_out_of_span_shares(),
+      cell_polity = cell_polity,
+      resolution = "grid",
+      data = .nbs_grid_data()
+    ),
+    "did not exist in that row's year"
+  )
+
+  testthat::expect_equal(sum(result$n_t), 100)
+})
+
+testthat::test_that("an in-span key reports nothing", {
+  testthat::expect_no_warning(
+    whep::spatialize_country_n_to_crops(
+      country_totals = .nbs_country_totals(),
+      crop_shares = .nbs_crop_shares(),
+      cell_polity = NULL,
+      resolution = "polity_crop"
+    )
+  )
+})

--- a/tests/testthat/test_n_deposition.R
+++ b/tests/testthat/test_n_deposition.R
@@ -185,3 +185,68 @@ testthat::test_that("build_n_deposition example fixture is schema-complete", {
   )
   pointblank::expect_col_vals_gte(out, "deposition_kgn_ha", 0)
 })
+
+# ---- polity_validity (#675) -------------------------------------------
+
+# Area 277 (South Sudan) exists only from 2011, so a cell the present-day
+# crosswalk labels 277 names a state that did not exist in any earlier year.
+.nd_out_of_span_cell_polity <- function() {
+  tibble::tribble(
+    ~lon, ~lat, ~area_code, ~polity_frac, ~cell_area_ha,
+    -0.25, -0.25, 277L, 1, 300000
+  )
+}
+
+.nd_out_of_span_data <- function() {
+  species <- tibble::tribble(
+    ~lon, ~lat, ~year, ~value_g,
+    -0.25, -0.25, 2000L, 1000000,
+    -0.25, -0.25, 2020L, 1000000
+  )
+  list(
+    nhx = species,
+    noy = species,
+    cell_polity = .nd_out_of_span_cell_polity()
+  )
+}
+
+testthat::test_that("build_n_deposition names an anachronistic polity", {
+  testthat::expect_warning(
+    out <- whep::build_n_deposition(data = .nd_out_of_span_data()),
+    "did not exist in that row's year"
+  )
+
+  # "keep" is the default and keeps both rows, so nothing published moves.
+  testthat::expect_equal(nrow(out), 2L)
+  testthat::expect_equal(
+    out$reporting_polity_code[out$year == 2000L],
+    "SSD-2011-2025"
+  )
+})
+
+testthat::test_that("build_n_deposition honours drop and flag", {
+  testthat::expect_warning(
+    dropped <- whep::build_n_deposition(
+      data = .nd_out_of_span_data(),
+      polity_validity = "drop"
+    )
+  )
+  testthat::expect_warning(
+    flagged <- whep::build_n_deposition(
+      data = .nd_out_of_span_data(),
+      polity_validity = "flag"
+    )
+  )
+
+  testthat::expect_equal(dropped$year, 2020L)
+  testthat::expect_equal(
+    flagged$reporting_polity_out_of_span,
+    flagged$year == 2000L
+  )
+})
+
+testthat::test_that("build_n_deposition is silent when every year is in span", {
+  testthat::expect_no_warning(
+    whep::build_n_deposition(years = 2020L, data = .nd_out_of_span_data())
+  )
+})

--- a/tests/testthat/test_n_urban.R
+++ b/tests/testthat/test_n_urban.R
@@ -224,3 +224,60 @@ testthat::test_that("build_urban_n example fixture is schema-complete", {
   )
   pointblank::expect_col_vals_gte(out, "urban_n_t", 0)
 })
+
+# ---- polity_validity (#675) -------------------------------------------
+
+# Area 277 (South Sudan) exists only from 2011: the 2000 row of this cell
+# names a state that did not exist that year.
+.urban_out_of_span_data <- function() {
+  list(
+    urban_population = tibble::tribble(
+      ~lon, ~lat, ~year, ~urban_pop,
+      -0.25, -0.25, 2000L, 100,
+      -0.25, -0.25, 2020L, 100
+    ),
+    cell_polity = tibble::tribble(
+      ~lon, ~lat, ~area_code,
+      -0.25, -0.25, 277L
+    ),
+    cropland_ha = tibble::tribble(
+      ~lon, ~lat, ~area_code, ~year, ~cropland_ha,
+      -0.25, -0.25, 277L, 2000L, 1000,
+      -0.25, -0.25, 277L, 2020L, 1000
+    )
+  )
+}
+
+testthat::test_that("build_urban_n names an anachronistic polity", {
+  testthat::expect_warning(
+    out <- whep::build_urban_n(data = .urban_out_of_span_data()),
+    "did not exist in that row's year"
+  )
+
+  testthat::expect_equal(nrow(out), 2L)
+  testthat::expect_equal(
+    out$reporting_polity_code[out$year == 2000L],
+    "SSD-2011-2025"
+  )
+})
+
+testthat::test_that("build_urban_n honours drop and flag", {
+  testthat::expect_warning(
+    dropped <- whep::build_urban_n(
+      data = .urban_out_of_span_data(),
+      polity_validity = "drop"
+    )
+  )
+  testthat::expect_warning(
+    flagged <- whep::build_urban_n(
+      data = .urban_out_of_span_data(),
+      polity_validity = "flag"
+    )
+  )
+
+  testthat::expect_equal(dropped$year, 2020L)
+  testthat::expect_equal(
+    flagged$reporting_polity_out_of_span,
+    flagged$year == 2000L
+  )
+})

--- a/tests/testthat/test_polity_validity.R
+++ b/tests/testthat/test_polity_validity.R
@@ -1,0 +1,166 @@
+# Tests for the shared year-validity helpers the gridded cell_polity consumers
+# route through (whep#462 introduced them for the water balance, whep#675
+# promoted them here so ~8 entry points cannot spell the same thing differently).
+#
+# Area 277 (South Sudan) is the sharpest case: its only polity SSD-2011-2025
+# postdates every historical year, so a cell the present-day crosswalk labels
+# 277 is out of span for the whole pre-2011 record. Area 203 (Spain) is in span
+# throughout and is the control.
+
+.pv_fixture <- function() {
+  tibble::tribble(
+    ~area_code, ~year, ~value,
+    203L, 1990L, 1,
+    203L, 2015L, 2,
+    277L, 1990L, 4,
+    277L, 2015L, 8
+  )
+}
+
+testthat::test_that("the gap set names the out-of-span pair and nothing else", {
+  gaps <- whep:::.polity_validity_gaps(.pv_fixture())
+
+  testthat::expect_equal(nrow(gaps), 1L)
+  testthat::expect_equal(gaps$area_code, 277L)
+  testthat::expect_equal(gaps$year, 1990L)
+})
+
+testthat::test_that("a table with no area_code or year has an empty gap set", {
+  gaps <- whep:::.polity_validity_gaps(tibble::tibble(value = 1))
+
+  testthat::expect_equal(nrow(gaps), 0L)
+  testthat::expect_named(gaps, c("area_code", "year"))
+})
+
+testthat::test_that("keep names the stand-in rows instead of staying silent", {
+  testthat::expect_warning(
+    out <- whep:::.resolve_polity_validity(.pv_fixture(), "keep"),
+    "did not exist in that row's year"
+  )
+
+  # Every row survives and every value is untouched: "keep" is today's output
+  # plus a warning, which is what makes it a safe default.
+  testthat::expect_equal(nrow(out), 4L)
+  testthat::expect_equal(sum(out$value), 15)
+  # And the anachronism it warns about is real: 1990 South Sudan.
+  testthat::expect_equal(
+    out$reporting_polity_code[out$area_code == 277L & out$year == 1990L],
+    "SSD-2011-2025"
+  )
+})
+
+testthat::test_that("the warning names the count, the codes and the fate", {
+  testthat::expect_warning(
+    whep:::.resolve_polity_validity(.pv_fixture(), "keep"),
+    "1 row over 1 area code"
+  )
+  testthat::expect_warning(
+    whep:::.resolve_polity_validity(.pv_fixture(), "keep"),
+    "Area codes: 277"
+  )
+  testthat::expect_warning(
+    whep:::.resolve_polity_validity(.pv_fixture(), "keep"),
+    "years 1990-1990.*kept as-is"
+  )
+  testthat::expect_warning(
+    whep:::.resolve_polity_validity(.pv_fixture(), "drop"),
+    "they are dropped"
+  )
+  testthat::expect_warning(
+    whep:::.resolve_polity_validity(.pv_fixture(), "flag"),
+    "kept and flagged in reporting_polity_out_of_span"
+  )
+})
+
+testthat::test_that("an all-in-span table warns about nothing", {
+  in_span <- dplyr::filter(.pv_fixture(), area_code == 203L)
+
+  testthat::expect_no_warning(
+    out <- whep:::.resolve_polity_validity(in_span, "keep")
+  )
+  testthat::expect_equal(nrow(out), 2L)
+})
+
+testthat::test_that("flag marks exactly the out-of-span rows, moving nothing", {
+  testthat::expect_warning(
+    kept <- whep:::.resolve_polity_validity(.pv_fixture(), "keep")
+  )
+  testthat::expect_warning(
+    flagged <- whep:::.resolve_polity_validity(.pv_fixture(), "flag")
+  )
+
+  pointblank::expect_col_exists(flagged, "reporting_polity_out_of_span")
+  testthat::expect_equal(
+    flagged$reporting_polity_out_of_span,
+    flagged$area_code == 277L & flagged$year == 1990L
+  )
+  # Same rows, same numbers: "flag" is "keep" plus one logical column.
+  testthat::expect_equal(
+    dplyr::select(flagged, -"reporting_polity_out_of_span"),
+    kept
+  )
+})
+
+testthat::test_that("drop removes only the out-of-span rows", {
+  testthat::expect_warning(
+    out <- whep:::.resolve_polity_validity(.pv_fixture(), "drop")
+  )
+
+  testthat::expect_equal(nrow(out), 3L)
+  testthat::expect_equal(sum(out$value), 11)
+  testthat::expect_false(any(out$area_code == 277L & out$year == 1990L))
+  # 277 does not vanish: its 2015 row is in span and stays.
+  testthat::expect_true(any(out$area_code == 277L))
+})
+
+testthat::test_that("one area_code still maps to one polity bucket", {
+  # The whep#561/#563 failure mode: a change that conserves mass while
+  # splitting a bucket. None of the three modes may split one.
+  modes <- c("keep", "flag", "drop")
+  buckets <- purrr::map(modes, function(mode) {
+    suppressWarnings(
+      whep:::.resolve_polity_validity(.pv_fixture(), mode)
+    ) |>
+      dplyr::distinct(area_code, polity_area_code) |>
+      dplyr::count(area_code)
+  })
+
+  purrr::walk(buckets, function(b) testthat::expect_true(all(b$n == 1L)))
+})
+
+testthat::test_that("attach_flag serves a table with no polity columns", {
+  testthat::expect_warning(
+    out <- whep:::.apply_polity_validity(
+      .pv_fixture(),
+      "flag",
+      attach_flag = TRUE
+    )
+  )
+
+  # The flag arrives, but no reporting-polity column is bolted onto an output
+  # whose published schema does not have them.
+  testthat::expect_equal(
+    out$reporting_polity_out_of_span,
+    out$area_code == 277L & out$year == 1990L
+  )
+  testthat::expect_false("reporting_polity_code" %in% names(out))
+  testthat::expect_equal(nrow(out), 4L)
+})
+
+testthat::test_that("attach_flag is all-FALSE when nothing is out of span", {
+  in_span <- dplyr::filter(.pv_fixture(), area_code == 203L)
+
+  out <- whep:::.apply_polity_validity(in_span, "flag", attach_flag = TRUE)
+
+  testthat::expect_false(any(out$reporting_polity_out_of_span))
+})
+
+testthat::test_that("keep leaves a bare table byte-identical", {
+  bare <- .pv_fixture()
+
+  testthat::expect_warning(
+    out <- whep:::.apply_polity_validity(bare, "keep", attach_flag = TRUE)
+  )
+
+  testthat::expect_identical(out, bare)
+})


### PR DESCRIPTION
## What was wrong

PR #674 gave `build_water_balance()` and `get_soc_climate_drivers()` a
`polity_validity = c("keep", "flag", "drop")` argument, so a cell-year
attributed to a polity that did not exist in that year is named in a warning
and can be excluded. **Every other consumer of the same year-less
`data$cell_polity` grid still had the defect, and had it silently.**

`data$cell_polity` is a present-day rasterization with no year dimension, while
polity validity is year-scoped. A cell labelled `area_code` 277 carries that
label in 1961 exactly as it does in 2020, and `.add_reporting_polity_columns()`
then resolves 1961 to `SSD-2011-2025` — a state that did not exist. The
substitution is already computed (`mapping_status == "out_of_span"`), but that
column is stripped from published outputs by design, so nothing said so.

**Re-verified against today's `main` (`3014506e`, 11 PRs newer than the issue).**
The claim holds for every consumer the issue lists, with two corrections:

- **`build_n_balance_spatialize()` does not exist.** The function is
  `spatialize_country_n_to_crops()`; nothing else in `R/n_balance_spatialize.R`
  is an entry point.
- **The HWSD clay/pH path is genuinely exempt, not merely small.**
  `read_soil_ph()`, `read_soil_hydraulic()` and `.cb_hwsd_clay()` take
  `cell_polity` as a spatial *extent* and gap-fill target; their output carries
  neither `year` nor `area_code`, so there is no `(area_code, year)` pair that
  could name a polity which did not exist. That is #671's option 3, and it is
  now written down in the file rather than inferred from the absence of a
  column.

## Evidence it reproduced BEFORE the change

At base commit `45231d03`, driving the real functions on the real deployed
`spatialize-country-grid` (58,795 cells, 178 area codes). Two cells, Spain
(203, in span) and South Sudan (277, `SSD-2011-2025`), at 1961 and 2020:

```
---- build_n_deposition(), BASE COMMIT ----
  area_code  year reporting_polity_code reporting_polity_name deposition_n_t
        203  1961 ESP-1800-2025         Spain                              2
        203  2020 ESP-1800-2025         Spain                              2
        277  1961 SSD-2011-2025         South Sudan                        2   <-- 1961
        277  2020 SSD-2011-2025         South Sudan                        2

---- build_urban_n(), BASE COMMIT ----
        277  1961 SSD-2011-2025                                         7.40   <-- 1961

---- aggregate_grass_to_polity(), BASE COMMIT ----
        277  1961                                                        100   <-- 1961
```

No warning was raised by any of the three. `WARNING RAISED:` never printed.

Exposure per consumer, on the real grid over each module's own year span
(the issue asked for exactly this, since a module starting in 2000 is not the
water balance starting in 1901):

| consumer | span | out-of-span keys | area codes | cells behind them |
|---|---|---|---|---|
| `build_n_deposition()` (HaNi) | 1850-2020 | 3,181 / 30,438 | 22 / 178 | 15,100 / 58,795 |
| `build_urban_n()` (HYDE) | 1850-2020 | 3,181 / 30,438 | 22 / 178 | 15,100 / 58,795 |
| `build_ag_land_support()` (LUH2) | 1850-2015 | 3,181 / 29,548 | 22 / 178 | 15,100 / 58,795 |
| `build_carbon_balance()` (LUH2) | 1850-2015 | 3,181 / 29,548 | 22 / 178 | 15,100 / 58,795 |
| `aggregate_grass_to_polity()` (LPJmL) | 1901-2009 | 2,057 / 19,402 | 22 / 178 | 15,100 / 58,795 |
| a modern-only module | 2000-2020 | **34 / 3,738** | **4 / 178** | 869 / 58,795 |

Codes: 1, 52, 57, 73, 80, 98, 108, 113, 146, 167, 178, 185, 198, 199, 208, 213,
230, 235, 272, 273, 276, 277 — the post-Soviet and post-Yugoslav successors
plus Sudan and South Sudan. **The last row is the one that matters for scoping:
even a module confined to 2000-2020 is exposed** (272 Serbia, 273 Montenegro,
276 Sudan, 277 South Sudan), so "this module is modern, it is fine" is not an
available exemption for any of them.

The counts differ from #674's (1,948 / 19,838 / 21 codes) because that measured
the deployed `cell_polity_fraction.parquet` over 1901-2009 and this measures the
`spatialize-country-grid` pin over each module's own span. Both are real; they
are different grids and different spans.

## What I changed

**`R/polity_validity.R` (new).** The three helpers move out of
`R/water_balance.R` unchanged in behaviour, which is what the issue asked for
once there were two callers, and split into the two shapes the consumers
actually have:

- `.resolve_polity_validity()` — warn, optionally drop, then
  `.add_reporting_polity_columns()`. For the consumers whose tail already was
  that call. The flag comes from the resolver's own `mapping_status`, byte-for-
  byte as #674 shipped it.
- `.apply_polity_validity(attach_flag = TRUE)` — the same three modes for a
  table whose published schema has **no** reporting-polity columns. There is no
  `mapping_status` to derive the flag from, so it is attached from the same gap
  set. This is what keeps `aggregate_grass_to_polity()` and
  `spatialize_country_n_to_crops()` from silently growing four polity columns
  they never published.

The gap set is resolved by the exported `polity_coverage_gaps()` on
`distinct(area_code, year)`, not on the rows — so a multi-million-row gridded
table costs one join over a few thousand pairs, and the report cannot disagree
with what `.add_reporting_polity_columns()` actually did.

**Wired, all with `polity_validity = c("keep", "flag", "drop")`, default
`"keep"`:** `build_n_deposition()`, `build_urban_n()`,
`build_ag_land_support()`, `aggregate_grass_to_polity()`,
`spatialize_country_n_to_crops()` and `build_carbon_balance()`. The `@param`
text is `@inheritParams build_water_balance` at every one, so there is
literally one spelling of it in the package, which was most of the point.

**Documented as exempt:** the HWSD clay/pH path, in a comment at each of the two
sites.

## How I verified

**Gates, on this branch:**

- `air format .` (the binary), then `devtools::document()`; `man/` committed.
  No new documented topic (nothing in `R/polity_validity.R` is exported), so
  `_pkgdown.yml` is untouched and the `comm` check is clean — verified, empty.
- `lintr::lint_package()` with the four disabled linters: **0 lints**.
- Full `devtools::test()`: **6,981 passing, 0 failed, 0 errors**, 11 skipped
  (all pre-existing env-var guards), up from **6,895 / 0 / 0 / 11** at the base
  commit. 86 new assertions.
- No new `utils::globalVariables()` entries: `area_code` and `year` are the
  only NSE symbols and both are already declared.
- **The `R/join_audit.R` gate (whep#669) needed no baseline row and got none.**
  Every join the new helper adds — `anti_join`, `semi_join`, `left_join` — is
  keyed on `c("area_code", "year")`, so none of them is year-free. The cap on
  `sum(baseline$n)` is **unchanged at 58**.

**Proving the guards are load-bearing.** I reintroduced the bug at all six call
sites at once — every `.resolve_polity_validity(polity_validity)` back to
`.add_reporting_polity_columns()`, every `.apply_polity_validity()` deleted —
and re-ran the seven affected files: **31 failures + 1 error across 13 of the 14
new consumer tests**, at least one in *every* consumer:

```
build_ag_land_support names an anachronistic polity            1 failure
build_ag_land_support honours drop and flag                    3
build_carbon_balance names an anachronistic polity             1
build_carbon_balance honours drop and flag                     5 + 1 error
aggregate_grass_to_polity names an anachronistic polity        1
aggregate_grass_to_polity honours drop and flag                5
polity_crop resolution names an anachronistic polity           1
spatialize_country_n_to_crops honours drop and flag            3
grid resolution reports validity too                           1
build_n_deposition names an anachronistic polity               1
build_n_deposition honours drop and flag                       4
build_urban_n names an anachronistic polity                    1
build_urban_n honours drop and flag                            4
```

`test_polity_validity.R` correctly kept passing throughout: it tests the shared
helper directly, and the helper was not what I broke. Restored, back to
**329 passing / 0 failed** across those seven files.

**Structural checks, not a totals diff.** I could **not** drive any of these
end to end: they need the multi-GB HaNi / HYDE / LUH2 / type_cropland /
crop_patterns rasters behind `WHEP_*` env vars I do not have, which the epic
puts out of budget. Saying that plainly rather than implying otherwise. What I
did instead is drive the shared helper over the **real** key space the polity
resolution produces — every `(area_code, year)` the deployed
`spatialize-country-grid` can emit — in all three modes:

| span | mode | rows | codes | polities | buckets | codes → >1 bucket | sum |
|---|---|---|---|---|---|---|---|
| 1850-2020 | keep | 30,438 | 178 | 224 | 177 | **0** | 30,438,000 |
| | flag | 30,438 | 178 | 224 | 177 | **0** | 30,438,000 (3,181 flagged) |
| | drop | 27,257 | 178 | 222 | 177 | **0** | 27,257,000 |
| 1901-2009 | keep | 19,402 | 178 | 222 | 177 | **0** | 19,402,000 |
| | flag | 19,402 | 178 | 222 | 177 | **0** | 19,402,000 (2,057 flagged) |
| | drop | 17,345 | 176 | 218 | 176 | **0** | 17,345,000 |
| 2000-2020 | keep | 3,738 | 178 | 177 | 177 | **0** | 3,738,000 |
| | flag | 3,738 | 178 | 177 | 177 | **0** | 3,738,000 (34 flagged) |
| | drop | 3,704 | 178 | 177 | 177 | **0** | 3,704,000 |

- **`"keep"` and `"flag"` are numerically identical** in every span — same rows,
  same keys, same sum; `all.equal()` on the frame minus the flag column is
  `TRUE`. `"flag"` adds one logical column and nothing else.
- **The flag count equals the gap count exactly**, in every span. That is the
  internal-consistency check that matters: the warning, the flag and the drop
  all describe the same rows the resolver really substituted.
- **One `area_code` → one bucket holds in all three modes, every span** (0 codes
  map to more than one `polity_area_code`). That is the #561/#563 failure mode
  this epic reverted a PR for, and no mode here splits a bucket.
- `"drop"` removes 3,181 keys over 1850-2020, **21.4% of cell-years**; over
  1901-2009 exactly two area codes vanish entirely (**276** Sudan-former and
  **277** South Sudan, both out of span for that whole span); over 2000-2020 it
  is 34 keys and 0.8% of cell-years, and nothing vanishes.

**One real, previously-silent case surfaced by the change.** The full suite's
warning count went 47 → 48. The new one is
`test_n_balance_inputs.R :: build_n_inputs re-keys FAOSTAT synthetic N to
polities`, where `spatialize_country_n_to_crops()` is now handed
`(area_code = 206, year = 2015)`. Bucket 206 is Sudan (former), whose polity
`SUD-1956-2011` ended in 2011 — the `"polity_ended"` gap kind from #690/#704,
which is the direction that *is* a real defect. The test still passes; the
warning is the diagnostic working on a real code path rather than on a fixture.
Filed as a follow-up, not fixed here.

**Offline.** Every new test builds its own two-row fixture; nothing reads a
`WHEP_*` path or the network, so the `offline-tests` job is unaffected.

## Moves published values

**No, not on the default path.** `"keep"` is the default at all six new entry
points and reproduces today's output row-for-row and value-for-value; the only
change is a warning when there is something to warn about. `"flag"` is
identical plus one logical column. Confirmed on the real key space above, and
by the suite: 0 existing assertions changed behaviour.

`"drop"` does move values — up to 21.4% of cell-years on a full historical span
— which is exactly why it is opt-in and not the default.

## What I deliberately did not do

- **I did not make `"drop"` the default**, and did not revisit #674's call. The
  rows are not wrong about the physics: the cells are real territory, the
  deposition/urban-N/land/carbon is per cell, and only the polity *name* is
  anachronistic. Deleting a fifth of a physical record to fix a labelling
  problem is the worse trade.
- **I did not thread `polity_validity` into `build_carbon_balance()`'s internal
  `get_soc_climate_drivers()` read.** It governs the balance's own output; the
  driver read keeps its rows. The march needs a climate modifier for **every**
  cell-year it steps through, so dropping driver rows for an anachronistic label
  would break the trajectory rather than relabel it. Written into `@details`
  rather than left to be discovered.
- **I did not touch the cell-polity grid itself.** #671 closed without changing
  it; if it ever becomes year-aware (polycell), the gap set simply goes empty
  and all three modes converge.
- **I did not thread the argument up through `build_n_inputs()` /
  `build_nitrogen_balance()`**, which call `build_n_deposition()`,
  `build_urban_n()`, `build_ag_land_support()` and
  `spatialize_country_n_to_crops()` internally. They inherit the *warning*
  today but cannot yet pass the choice down. Same shape as the gap #675 named
  for the carbon balance, and it deserves its own before/after. Follow-up.
- **I did not run any of these six functions end to end.** They need rasters
  behind env vars I do not have. Everything above is measured at the helper
  boundary over the real grid, plus the six functions driven on injected
  fixtures through `data =`. What I therefore **could not** measure: the actual
  kg N/ha or Mg C/ha each dropped cell-year carries, and whether any downstream
  consumer breaks on the missing keys under `"drop"`.
- **I did not add a constant `method_*` column.** As in #674, the multi-method
  rule is met by `"flag"`'s per-row `reporting_polity_out_of_span`, which says
  *which* rows are stand-ins rather than repeating which mode ran.
- **`spatialize_country_n_to_crops()` and `build_carbon_balance()` now have 6
  arguments**, one over CLAUDE.md's "avoid more than ~5". `build_water_balance()`
  went to 6 for the same argument in #674; grouping this one into a list would
  have made the eight signatures disagree, which is the thing this PR exists to
  prevent. Flagging it rather than hiding it.

## The open decision

**Should the argument keep being offered per-consumer, or become a package-level
option?** Eight entry points now carry an identically-spelled argument that
almost every caller will leave at its default. An `options(whep.polity_validity
= )` would be one place to set it and one place for a reviewer to look; the
counter-argument is that a global switch silently changing what a build drops is
exactly the class of hidden state this epic keeps finding. I kept the explicit
per-function argument, which is #674's shape, but the eighth repetition is where
the question becomes real.

Underneath it, unchanged from #674 and still not decided: **should a gridded
physical record drop, flag, or keep an anachronistic polity label?** The default
here is "keep and say so". If this project's rule is that a published row must
never name a polity that did not exist, `"drop"` is the correct default and a
follow-up should flip all eight at once — a maintainer's science decision, not
one to take on green CI.

Closes #675

Part of the polity migration epic #458.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
