### PR TITLE
fix(production): read livestock stocks over their own span (#666, partial)

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -9,6 +9,17 @@
   `identical()` and no time cost (64 s vs 68 s). This is a fixed cost on every
   `build_carbon_balance()` and `get_soc_climate_drivers()` call, independent of
   how many years are requested (#624).
+
+* **A year-scoped production build no longer depends on the window for which
+  livestock stock combinations exist.** `.build_livestock_stocks()` read the
+  stock series scoped to the caller's window, but `.combine_livestock()`
+  completes the year axis against the (area, item) combinations that read
+  produced — so a combination absent from the window was absent from the
+  completion, and the completed rows are what give a livestock-product row its
+  unit downstream. The series is now read over its full span and trimmed
+  afterwards; full-range output is unchanged. This narrows the remaining
+  year-scoping gap (`t_LU` at 2010: 2.18e-04 to 1.61e-04) but does not close
+  #666 — a scoped build still derives `LU` as NA where a full build derives 0.
 * **`build_carbon_balance()` no longer grows its memory with the length of the
   span.** The RothC/HSOC climate modifier is now reduced one year at a time.
   Attaching soil cover crosses the monthly climate table with every land-use

--- a/R/build_production.R
+++ b/R/build_production.R
@@ -1138,7 +1138,24 @@ build_primary_production <- function(
   animals <- whep::animals_codes
   liv_lu <- whep::liv_lu_coefs
 
-  fao_stocks <- .read_livestock_stocks(years = years)
+  # Read the stock series over its full span, not the caller's window, for the
+  # same reason as `.compute_stock_shares()`: `.combine_livestock()` completes
+  # the year axis against the (area, item) combinations the read produced, so a
+  # combination absent from the window is absent from the completion too. Those
+  # completed rows are what give a livestock-product row its `unit` downstream in
+  # `.calculate_raw_yields()`, and without a unit the row is dropped. Measured at
+  # 2010, Italy, Kazakhstan and Latvia have no duck stock row of their own that
+  # year, so a scoped read never formed the combination at all.
+  #
+  # This is a partial improvement, not a fix for #666. It does now form the
+  # combination -- the rows appear -- but a scoped build still derives `LU` as NA
+  # where a full build derives 0, so the duck-product rows are still lost at 2010
+  # and 1995 and only half recovered at 2015. `LU` = heads * LU_head via a join
+  # on `Animal_class`, which the completion's `nesting()` does not carry; why the
+  # full build nonetheless lands on 0 is the open question. See #666.
+  #
+  # Trimmed back below, so only the read widens: full-range output is unchanged.
+  fao_stocks <- .read_livestock_stocks(years = NULL)
 
   fao_liv_raw <- .combine_livestock(
     fao_combined,
@@ -1146,7 +1163,8 @@ build_primary_production <- function(
     animals
   )
 
-  .finalise_livestock(fao_liv_raw, animals, liv_lu)
+  .finalise_livestock(fao_liv_raw, animals, liv_lu) |>
+    .filter_years(years)
 }
 
 .read_livestock_stocks <- function(years = NULL) {


### PR DESCRIPTION
Partial improvement toward #666. **Deliberately does not close it** — see below.

**Classification: mechanical.** A window should not determine which stock
combinations exist. Full-range output is unchanged.

## The bug

`.build_livestock_stocks()` read the stock series scoped to the caller's window.
`.combine_livestock()` then completes the year axis against the `(area, item)`
combinations *that read produced* — so a combination absent from the window is
absent from the completion too. Those completed rows are what give a
livestock-product row its `unit` downstream in `.calculate_raw_yields()`, and a
row with no unit is dropped.

Measured at 2010: Italy, Kazakhstan and Latvia have **no duck stock row of their
own that year**, so a scoped read never formed the combination at all.

| build | duck stock rows for those areas @2010 |
| --- | --- |
| scoped, before | **0** |
| scoped, after | 2 each |
| full | 2 each |

## The fix

Read the stock series over its full span and trim afterwards — the same remedy
as `.compute_stock_shares()` in #665. Cheap: 3.3 s for 191,146 rows, and the
scoped build does not measurably change (~35 s).

## What it achieves, and what it does not

| | before | after |
| --- | --- | --- |
| `t_LU` @2010 | 2.180e-04 | **1.607e-04** |
| duck rows @2015 | 0 / 6 | **3 / 6** |
| `t_LU` @1995 | 3.062e-03 | **unchanged** |

So: a real but uneven improvement. **#666 stays open.** The combination now forms
and the rows appear, but a scoped build derives `LU` as **NA** where a full build
derives **0**:

| build | `LU` | `heads` |
| --- | --- | --- |
| scoped | **NA** | 0 |
| full | **0** | 0 |

`LU = heads * LU_head` via a join on `Animal_class`, which the completion's
`nesting()` does not carry — so it should be NA in *both* builds. Why the full
build lands on 0 anyway is the open question, recorded on #666 along with the
full stage-by-stage trace.

## Why not keep going

This was the fifth hypothesis on #666. The previous four — a year margin,
`.add_global_yields()`, a full-span `yield_glo`, and this one as a complete fix —
each looked right from reading the code and failed against a measurement. Each
round costs a full build cycle, and the remaining error is **0.3% worst case on
one derived ratio column** while every level quantity (`LU`, `heads`, `ha`,
`tonnes`, `slaughtered_heads`) is now exact at 2010, 2015 and 1995.

Shipping the improvement because it is free and principled; stopping short of
claiming a fix.

## Verification

- **full-range data payload `identical()`** to the build without this change,
  6,310,390 rows both ways
- touched-area tests: **409 pass, 0 failed**

🤖 Generated with [Claude Code](https://claude.com/claude-code)