### PR TITLE
Let `source` decide the pre-1962 polity vocabulary — and a refutation of #739's premise

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,24 @@
 # whep (development version)
 
+* **`build_primary_production()` gains `polity_vocabulary`, which lets a row's
+  `source` decide whether its polity is looked up at its own year or at the
+  1961 back-cast anchor (#739).** The anchor floor itself is not new -- it has
+  applied to every pre-1962 row since `256b37a1`, whatever the source -- so
+  `"anchor"`, the default, keeps doing exactly that. `"observed_period"` gives
+  the own-year polity to genuinely observed `historical_data` rows and
+  `"historical_period"` extends that to the three `historical_LUH2_*` /
+  `historical_fill_linear` labels; both add a `method_reporting_polity` column
+  saying which route each row took. **No published value changes:** the default
+  `get_primary_production()` output is `identical()` across all 6,310,390 rows
+  and 12 columns, `get_wide_cbs()` likewise, and because a default build
+  carries **no** `historical_*` row at all, so are the two non-default
+  vocabularies -- the switch is inert until `historical_data` is wired in.
+  The open question it does not settle is a different one from the one #739
+  states: a back-cast row's *level* is its area's 1961 value while its
+  *year-on-year movement* is a present-day-ISO3 LUH2 land ratio, so for the
+  43 of 217 published areas whose territory changed after 1961 (747,758
+  pre-1961 rows) the value and its label describe two different extents.
+
 * **`build_carbon_inputs()` no longer attaches reporting polity columns to an
   intermediate that discards them.** `build_soil_carbon_inputs()` produced a
   5.0e7-row gridded table for a 40-year span, and adding the four reporting

--- a/R/build_production.R
+++ b/R/build_production.R
@@ -37,6 +37,37 @@
 #'     its successor states' LUH2 land, resolved from the `successor` relation
 #'     published in [polities]. This back-casts 14.3% more of the 1961-62
 #'     production tonnage and therefore moves published pre-1962 values.
+#' @param polity_vocabulary Character. Which polity a pre-1962 row is named by.
+#'   A pre-1962 WHEP row is a reconstruction, not an observation: its **level**
+#'   is the area's 1961 reported value, and its **year-on-year movement** is the
+#'   ratio of LUH2 land, which is keyed on present-day ISO3. Neither is the
+#'   territory that governed the ground in the row's own year, so the polity
+#'   lookup floors its year at the 1961 anchor -- and has done since `256b37a1`,
+#'   for every pre-1962 row whatever its source. This argument makes that floor
+#'   answer to `source` instead, which is what whep#739 asks for; what it does
+#'   **not** address is that the level and the movement describe two different
+#'   extents wherever a territory changed after 1961 (43 of 217 published areas,
+#'   747,758 pre-1961 rows -- see whep#739).
+#'   * `"anchor"` (default, current published behaviour) names **every**
+#'     pre-1962 row by the polity active at the 1961 anchor, whatever its
+#'     source.
+#'   * `"observed_period"` names a genuinely observed historical row -- one
+#'     supplied through `historical_data`, which keeps its own
+#'     `historical_*` source -- by the polity active in its **own** year, and
+#'     leaves every reconstruction anchored.
+#'   * `"historical_period"` does the same and additionally gives the own-year
+#'     polity to `historical_LUH2_cropland`, `historical_LUH2_agriland` and
+#'     `historical_fill_linear` rows, which are a real historical observation
+#'     grown by a modern-border land ratio. Whether those belong with the
+#'     observations or with the reconstructions is an open question: their
+#'     level describes the historical territory and their year-on-year movement
+#'     the modern one.
+#'
+#'   The two non-default values additionally emit a `method_reporting_polity`
+#'   column recording, per row, whether its polity was resolved at the anchor
+#'   (`"anchor"`) or in its own year (`"period"`). With
+#'   `historical_data = NULL` all three values give the same result, because
+#'   the build then contains no observed pre-1962 row at all.
 #' @param .raw_data Optional tibble with the same structure as the output
 #'   of the internal `.read_production()` step. When supplied, the
 #'   remote-data read is skipped entirely and the pipeline starts from
@@ -52,7 +83,11 @@
 #'   `live_anim_code`, `unit`, `value`, and `source`.
 #'   Item names can be recovered via [add_item_prod_name()] and related helpers.
 #'   When `show_duplicates = TRUE`, returns a wide tibble with one
-#'   column per source showing the competing values.
+#'   column per source showing the competing values. A non-default
+#'   `polity_vocabulary` adds `method_reporting_polity`; the default schema is
+#'   unchanged, because under `"anchor"` the rule is one fact about the whole
+#'   build -- every row before the anchor year is anchored -- and `year` already
+#'   says which rows those are.
 #'
 #' @export
 #'
@@ -66,12 +101,14 @@ build_primary_production <- function(
   show_duplicates = FALSE,
   historical_data = NULL,
   federation_land = c("none", "successor_union"),
+  polity_vocabulary = c("anchor", "observed_period", "historical_period"),
   .raw_data = NULL
 ) {
   if (example) {
     return(.example_build_primary_prod())
   }
   federation_land <- rlang::arg_match(federation_land)
+  polity_vocabulary <- rlang::arg_match(polity_vocabulary)
   cli::cli_h1("Building primary production")
   if (is.null(.raw_data)) {
     raw <- .read_production(
@@ -122,7 +159,7 @@ build_primary_production <- function(
       source,
       dplyr::any_of("fao_flag")
     ) |>
-    .add_reporting_polity_columns()
+    .resolve_prod_polities(polity_vocabulary)
 
   attr(result, ".cb_extracts") <- cb_extracts
   result
@@ -3333,6 +3370,66 @@ build_primary_production <- function(
     source == "LUH2_grassland" ~ 11L,
     source == "Estimated" ~ 12L,
     TRUE ~ 13L
+  )
+}
+
+# The three `source` values `.fill_pre_faostat()` stamps on a row it grew from a
+# genuine historical observation with a modern-border LUH2 land ratio. They
+# share the `historical_` prefix with the observations themselves, because
+# `.prepare_historical_production()` gives every `historical_data` source that
+# prefix and `.historical_anchor` keys on it -- so the prefix alone says
+# "descends from an observation", and only these three names say "reconstructed
+# from one".
+.prod_hist_recon_sources <- function() {
+  c(
+    "historical_LUH2_cropland",
+    "historical_LUH2_agriland",
+    "historical_fill_linear"
+  )
+}
+
+# Which rows are named by the polity of their own year rather than the anchor's
+# (whep#739). The default names none of them that way, which is what every
+# published build has done.
+#
+# The test is positive and closed: a row earns the own-year polity only by
+# carrying a source that says it was observed in that year, so a source label
+# nobody has classified keeps the anchor rather than silently acquiring a
+# historical polygon. Pure reconstructions -- `LUH2_cropland`, `LUH2_agriland`,
+# `fill_linear_historical`, and the `LUH2_grassland` series, which is LUH2
+# pasture read on present-day ISO3 for every year -- therefore stay anchored
+# under every value.
+.prod_period_rows <- function(source, vocabulary) {
+  from_history <- !is.na(source) & stringr::str_starts(source, "historical_")
+  switch(
+    vocabulary,
+    anchor = rep(FALSE, length(source)),
+    observed_period = from_history &
+      !(source %in% .prod_hist_recon_sources()),
+    historical_period = from_history
+  )
+}
+
+.resolve_prod_polities <- function(table, vocabulary, anchor = 1961L) {
+  row_anchor <- dplyr::if_else(
+    .prod_period_rows(table$source, vocabulary),
+    -Inf,
+    as.numeric(anchor)
+  )
+  out <- .add_reporting_polity_columns(table, backcast_anchor = row_anchor)
+  if (identical(vocabulary, "anchor")) {
+    return(out)
+  }
+  # `.add_reporting_polity_columns()` preserves row order, so `row_anchor` still
+  # lines up. A row at or after its own floor is named by the polity of its own
+  # year whatever the vocabulary says, because flooring changes nothing there.
+  dplyr::mutate(
+    out,
+    method_reporting_polity = dplyr::if_else(
+      dplyr::coalesce(.data$year >= row_anchor, FALSE),
+      "period",
+      "anchor"
+    )
   )
 }
 

--- a/R/polities.R
+++ b/R/polities.R
@@ -339,6 +339,28 @@
   )
 }
 
+# The year floor the polity lookup applies, one value per row.
+#
+# A scalar floors every row at the same anchor, which is what every caller did
+# before whep#739 and what both published routes still are: `1961L` for WHEP's
+# back-cast production series, `-Inf` for a genuine historical source reported
+# under its own year's borders (`.resolve_hist_trade_polities()`). A vector
+# lets one build mix the two, so a frame whose rows are not all reconstructions
+# can resolve each row in the vocabulary its own `source` calls for.
+.backcast_anchor_by_row <- function(backcast_anchor, n) {
+  anchor <- as.numeric(backcast_anchor)
+  if (length(anchor) == 1L) {
+    return(rep(anchor, n))
+  }
+  if (length(anchor) != n) {
+    cli::cli_abort(c(
+      "{.arg backcast_anchor} must be length 1 or one value per row.",
+      "x" = "It has {length(anchor)} value{?s} for {n} row{?s}."
+    ))
+  }
+  anchor
+}
+
 .add_polity_columns_dt <- function(
   data,
   code_col = "area_code",
@@ -351,6 +373,7 @@
     data.table::setDT(data)
   }
   dt <- data.table::copy(data)
+  row_anchor <- .backcast_anchor_by_row(backcast_anchor, nrow(dt))
 
   if (!code_col %in% names(dt)) {
     cli::cli_abort("Column {.field {code_col}} is required for polity mapping.")
@@ -433,12 +456,15 @@
     # modern republic; USSR/Yugoslavia/Czechoslovakia for entities that only
     # dissolved AFTER 1961) instead of a larger historical-extent period.
     # Genuine historical-source data (reported under real historical borders) is
-    # handled separately, keyed directly to its polity, not via this lookup.
+    # handled separately, either by a caller passing `backcast_anchor = -Inf`
+    # for a whole dataset (`.resolve_hist_trade_polities()`) or, since whep#739,
+    # by passing a per-row anchor so one build can resolve its reconstructed
+    # rows at the anchor and its observed ones at their own year.
     join_data <- dt[,
       .(
         ..whep_polity_rowid = get(rowid_col),
         area_code = get(code_col),
-        year = pmax(as.numeric(get(year_col)), as.numeric(backcast_anchor))
+        year = pmax(as.numeric(get(year_col)), row_anchor)
       )
     ]
     matches <- lookup[
@@ -984,14 +1010,28 @@ polity_coverage_gaps <- function(
   any(both & x != y)
 }
 
+# The carried fast path republishes an identity that was resolved under the
+# default anchor, so it can only stand in for a call asking for that same
+# anchor. Anything else -- a whole-dataset `-Inf`, or the per-row vector
+# whep#739 introduced -- has to resolve, or the requested vocabulary would be
+# silently replaced by the carried one. The literal matches the formal default
+# of `.add_polity_columns_dt()`.
+.default_backcast_anchor <- function(backcast_anchor) {
+  length(backcast_anchor) == 1L && isTRUE(backcast_anchor == 1961L)
+}
+
 .add_reporting_polity_columns <- function(
   table,
   code_column = "area_code",
-  mapping_status = NULL
+  mapping_status = NULL,
+  backcast_anchor = 1961L
 ) {
   mode <- .polity_status_mode(mapping_status)
   dt <- data.table::as.data.table(table)
-  if (.carried_reporting_polity(dt, code_column, mode)) {
+  if (
+    .default_backcast_anchor(backcast_anchor) &&
+      .carried_reporting_polity(dt, code_column, mode)
+  ) {
     # A copy, because `as.data.table()` hands back the caller's own data.table
     # when it is given one, and the resolving path below never reorders the
     # input's columns by reference.
@@ -1026,7 +1066,8 @@ polity_coverage_gaps <- function(
     code_col = code_column,
     year_col = year_col,
     prefix = "reporting_",
-    include_unmapped = TRUE
+    include_unmapped = TRUE,
+    backcast_anchor = backcast_anchor
   )
   if ("reporting_has_geometry" %in% names(out)) {
     data.table::setnames(

--- a/man/build_primary_production.Rd
+++ b/man/build_primary_production.Rd
@@ -12,6 +12,7 @@ build_primary_production(
   show_duplicates = FALSE,
   historical_data = NULL,
   federation_land = c("none", "successor_union"),
+  polity_vocabulary = c("anchor", "observed_period", "historical_period"),
   .raw_data = NULL
 )
 }
@@ -52,6 +53,40 @@ published in \link{polities}. This back-casts 14.3\% more of the 1961-62
 production tonnage and therefore moves published pre-1962 values.
 }}
 
+\item{polity_vocabulary}{Character. Which polity a pre-1962 row is named by.
+A pre-1962 WHEP row is a reconstruction, not an observation: its \strong{level}
+is the area's 1961 reported value, and its \strong{year-on-year movement} is the
+ratio of LUH2 land, which is keyed on present-day ISO3. Neither is the
+territory that governed the ground in the row's own year, so the polity
+lookup floors its year at the 1961 anchor -- and has done since \verb{256b37a1},
+for every pre-1962 row whatever its source. This argument makes that floor
+answer to \code{source} instead, which is what whep#739 asks for; what it does
+\strong{not} address is that the level and the movement describe two different
+extents wherever a territory changed after 1961 (43 of 217 published areas,
+747,758 pre-1961 rows -- see whep#739).
+\itemize{
+\item \code{"anchor"} (default, current published behaviour) names \strong{every}
+pre-1962 row by the polity active at the 1961 anchor, whatever its
+source.
+\item \code{"observed_period"} names a genuinely observed historical row -- one
+supplied through \code{historical_data}, which keeps its own
+\verb{historical_*} source -- by the polity active in its \strong{own} year, and
+leaves every reconstruction anchored.
+\item \code{"historical_period"} does the same and additionally gives the own-year
+polity to \code{historical_LUH2_cropland}, \code{historical_LUH2_agriland} and
+\code{historical_fill_linear} rows, which are a real historical observation
+grown by a modern-border land ratio. Whether those belong with the
+observations or with the reconstructions is an open question: their
+level describes the historical territory and their year-on-year movement
+the modern one.
+}
+
+The two non-default values additionally emit a \code{method_reporting_polity}
+column recording, per row, whether its polity was resolved at the anchor
+(\code{"anchor"}) or in its own year (\code{"period"}). With
+\code{historical_data = NULL} all three values give the same result, because
+the build then contains no observed pre-1962 row at all.}
+
 \item{.raw_data}{Optional tibble with the same structure as the output
 of the internal \code{.read_production()} step. When supplied, the
 remote-data read is skipped entirely and the pipeline starts from
@@ -68,7 +103,11 @@ A tibble with the same columns as \code{\link[=get_primary_production]{get_prima
 \code{live_anim_code}, \code{unit}, \code{value}, and \code{source}.
 Item names can be recovered via \code{\link[=add_item_prod_name]{add_item_prod_name()}} and related helpers.
 When \code{show_duplicates = TRUE}, returns a wide tibble with one
-column per source showing the competing values.
+column per source showing the competing values. A non-default
+\code{polity_vocabulary} adds \code{method_reporting_polity}; the default schema is
+unchanged, because under \code{"anchor"} the rule is one fact about the whole
+build -- every row before the anchor year is anchored -- and \code{year} already
+says which rows those are.
 }
 \description{
 Construct the full primary production dataset from raw FAOSTAT inputs.

--- a/tests/testthat/test_build_production.R
+++ b/tests/testthat/test_build_production.R
@@ -1213,3 +1213,125 @@ test_that(".split_stock_share keys on the code, so a shared label cannot dilute"
   # Whole numbers: a single-member group has share 1, never 1/n.
   expect_equal(result$value_comb, round(result$value_comb))
 })
+
+# -- Polity vocabulary (whep#739) ----------------------------------------------
+
+# One area, one pre-anchor year, one row per source class, plus a FAOSTAT-era
+# row. Area 238 is the case whep#739 argues from: its crosswalk carries eight
+# pre-1993 Ethiopian periods, so "the polity of 1850" and "the polity of the
+# 1961 anchor" are different polygons and the choice between them is visible.
+.make_vocabulary_raw <- function() {
+  tibble::tribble(
+    ~year, ~area, ~area_code, ~item_prod, ~item_prod_code, ~item_cbs, ~item_cbs_code, ~live_anim, ~live_anim_code, ~unit, ~value, ~source,
+    1850L, "Ethiopia", 238L, "Wheat", 15L, "Wheat and products", 2511L, NA_character_, NA_integer_, "tonnes", 100, "historical_Federico",
+    1850L, "Ethiopia", 238L, "Maize (corn)", 56L, "Maize and products", 2514L, NA_character_, NA_integer_, "tonnes", 200, "historical_LUH2_cropland",
+    1850L, "Ethiopia", 238L, "Barley", 44L, "Barley and products", 2513L, NA_character_, NA_integer_, "tonnes", 300, "LUH2_cropland",
+    1990L, "Ethiopia", 238L, "Wheat", 15L, "Wheat and products", 2511L, NA_character_, NA_integer_, "tonnes", 400, "FAOSTAT_prod"
+  )
+}
+
+# Sorted, so the four rows always arrive in the order the expectations name:
+#   1  1850 wheat   15  historical_Federico       observed in 1850
+#   2  1850 barley  44  LUH2_cropland             pure back-cast
+#   3  1850 maize   56  historical_LUH2_cropland  observation x modern ratio
+#   4  1990 wheat   15  FAOSTAT_prod              past the anchor
+.vocabulary_polities <- function(vocabulary) {
+  whep::build_primary_production(
+    .raw_data = .make_vocabulary_raw(),
+    polity_vocabulary = vocabulary
+  ) |>
+    dplyr::arrange(year, item_prod_code)
+}
+
+test_that(".prod_period_rows names only the sources that say own-year", {
+  sources <- c(
+    "FAOSTAT_prod",
+    "LUH2_cropland",
+    "LUH2_agriland",
+    "fill_linear_historical",
+    "LUH2_grassland",
+    "historical_Federico",
+    "historical_LUH2_cropland",
+    "historical_LUH2_agriland",
+    "historical_fill_linear"
+  )
+
+  # The default names none of them, which is what every published build did.
+  expect_false(any(whep:::.prod_period_rows(sources, "anchor")))
+
+  # A source nobody classified keeps the anchor rather than silently acquiring
+  # a historical polygon, so every reconstruction is FALSE under every value.
+  observed <- whep:::.prod_period_rows(sources, "observed_period")
+  expect_identical(sources[observed], "historical_Federico")
+
+  historical <- whep:::.prod_period_rows(sources, "historical_period")
+  expect_identical(
+    sources[historical],
+    c(
+      "historical_Federico",
+      "historical_LUH2_cropland",
+      "historical_LUH2_agriland",
+      "historical_fill_linear"
+    )
+  )
+
+  # NA is not an own-year observation.
+  expect_false(whep:::.prod_period_rows(NA_character_, "historical_period"))
+})
+
+test_that("the default vocabulary anchors every pre-1962 row", {
+  result <- .vocabulary_polities("anchor")
+
+  expect_equal(result$reporting_polity_code, rep("ETH-1952-1993", 4))
+  # The default schema is the published one: no method column, because under
+  # the default the rule is one fact about the whole build, not a per-row one.
+  expect_false(rlang::has_name(result, "method_reporting_polity"))
+})
+
+test_that("observed_period gives an observed row its own year's polity", {
+  result <- .vocabulary_polities("observed_period")
+
+  expect_equal(
+    result$reporting_polity_code,
+    c("ETH-1800-1889", "ETH-1952-1993", "ETH-1952-1993", "ETH-1952-1993")
+  )
+  expect_equal(
+    result$method_reporting_polity,
+    c("period", "anchor", "anchor", "period")
+  )
+})
+
+test_that("historical_period extends that to the LUH2-shaped rows", {
+  result <- .vocabulary_polities("historical_period")
+
+  # Only row 3, `historical_LUH2_cropland`, moves against observed_period;
+  # that single row IS the open decision in whep#739.
+  expect_equal(
+    result$reporting_polity_code,
+    c("ETH-1800-1889", "ETH-1952-1993", "ETH-1800-1889", "ETH-1952-1993")
+  )
+  expect_equal(
+    result$method_reporting_polity,
+    c("period", "anchor", "period", "period")
+  )
+})
+
+test_that("the vocabulary moves the identity, never the aggregation bucket", {
+  buckets <- purrr::map(
+    c("anchor", "observed_period", "historical_period"),
+    \(v) .vocabulary_polities(v)$polity_area_code
+  )
+
+  expect_equal(buckets[[2]], buckets[[1]])
+  expect_equal(buckets[[3]], buckets[[1]])
+})
+
+test_that("build_primary_production rejects an unknown polity_vocabulary", {
+  expect_error(
+    whep::build_primary_production(
+      .raw_data = .make_vocabulary_raw(),
+      polity_vocabulary = "historical"
+    ),
+    class = "rlang_error"
+  )
+})

--- a/tests/testthat/test_polities.R
+++ b/tests/testthat/test_polities.R
@@ -1107,3 +1107,54 @@ testthat::test_that("the status switch always re-resolves", {
     "out_of_span"
   )
 })
+
+# -- Per-row back-cast anchor (whep#739) ---------------------------------------
+
+testthat::test_that(".backcast_anchor_by_row recycles or aborts", {
+  testthat::expect_equal(
+    whep:::.backcast_anchor_by_row(1961L, 3L),
+    c(1961, 1961, 1961)
+  )
+  testthat::expect_equal(
+    whep:::.backcast_anchor_by_row(c(-Inf, 1961), 2L),
+    c(-Inf, 1961)
+  )
+  # A length that is neither 1 nor one-per-row would recycle silently against
+  # the wrong rows, which is the one failure mode a vector anchor introduces.
+  testthat::expect_error(
+    whep:::.backcast_anchor_by_row(c(1961, 1961), 3L),
+    class = "rlang_error"
+  )
+})
+
+testthat::test_that("a per-row anchor resolves one key two ways", {
+  # Two rows with the SAME (area_code, year): only the anchor differs, so any
+  # difference in the answer is the anchor's doing and nothing else's.
+  keys <- tibble::tibble(area_code = c(238L, 238L), year = c(1850L, 1850L))
+
+  out <- whep:::.add_reporting_polity_columns(
+    keys,
+    backcast_anchor = c(1961L, -Inf)
+  )
+
+  testthat::expect_equal(
+    out$reporting_polity_code,
+    c("ETH-1952-1993", "ETH-1800-1889")
+  )
+  # The bucket is the same territory either way; only the identity moves.
+  testthat::expect_equal(out$polity_area_code, c(238L, 238L))
+})
+
+testthat::test_that("a non-default anchor cannot be served by the carry", {
+  # The carried fast path republishes an identity resolved at the default
+  # anchor. Serving a `-Inf` request from it would silently return the
+  # anchored answer to a caller that asked for the own-year one.
+  carried <- .carried_frame(4L)
+  carried$year <- 1850L
+
+  out <- whep:::.add_reporting_polity_columns(carried, backcast_anchor = -Inf)
+
+  testthat::expect_false(
+    identical(out$reporting_polity_code, carried$reporting_polity_code)
+  )
+})


### PR DESCRIPTION
> **Draft, deliberately.** #739's central factual claim is refuted below, and
> the code half of this PR is inert on today's data. The measurement is the
> deliverable; the switch is offered, not argued for, and can be dropped
> without losing anything above it.

## What was wrong

**#739's premise is false, and I verified it before implementing anything.**

The issue says a pre-1962 row is given a *historical* polity — "area 238's 1850
row resolves to `ETH-1800-1889`, whose polygon is a different territory" — and
proposes that pure back-cast rows take the 1961-anchor polity instead.

whep has done exactly that since `256b37a1`. `.add_polity_columns_dt()`
(`R/polities.R`) carries `backcast_anchor = 1961L` and floors every polity
lookup at it:

```r
year = pmax(as.numeric(get(year_col)), as.numeric(backcast_anchor))
```

with a comment giving the issue's own reasoning as its rationale ("a 1900
'Austria' figure represents 1961 Austria, not the 1900 Habsburg crownland").
Measured on the published artifact: **area 238 carries `ETH-1952-1993` at every
year from 1850 to 1992**, and area 62 publishes 0 rows. The proposed class-3
branch is the status quo, not a change.

What *is* missing is the other branch: the floor is **blanket**, so a row
genuinely observed in 1850 (via `historical_data`) would be given the 1961
polity too. And the vocabulary is currently a per-**dataset** constant — the one
caller that wants the other answer switches it off wholesale
(`.resolve_hist_trade_polities()` passes `backcast_anchor = -Inf`) — where #739
argues it should be a per-**row** consequence of `source`.

**And the question underneath is sharper than the issue states.** A pre-1961 row
is neither "on present-day borders" nor "on 1961 borders". It is a hybrid: its
**level** is the area's 1961 reported value, its **year-on-year movement** is a
LUH2 land ratio, and LUH2 is keyed on present-day ISO3. Two anchors, and they
disagree for every territory that changed after 1961.

## Evidence it reproduced BEFORE the change

Real `get_primary_production()` at `origin/main` (`4b1d2633`), 6,310,390 rows,
warm pins.

**The published artifact has four `source` values, and #739's three classes are
not evenly populated:**

| # | class | `source` values actually present | rows | share |
|---|---|---|---|---|
| 1 | observed | `FAOSTAT_prod` — **every one at year ≥ 1961** | 2,640,245 | 41.84% |
| 2 | historically anchored (`historical_*`) | *none* | **0** | 0.00% |
| 3 | pure back-cast | `LUH2_cropland` 1,987,344 · `LUH2_agriland` 1,621,821 · `LUH2_grassland` 60,980 | 3,670,145 | 58.16% |

**#739's open question 3, answered: the artifact contains ZERO `historical_*`
rows.** `historical_data` defaults to `NULL` and nothing else emits the prefix,
so class 2 is empty and class 1 lives entirely at or after the anchor year,
where flooring the lookup year is a no-op. **The rule has one branch in
practice today.**

**What the anchor floor is currently worth.** Resolving the 35,821 distinct
`(area_code, year)` pairs with the floor and without it:

| | |
|---|---|
| pairs where the two answers differ | **7,282**, all at year < 1962 |
| published **rows** whose `reporting_polity_code` would move | **1,614,244 (25.58%)** |
| reporting areas affected | **85** |
| distinct anchor → own-year polity substitutions | **231** |
| `polity_area_code` (the aggregation bucket) pairs that move | **0** |

The bucket never moves: this is an identity question, not an aggregation one.

**The second-order effect #740 depends on, verified — and it is bigger than the
issue claims.** Joining each published row's polity to the crosswalk row that
authorises it (596 rows: 245 `upstream_map`, 262 `prefix_outside_map`, 62
`fabio_row_fold`, 27 `prefix_fallback`):

| authority | anchor route (i.e. today) | own-year route |
|---|---|---|
| `upstream_map` | 6,062,157 rows / 241 pairs | 4,483,681 / 241 |
| `fabio_row_fold` | 212,675 / 24 | 212,675 / 24 |
| **`prefix_outside_map`** (fabricated) | **35,558 / 1 pair** | **1,614,034 / 231 pairs** |

1961 is the upstream map's **first** year (`map_year_start` spans 1961-2014, no
NAs), so the anchoring **already** retires 261 of the 262 fabricated rows. The
262nd is `238 → ETH-1952-1993` — precisely **#741**: upstream gives that polity
to area **62** for 1961-1992, area 238's only `upstream_map` row is
`ETH-1993-2025` (1993-2024). It is load-bearing for 35,558 published rows, so it
wants upstream stating area 238's pre-1993 span (whep-polities#200), not a
deletion.

**The two anchors, verified on Ethiopia.** Area 238's published harvested-area
series moves year on year *exactly* with LUH2's **ETH-only** (present-day, no
Eritrea) cropland proxy:

| year | published ha | LUH2 ETH cropland Mha | value ratio y/y+1 | proxy ratio y/y+1 |
|---|---|---|---|---|
| 1955 | 26,132,703 | 9.978 | 0.9802472 | 0.9802927 |
| 1957 | 27,207,349 | 10.387 | 0.9793245 | 0.9793825 |
| 1959 | 28,388,302 | 10.836 | 0.9778245 | 0.9779047 |
| 1960 | 29,032,104 | 11.081 | 0.9773180 | 0.9770967 |

max ratio difference over 1955-1960 = **2.2e-04**. Meanwhile the row is labelled
`ETH-1952-1993`, which **includes** Eritrea; LUH2 carries ERI as a separate
present-day mask at 4.8% of ETH+ERI cropland in 1961, and area 178
(`ERI-1993-2025`) publishes its own 1850-1992 grassland rows *inside* the
polygon area 238 claims.

**Enumerated: 43 of 217 published areas have a 1961-anchor polity that is a
different entity from their present-day one — 747,758 pre-1961 rows, 20.5% of
the pre-1961 block, 11.85% of the artifact, 35.1 of 391.2 Gt of pre-1961
tonnage.** Largest by row count:

```
 59 EGY-1925-1967 -> EGY-1979-2025   36,408      4 DZA-1919-1962 -> DZA-1962-2025   27,417
143 MAR-1958-1975 -> MAR-1979-2025   35,187    238 ETH-1952-1993 -> ETH-1993-2025   27,084
105 ISR-1948-1967 -> ISR-1979-2025   33,744    131 MYS-1957-1963 -> MYS-1965-2025   25,752
 79 DEU-1949-1990 -> DEU-1990-2025   32,856    237 F237-1954-1975 -> VNM-1975-2025   23,532
 16 BGD-1947-1971 -> BGD-1971-2025   30,969    144 MOZ-1891-1975 -> MOZ-1975-2025   22,533
101 IDN-1949-1969 -> IDN-2002-2025   30,081    181 SRH-1953-1964 -> ZWE-1980-2025   20,091
114 KEN-1926-1963 -> KEN-1963-2025   28,638    249 F249-1918-1990 -> YEM-1990-2025   17,783
165 PAK-1949-1971 -> PAK-1971-2025   28,416    248 F248-1947-1991 -> F248-1991-1992   9,990
215 TZA-1961-1964 -> TZA-1964-2025   27,528     15 BLX-1850-1999 -> (none)            8,769
```

`polygon_area_km2` is `NA` for 35 of the 40 in packaged `polities`, so the km²
gap is not quantifiable offline; the polity names carry it (SRH→ZWE, NRH→ZMB,
BEC→BWA, PAK pre/post Bangladesh).

## What I changed

- `.add_polity_columns_dt()` / `.add_reporting_polity_columns()` accept
  `backcast_anchor` as **one value per row**, not only a scalar
  (`.backcast_anchor_by_row()` recycles or aborts). A scalar behaves exactly as
  before, so both existing routes (`1961L`; `-Inf` for historical trade) are
  untouched. This is the mechanism any per-row answer to the vocabulary question
  needs, whichever way it is answered.
- The carried-identity fast path in `.add_reporting_polity_columns()` now only
  serves a request at the default anchor. It republishes an identity resolved at
  1961, so answering a `-Inf` request from it would silently swap the vocabulary.
- `build_primary_production(polity_vocabulary =)`, `rlang::arg_match()`-validated:
  - **`"anchor"` (default, current published behaviour)** — every pre-1962 row
    takes the anchor polity, whatever its source.
  - `"observed_period"` — a genuinely observed historical row (a `historical_data`
    row, which keeps its own `historical_*` source) takes the polity of its
    **own** year; every reconstruction stays anchored.
  - `"historical_period"` — the same, plus the three `historical_LUH2_cropland` /
    `historical_LUH2_agriland` / `historical_fill_linear` labels.
- The two non-default values emit **`method_reporting_polity`** (`"anchor"` /
  `"period"`) per row, per the multi-method rule in `CLAUDE.md`.

**Design notes, since these are choices and not obvious:**

*Three levels, not two.* The `historical_LUH2_*` class is the genuinely
undecided case, so it is the **only** thing separating `"observed_period"` from
`"historical_period"`. The open decision is then a choice between two named
values rather than a comment.

*The period test is positive and closed.* A row earns the own-year polity only
by carrying a source that says it was observed in that year. A source nobody has
classified keeps the anchor, so the failure mode is always the status quo.

*The method column is emitted only when it says something.* Adding a column to
the published 6.3M-row schema is a downstream event; under `"anchor"` it would
carry a fact `year` already carries. (I had written that
`polity_coverage_gaps()` surfaces the anchoring per row — **it does not**:
`.polity_gap_kind()` applies the same floor, so only 4,309 of the 3,647,603
anchored rows are flagged `polity_not_started`. That is an open question below,
not a doc claim.)

*The argument sits on `build_primary_production()`, not `get_primary_production()`,*
matching `federation_land`. The cache key is untouched and the published entry
point cannot change by accident.

## How I verified

| check | result |
|---|---|
| `get_primary_production()`, default, branch vs `main` | **`identical()`**, 6,310,390 rows × 12 columns |
| `main` run 1 vs `main` run 2 (control) | frame `identical()`; **whole object is not** — see below |
| `get_wide_cbs()`, branch vs `main` | **`identical()`**, 2,184,850 rows × 18 columns |
| `polity_vocabulary = "observed_period"` on real data | `identical()` on the published schema; **0** polity codes move |
| `polity_vocabulary = "historical_period"` on real data | `identical()` on the published schema; **0** move |
| `method_reporting_polity` on the real build | 3,647,603 `anchor` / 2,662,787 `period` — exactly the rows before 1961 |
| `devtools::test()` | **FAIL 0 · PASS 7172 · SKIP 9** |
| `lintr::lint_package()` | No lints found |
| `air format .` | clean |
| every `man/*.Rd` in `_pkgdown.yml` | `character(0)` |

The `identical()` control matters: **`main` is not `identical()` to itself**
across two runs, on the `.cb_extracts` attribute only — its four tables carry
the same rows in a different order run to run. The published frame is
`identical()` in all three pairings. Filed as a follow-up; it is upstream of
anything here (`.read_production()` sets it before this code runs).

Tests added, all failing against the pre-change code:

- `.prod_period_rows()` over all nine source labels × three vocabularies,
  including that `NA` is not an own-year observation.
- `.backcast_anchor_by_row()` recycles a scalar, passes a per-row vector, and
  **aborts** on a length that is neither.
- Two rows with the *same* `(area_code, year)` and different anchors resolve to
  `ETH-1952-1993` and `ETH-1800-1889` — so the difference is the anchor's doing
  and nothing else's — with `polity_area_code` unchanged.
- A `-Inf` request is not served from the carried fast path.
- End-to-end `build_primary_production(.raw_data =)` on a four-row fixture, one
  row per source class, under each vocabulary; plus the bucket invariant across
  all three, and the `arg_match` abort.

All offline: package crosswalk data and `tribble()` fixtures only, no pin, no
`WHEP_*` path, no join added (`test_join_audit.R` green, baseline untouched).

## Moves published values

**No — default unchanged, asserted by `identical()`** on the full 6,310,390-row
`get_primary_production()` output and on `get_wide_cbs()`. And because the
published build carries no `historical_*` row at all, **both non-default
vocabularies also produce `identical()` published values today**: the switch is
inert until someone passes `historical_data`. That is stated here rather than
dressed up — it is why this is a draft.

## What I deliberately did not do

- **Did not flip the default**, and did not implement an answer to the
  two-anchors question. Resolving that needs a **ceiling** on the lookup year
  (name a back-cast row by its *present-day* polity, matching the trajectory),
  not a floor; `pmax()` cannot express it and it is a decision, not a patch.
- **Did not invent a change to justify the issue.** The switch closes the one
  branch of #739's rule that is genuinely unimplemented, and nothing more. If
  the answer to the real question makes it redundant, drop the code and keep the
  measurement.
- **Did not touch `data-raw/table_mappings.R` or `data/*.rda`** (#741's owner)
  and **did not delete any crosswalk-building code** (#740/#741). The authority
  table above is the input those two want, not a change to them.
- **Did not route observed rows through `label_alias_map.csv`.** #739 proposes
  resolving them through upstream's
  `(source_label, source, year_start, year_end, polity_code)` map, because
  `pipelines/pre1961-matching/` resolves by `(iso3c, year)` with real historical
  routing (`TUR < 1913 -> OTT`). This resolves them through the **same FAOSTAT
  area crosswalk, minus the floor** — right vocabulary, routing only as right as
  the area crosswalk. Two join paths for two populations is a bigger change than
  a default-preserving switch, and there is no such row to test it on.
- Did not extend the switch to `build_commodity_balances()` or the trade chain,
  and did not re-measure the footprint chain — the bucket does not move, so the
  IO layer cannot see this.

## The open decision

1. **The real one: 1961 anchor or present-day anchor?** A back-cast row's level
   describes the 1961 territory and its movement the present-day one. 43 areas /
   747,758 rows sit on the gap. The anchor matches the level; the present-day
   polity would match the movement. **Neither matches both**, and this PR does
   not choose — it does not even offer the second option.
2. **Which polity a `historical_LUH2_*` row should carry** — the same
   level-vs-movement split, one layer down, and the only difference between
   `"observed_period"` and `"historical_period"`. 0 rows today.
3. **Should the default flip to a source-driven rule?** It costs nothing today
   and takes effect the day `historical_data` is wired in. Deciding now means
   the first historical build is right by default.
4. **Is the anchor's temporal absurdity acceptable, and should it be visible?**
   Labelling an 1850 row `ETH-1952-1993` is territorially defensible and
   temporally nonsense. #739 argues for embracing it. Note that it is currently
   **invisible**: `.polity_gap_kind()` floors at the same anchor, so only 4,309
   of the 3,647,603 anchored rows are flagged `polity_not_started`. Making
   `method_reporting_polity` unconditional is the candidate fix and is a schema
   change worth deciding on purpose.
5. **Whether `LUH2_grassland` is a reconstruction.** Treated as one here (LUH2
   pasture on present-day ISO3, 38,438 pre-1961 rows). #739's class table does
   not mention it.
6. **A non-default vocabulary does not survive downstream.**
   `.carried_reporting_polity()` re-resolves at the default anchor when a
   consumer re-adds polity columns, and warns when the two answers contradict.
   Loud, not silent, and moot while the observed class is empty — but it means
   the vocabulary is a property of the production build, not of the pipeline.

Part of the polity migration epic #458. Refs #739.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
