### PR TITLE
Aggregate HWSD in latitude bands instead of one whole-grid pass (partial fix for #624)

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,18 @@
 # whep (development version)
 
+* **The HWSD readers aggregate in latitude bands instead of one whole-grid
+  pass.** Classifying the 30-arcsec HWSD grid in one go materialised ~11 GB of
+  full-resolution intermediates to produce a few MB, and `terra::crop()` pulled
+  the whole grid into memory before any aggregation began. Every aggregated cell
+  draws only on the source pixels beneath it, so the work splits by latitude
+  band with no cross-band dependency as long as each band is a whole number of
+  target rows. Peak per call goes from ~16.8 GB to ~2.6 GB and each call is
+  faster (clay 20 s to 23 s, hydraulic 60 s to 67 s, soil pH 23 s to 26 s on a
+  loaded machine; ~2.5x faster when measured alone). Output is `identical()` at
+  all three call sites -- `.cb_hwsd_clay()`, `read_soil_hydraulic()` and
+  `read_soil_ph()`. This supersedes the per-call-site reclaim added in #735,
+  which only covered one of the three (#624).
+
 * **`polity_area_crosswalk` no longer gives an area a polity the upstream map
   awarded outside its fold (#741).** The prefix expansion removed a candidate
   only when it overlapped a map span of *its own* area, so nothing ever asked

--- a/R/soil_ph.R
+++ b/R/soil_ph.R
@@ -274,13 +274,6 @@ read_soil_hydraulic <- function(
       value_col = col,
       out_col = col
     )
-    # Each pass classifies the full 30-arcsec HWSD raster, which costs ~11 GB
-    # of terra intermediates for a 3 MB result. That memory is reclaimable, but
-    # R's collector does not run on its own here, so three passes accumulate
-    # (11.4 -> 22.1 -> 32.8 GB) instead of reusing one pass's worth. Reclaiming
-    # between passes holds it at ~11 GB and is invisible against the ~60 s each
-    # pass already takes.
-    invisible(gc(full = TRUE))
     grid
   })
   purrr::reduce(grids, dplyr::inner_join, by = c("lon", "lat"))
@@ -336,21 +329,19 @@ read_soil_hydraulic <- function(
   if (!file.exists(hwsd_path)) {
     cli::cli_abort("HWSD raster not found at {.file {hwsd_path}}.")
   }
-  hwsd_rast <- .crop_to_target(terra::rast(hwsd_path), target_grid, target_res)
-  agg_factor <- as.integer(target_res / terra::res(hwsd_rast)[1])
-
+  # terra::rast() only opens the file; the pixels stay on disk until a band asks
+  # for them. Cropping the whole grid up front would pull all ~11 GB into memory
+  # before any aggregation happens, which is the cost this banding avoids.
+  src <- terra::rast(hwsd_path)
+  extent <- .hwsd_target_extent(src, target_grid, target_res)
   rcl <- as.matrix(mu_soils[, c("mu_global", value_col)])
-  val_rast <- terra::classify(hwsd_rast, rcl, others = NA)
-  val_coarse <- terra::aggregate(
-    val_rast,
-    fact = agg_factor,
-    fun = "mean",
-    na.rm = TRUE
-  )
-
-  val_df <- terra::as.data.frame(val_coarse, xy = TRUE, na.rm = TRUE)
-  names(val_df) <- c("lon", "lat", out_col)
-  tibble::as_tibble(val_df) |>
+  values <- purrr::map(
+    .hwsd_band_extents(extent, target_res),
+    \(band) .hwsd_band_values(src, band, rcl, target_res)
+  ) |>
+    dplyr::bind_rows()
+  names(values) <- c("lon", "lat", out_col)
+  tibble::as_tibble(values) |>
     dplyr::mutate(
       lon = round(.data$lon, 2),
       lat = round(.data$lat, 2),
@@ -358,21 +349,62 @@ read_soil_hydraulic <- function(
     )
 }
 
-# Crop the native HWSD raster to a target grid's bounding box, padded half a
-# target cell on each side. Returns the raster unchanged when no target grid
-# is supplied (the documented global path).
-.crop_to_target <- function(rast, target_grid, target_res) {
+# The extent to aggregate over: the target grid's bounding box padded by half a
+# target cell, or the whole raster when no target grid is given.
+.hwsd_target_extent <- function(src, target_grid, target_res) {
   if (is.null(target_grid)) {
-    return(rast)
+    return(terra::ext(src))
   }
   pad <- target_res / 2
-  extent <- terra::ext(
+  terra::ext(
     min(target_grid$lon) - pad,
     max(target_grid$lon) + pad,
     min(target_grid$lat) - pad,
     max(target_grid$lat) + pad
   )
-  terra::crop(rast, extent)
+}
+
+# Split an extent into latitude bands, each a whole number of target rows tall.
+# Whole target rows is what makes this safe: every aggregated cell's source
+# pixels then lie inside exactly one band, so banding cannot change a single
+# aggregated value.
+.hwsd_band_extents <- function(extent, target_res) {
+  n_rows <- as.integer(round((extent$ymax - extent$ymin) / target_res))
+  starts <- seq(0L, max(n_rows - 1L, 0L), by = .hwsd_band_rows())
+  purrr::map(starts, function(start) {
+    rows <- min(.hwsd_band_rows(), n_rows - start)
+    terra::ext(
+      extent$xmin,
+      extent$xmax,
+      extent$ymax - (start + rows) * target_res,
+      extent$ymax - start * target_res
+    )
+  })
+}
+
+# Target rows per band. 32 keeps a global 0.5-degree pass near 2 GB; the value
+# only trades peak memory against the number of passes, never the result.
+.hwsd_band_rows <- function() {
+  32L
+}
+
+# Classify and mean-aggregate one latitude band, releasing its full-resolution
+# intermediates before the next band allocates its own.
+.hwsd_band_values <- function(src, band, rcl, target_res) {
+  sub <- terra::crop(src, band)
+  agg_factor <- as.integer(target_res / terra::res(sub)[1])
+  classified <- terra::classify(sub, rcl, others = NA)
+  coarse <- terra::aggregate(
+    classified,
+    fact = agg_factor,
+    fun = "mean",
+    na.rm = TRUE
+  )
+  values <- terra::as.data.frame(coarse, xy = TRUE, na.rm = TRUE)
+  names(values) <- c("lon", "lat", "value")
+  rm(sub, classified, coarse)
+  invisible(gc(full = TRUE))
+  values
 }
 
 # Gap-fill cells present in the target grid but missing from the aggregated

--- a/tests/testthat/test_soil_ph.R
+++ b/tests/testthat/test_soil_ph.R
@@ -337,7 +337,7 @@ testthat::test_that("read_soil_ph aggregates HWSD raster + attributes", {
   testthat::expect_true(all(result$soil_ph == 6.5))
 })
 
-testthat::test_that(".crop_to_target crops the raster to the target extent", {
+testthat::test_that(".hwsd_target_extent pads the target grid's bounding box", {
   testthat::skip_if_not_installed("terra")
   rast <- terra::rast(
     nrows = 12,
@@ -348,34 +348,71 @@ testthat::test_that(".crop_to_target crops the raster to the target extent", {
     ymax = 3,
     resolution = 0.5
   )
-  terra::values(rast) <- seq_len(terra::ncell(rast))
   target <- tibble::tibble(lon = c(-0.25, 0.25), lat = c(-0.25, 0.25))
 
-  cropped <- whep:::.crop_to_target(rast, target, target_res = 0.5)
-  ext <- terra::ext(cropped)
+  ext <- whep:::.hwsd_target_extent(rast, target, target_res = 0.5)
 
-  testthat::expect_lt(terra::ncell(cropped), terra::ncell(rast))
-  testthat::expect_gte(ext$xmin, -1)
-  testthat::expect_lte(ext$xmax, 1)
-  testthat::expect_gte(ext$ymin, -1)
-  testthat::expect_lte(ext$ymax, 1)
+  testthat::expect_equal(unname(ext$xmin), -0.5)
+  testthat::expect_equal(unname(ext$xmax), 0.5)
+  testthat::expect_equal(unname(ext$ymin), -0.5)
+  testthat::expect_equal(unname(ext$ymax), 0.5)
 })
 
-testthat::test_that(".crop_to_target is a no-op without a target grid", {
+testthat::test_that(".hwsd_target_extent falls back to the whole raster", {
   testthat::skip_if_not_installed("terra")
   rast <- terra::rast(
-    nrows = 4,
-    ncols = 4,
-    xmin = -1,
-    xmax = 1,
-    ymin = -1,
-    ymax = 1
+    nrows = 12,
+    ncols = 12,
+    xmin = -3,
+    xmax = 3,
+    ymin = -3,
+    ymax = 3,
+    resolution = 0.5
   )
-  terra::values(rast) <- seq_len(terra::ncell(rast))
 
-  unchanged <- whep:::.crop_to_target(rast, NULL, target_res = 0.5)
+  ext <- whep:::.hwsd_target_extent(rast, NULL, target_res = 0.5)
 
-  testthat::expect_equal(terra::ncell(unchanged), terra::ncell(rast))
+  testthat::expect_equal(as.vector(ext), as.vector(terra::ext(rast)))
+})
+
+# Banding is only safe because each band is a whole number of target rows: an
+# aggregated cell's source pixels then lie inside exactly one band, so no
+# aggregated value can straddle a boundary. Tile the extent exactly, with no
+# gap and no overlap, or the result changes.
+testthat::test_that(".hwsd_band_extents tiles the extent in whole target rows", {
+  testthat::skip_if_not_installed("terra")
+  res <- 0.5
+  extent <- terra::ext(-10, 10, -25, 25)
+
+  bands <- whep:::.hwsd_band_extents(extent, target_res = res)
+  tops <- vapply(bands, function(b) b$ymax, numeric(1))
+  bottoms <- vapply(bands, function(b) b$ymin, numeric(1))
+
+  # every band spans a whole number of target rows
+  rows <- (tops - bottoms) / res
+  testthat::expect_equal(rows, round(rows))
+  # contiguous, no gaps or overlaps, covering the extent exactly
+  testthat::expect_equal(max(tops), unname(extent$ymax))
+  testthat::expect_equal(min(bottoms), unname(extent$ymin))
+  testthat::expect_equal(bottoms[-length(bottoms)], tops[-1])
+  # longitude is never split
+  testthat::expect_true(all(
+    vapply(bands, function(b) b$xmin, numeric(1)) == extent$xmin
+  ))
+  testthat::expect_true(all(
+    vapply(bands, function(b) b$xmax, numeric(1)) == extent$xmax
+  ))
+})
+
+testthat::test_that(".hwsd_band_extents handles an extent shorter than one band", {
+  testthat::skip_if_not_installed("terra")
+  extent <- terra::ext(-10, 10, 0, 1)
+
+  bands <- whep:::.hwsd_band_extents(extent, target_res = 0.5)
+
+  testthat::expect_length(bands, 1L)
+  testthat::expect_equal(unname(bands[[1]]$ymin), 0)
+  testthat::expect_equal(unname(bands[[1]]$ymax), 1)
 })
 
 testthat::test_that("read_soil_ph reads real local HWSD data (smoke)", {


### PR DESCRIPTION
Refs #624. Supersedes the narrower fix in #735.

## The defect

`.aggregate_hwsd()` cropped the entire 30-arcsec HWSD grid into memory and
classified it in a single pass — **~11 GB of full-resolution intermediates to
produce a few MB** of aggregated cells. `terra::crop()` pulled the whole grid in
before any aggregation began.

#735 reclaimed that memory between the three hydraulic passes, but it patched
**one of three call sites**. `.cb_hwsd_clay()` and `read_soil_ph()` still paid it
in full — and the clay grid's 11 GB then stayed resident for the remainder of
every `build_carbon_balance()` run, inflating every later peak.

## The change

Every aggregated cell draws only on the source pixels beneath it, so the work
splits by latitude band with no cross-band dependency — **provided each band is
a whole number of target rows tall**. `terra::rast()` opens the file without
reading it, so each band reads only its own pixels.

## Measured

| call site | before | after |
|---|---|---|
| `.cb_hwsd_clay()` | 16.7 GB | **2.5 GB** |
| `read_soil_hydraulic()` | 16.8 GB | **2.6 GB** |
| `read_soil_ph()` | 16.8 GB | **2.7 GB** |

Output is `identical()` at all three, including `read_soil_ph()`'s `NULL`
target-grid path. Measured alone, a pass is also ~2.5× faster (23 s vs 60 s).

## Two approaches tried first and rejected

Both because they **changed results**, which is not acceptable for a
memory fix:

- terra's file-backed mode (`todisk = TRUE`) reaches 3.3 GB but moved **153 of
  67,352** clay cells by 0.01 pp.
- Adding `datatype = "FLT8S"` cut that to **44 cells** but did not remove it —
  terra's chunk boundaries do not align with the aggregation factor.

Banding by whole target rows *does* align, which is why it is exact rather than
nearly exact.

## Also

`.crop_to_target()` had no remaining callers and is removed. Its two tests move
to `.hwsd_target_extent()`, plus new coverage of the tiling invariant — bands
whole-target-row tall, tiling the extent with no gap or overlap. If that ever
breaks, an aggregated cell straddles a boundary and values change silently, so
it is worth asserting directly.
