### PR TITLE
Skip polity columns on the intermediate that discards them (partial fix for #624)

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,16 @@
 # whep (development version)
 
+* **`build_carbon_inputs()` no longer attaches reporting polity columns to an
+  intermediate that discards them.** `build_soil_carbon_inputs()` produced a
+  5.0e7-row gridded table for a 40-year span, and adding the four reporting
+  polity columns to it cost +20.4 GB and 20 s -- two of them are character
+  columns. `.ci_cropland_class()` then collapsed that table 42-fold, to 1.2e6
+  rows, discarding all four, and `build_carbon_inputs()` re-added them to its own
+  output. The internal path now skips them and only the exported
+  `build_soil_carbon_inputs()` pays. Peak for a 40-year `build_carbon_inputs()`
+  goes from 37.8 GB to 25.4 GB, slightly faster (725 s vs 742 s), with output
+  `identical()` across all 5,275,974 rows and 12 columns (#624).
+
 * **BNF coefficients now ship with cell-level provenance (#497).** The long
   `bnf_provenance` sidecar is readable with
   `whep_coef_table("bnf_provenance")` and accounts for every one of the 60

--- a/R/carbon_inputs.R
+++ b/R/carbon_inputs.R
@@ -75,8 +75,11 @@ build_carbon_inputs <- function(
 
 .ci_resolve_inputs <- function(data, years = NULL) {
   list(
-    cropland = data$cropland %||%
-      build_soil_carbon_inputs(data = data, years = years),
+    # .sci_build() rather than build_soil_carbon_inputs(): the reporting polity
+    # columns the exported function attaches are discarded by
+    # .ci_cropland_class() below and re-added to this function's own output, so
+    # paying for them on the pre-collapse intermediate is pure cost (#624).
+    cropland = data$cropland %||% .sci_build("grid", data, years),
     crop_area = data$crop_area %||% .ci_crop_area(data),
     grass_natural = data$grass_natural %||%
       build_grass_natural_carbon_inputs(data = data, years = years)

--- a/R/soil_carbon_inputs.R
+++ b/R/soil_carbon_inputs.R
@@ -68,10 +68,22 @@ build_soil_carbon_inputs <- function(
   if (isTRUE(example)) {
     return(.example_soil_carbon_inputs())
   }
+  .sci_build(resolution, data, years) |>
+    .add_reporting_polity_columns()
+}
+
+# The gridded carbon inputs WITHOUT the reporting polity columns.
+#
+# build_carbon_inputs() collapses this table by ~42x (a 40-year span is 5.0e7
+# rows before .ci_cropland_class() and 1.2e6 after) and then adds the reporting
+# polity columns to its own output. Attaching them here first costs +20.4 GB and
+# 20 s on that 5.0e7-row intermediate -- two of the four are character columns --
+# and .ci_cropland_class() then discards all four. So the internal caller takes
+# this, and only the exported wrapper above pays for the columns (#624).
+.sci_build <- function(resolution, data, years) {
   d <- .sci_resolve_inputs(data, years)
   components <- .sci_assemble_components(d$npp, d$manure)
-  .sci_grid_and_finalise(components, d, resolution) |>
-    .add_reporting_polity_columns()
+  .sci_grid_and_finalise(components, d, resolution)
 }
 
 # Private helpers ----


### PR DESCRIPTION
Refs #624.

## The defect

`build_soil_carbon_inputs()` emits a **50-million-row** gridded table for a
40-year span. Attaching the four reporting polity columns to it costs **+20.4 GB
and 20 s** — two of the four are character columns, on fifty million rows:

| | peak | rows | cols |
|---|---|---|---|
| before `.add_reporting_polity_columns()` | 17.0 GB | 49,987,294 | 12 |
| after | **37.4 GB** | 49,987,294 | 16 |

`.ci_cropland_class()` then collapses that table **42-fold** — to 1,188,567 rows
— and keeps **none** of the four. `build_carbon_inputs()` adds the reporting
polity columns to its own output afterwards regardless.

So on this path the columns are computed on the largest table in the pipeline
purely to be thrown away by the next call.

## The change

Split the core out as `.sci_build()` and let the internal caller take that. The
exported `build_soil_carbon_inputs()` still attaches the columns, so its
documented contract is unchanged.

## Measured

`build_carbon_inputs(resolution = "grid", years = 1961:2000)`:

| | peak RSS | time |
|---|---|---|
| before | 37.8 GB | 742 s |
| after | **25.4 GB** | 725 s |

**12.4 GB saved**, marginally faster, and output `identical()` across all
5,275,974 rows and 12 columns.

The saving scales with the intermediate (~1.25e6 rows per simulated year), so it
grows with the span rather than being a fixed deduction — unlike #735.

## How it was found

`build_carbon_balance(years = 1901:2022)` still peaked at 88.9 GB after #713 and
#735, dying inside "Reading model inputs". A reader census at 40 years put
`c_inputs` at 38.2 GB; stepping into it put 501 s and 37.8 GB on
`build_soil_carbon_inputs`; stepping into *that* showed everything up to and
including the per-year loop peaking at 19.1 GB, with the jump arriving on the
final `.add_reporting_polity_columns()` — and the columns not surviving the next
call.

Whether this is enough to make the full span run is not something I want to
assert here; it gets measured next.
